### PR TITLE
Suppress stderr on cross-device copy rules

### DIFF
--- a/misc/gyp.patch
+++ b/misc/gyp.patch
@@ -86,7 +86,7 @@ index 0000000..be2a8af
 +
 +rule copy
 +  description = COPY $out
-+  command = ln -f $in $out || cp -af $in $out
++  command = ln -f $in $out 2>/dev/null || cp -af $in $out
 +
 +""" % {
 +  'cwd': os.getcwd(),


### PR DESCRIPTION
(this mirrors what make's generator does, fwiw)
