### PR TITLE
Add link to mailing list to README

### DIFF
--- a/README
+++ b/README
@@ -6,3 +6,6 @@ including motivation and build instructions.
 
 Though the code is copyright Google, don't take that as an
 endorsement; I wrote this in my spare time for fun.
+
+Discussions about Ninja should take place on the mailing list:
+http://groups.google.com/group/ninja-build


### PR DESCRIPTION
This is a lame patch, and you could add it yourself just as easily, if not more so.

Maybe mailing list links also need to go into the manual somewhere? But I couldn't figure out a good section to include them in ...
