### PR TITLE
fix to compiling src/subprocess-win32.cc on bootstraping

### DIFF
--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifdef _WIN32
+
 #include "subprocess.h"
 
 #include <stdio.h>
@@ -209,3 +211,5 @@ Subprocess* SubprocessSet::NextFinished() {
   finished_.pop();
   return subproc;
 }
+
+#endif // _WIN32


### PR DESCRIPTION
Latest bootstrap.sh always compiles src/subprocess-win32.cc.
Then I failed to compiling it on Mac OS X.
I think that #ifdef _WIN32 is necessary.
