### PR TITLE
Quick fix for bootstrap.sh due to win32 files

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -31,7 +31,13 @@ fi
 echo "Building ninja manually..."
 mkdir -p build
 ./src/inline.sh kBrowsePy < src/browse.py > build/browse_py.h
-srcs=$(ls src/*.cc | grep -v test)
+
+if [ "${SYSTEMNAME:0:7}" = "MINGW32" ]; then
+    srcs=$(ls src/*.cc | grep -v test | grep -v subprocess.cc)
+else
+    srcs=$(ls src/*.cc | grep -v test | grep -v subprocess-win32.cc)
+fi
+
 g++ -Wno-deprecated ${CFLAGS} ${LDFLAGS} -o ninja.bootstrap $srcs
 
 echo "Building ninja using itself..."


### PR DESCRIPTION
Fix bootstrap.sh to include the correct subprocess{-win32}.cc based on the platform.
