### PR TITLE
Fix bootstrap script for dash.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,11 +32,14 @@ echo "Building ninja manually..."
 mkdir -p build
 ./src/inline.sh kBrowsePy < src/browse.py > build/browse_py.h
 
-if [ "${SYSTEMNAME:0:7}" = "MINGW32" ]; then
+case "$SYSTEMNAME" in
+  MINGW32*)
     srcs=$(ls src/*.cc | grep -v test | grep -v subprocess.cc)
-else
+    ;;
+  *)
     srcs=$(ls src/*.cc | grep -v test | grep -v subprocess-win32.cc)
-fi
+    ;;
+esac
 
 g++ -Wno-deprecated ${CFLAGS} ${LDFLAGS} -o ninja.bootstrap $srcs
 


### PR DESCRIPTION
On Ubuntu /bin/sh is a link to dash.  The bootstrap script reported a
'Bad substitution' error line 39 when interpreted by dash.  This patch fix the
problem.
