### PR TITLE
fix the error: 'asciidoc: To many arguments'

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -162,7 +162,7 @@ n.newline()
 
 n.comment('Generate the manual using asciidoc.')
 n.rule('asciidoc',
-       command='asciidoc -a toc $in -o $out',
+       command='asciidoc -a toc -o $out $in',
        description='ASCIIDOC $in')
 manual = n.build(doc('manual.html'), 'asciidoc', doc('manual.asciidoc'))
 n.build('manual', 'phony',


### PR DESCRIPTION
Fix the error by asciidoc 8.6.4 on Mac OS X 10.6.7.

```
[5/15] ASCIIDOC doc/manual.asciidoc
FAILED: asciidoc -a toc doc/manual.asciidoc -o doc/manual.html
asciidoc: To many arguments

Man page:     asciidoc --help manpage
Syntax:       asciidoc --help syntax
build stopped: subcommand failed.
```
