### PR TITLE
Fixes to let native builds on Visual Studio 2010 build, pass tests

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -54,7 +54,7 @@ bool BuildLog::OpenForWrite(const string& path, string* err) {
     *err = strerror(errno);
     return false;
   }
-  setvbuf(log_file_, NULL, _IOLBF, 0);
+  setvbuf(log_file_, NULL, _IOLBF, BUFSIZ);
 
   if (ftell(log_file_) == 0) {
     if (fwrite(kFileSignature, sizeof(kFileSignature) - 1, 1, log_file_) < 1) {

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -217,7 +217,7 @@ TEST_F(StatTest, Middle) {
 #ifndef _mktemp_s
 /// mingw has no mktemp.  Implement one with the same type as the one
 /// found in the Windows API.
-int _mktemp_s(const char* templ) {
+int _mktemp_s(char* templ) {
   char* ofs = strchr(templ, 'X');
   sprintf(ofs, "%d", rand() % 1000000);
   return 0;

--- a/src/util.cc
+++ b/src/util.cc
@@ -25,7 +25,10 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 
 #include <vector>
 

--- a/src/util.h
+++ b/src/util.h
@@ -46,4 +46,8 @@ int ReadFile(const string& path, string* contents, string* err);
 /// time.
 int64_t GetTimeMillis();
 
+#ifdef _WIN32
+#define snprintf _snprintf
+#endif
+
 #endif  // NINJA_UTIL_H_


### PR DESCRIPTION
All tests except SubProcess pass on a native Windows build
Tests continue not to build on a platform=mingw build
All platform=linux tests still pass
