### PR TITLE
mingw ninja_test links and passes. (as do linux and native VS2010)

### DIFF
--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -18,6 +18,7 @@
 
 #ifdef WIN32
 #include <fcntl.h>
+#include <share.h>
 #endif
 
 static const char kTestFilename[] = "BuildLogTest-tempfile";
@@ -98,7 +99,7 @@ TEST_F(BuildLogTest, Truncate) {
     ASSERT_EQ(0, truncate(kTestFilename, size));
 #else
     int fh;
-    ASSERT_EQ(0, _sopen_s(&fh, kTestFilename, _O_RDWR | _O_CREAT, _SH_DENYNO, _S_IREAD | _S_IWRITE));
+    fh = _sopen(kTestFilename, _O_RDWR | _O_CREAT, _SH_DENYNO, _S_IREAD | _S_IWRITE);
     ASSERT_EQ(0, _chsize(fh, size));
     _close(fh);
 #endif

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -30,32 +30,19 @@ struct SubprocessTest : public testing::Test {
 
 }  // anonymous namespace
 
-// Run a command that succeeds and emits to stdout.
-TEST_F(SubprocessTest, GoodCommandStdout) {
-  Subprocess ls;
-  EXPECT_TRUE(ls.Start(&subprocs_, kSimpleCommand));
-
-  while (!ls.Done()) {
-    // Pretend we discovered that stdout was ready for writing.
-    ls.OnPipeReady();
-  }
-
-  EXPECT_TRUE(ls.Finish());
-  EXPECT_NE("", ls.GetOutput());
-}
-
 // Run a command that fails and emits to stderr.
 TEST_F(SubprocessTest, BadCommandStderr) {
-  Subprocess subproc;
-  EXPECT_TRUE(subproc.Start(&subprocs_, "ninja_no_such_command"));
+  Subprocess* subproc = new Subprocess;
+  EXPECT_TRUE(subproc->Start(&subprocs_, "ninja_no_such_command"));
+  subprocs_.Add(subproc);
 
-  while (!subproc.Done()) {
+  while (!subproc->Done()) {
     // Pretend we discovered that stderr was ready for writing.
-    subproc.OnPipeReady();
+    subprocs_.DoWork();
   }
 
-  EXPECT_FALSE(subproc.Finish());
-  EXPECT_NE("", subproc.GetOutput());
+  EXPECT_FALSE(subproc->Finish());
+  EXPECT_NE("", subproc->GetOutput());
 }
 
 TEST_F(SubprocessTest, SetWithSingle) {


### PR DESCRIPTION
Use chsize instead of truncate for mingw compatibility
SubprocessTest uses DoWork to force Subprocesses to execute
Drop GoodCommandStdOut test as it is tested in SetWithSingle
