### PR TITLE
Call fflush after every line for the non smart terminal case.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -169,6 +169,7 @@ void BuildStatus::PrintStatus(Edge* edge) {
     fflush(stdout);
   } else {
     printf("\n");
+    fflush(stdout);
   }
 }
 


### PR DESCRIPTION
This is to force ninja output to be flushed out as soon as possible
even when its standard output is redictced to a pipe or a file.
