### PR TITLE
Fix for long command lines in Win32

### DIFF
--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -102,8 +102,9 @@ bool Subprocess::Start(struct SubprocessSet* set, const string& command) {
 
   PROCESS_INFORMATION process_info;
 
-  string full_command = "cmd /c " + command;
-  if (!CreateProcessA(NULL, (char*)full_command.c_str(), NULL, NULL,
+  // Do not prepend 'cmd /c' on Windows, this breaks command
+  // lines greater than 8,191 chars.
+  if (!CreateProcessA(NULL, (char*)command.c_str(), NULL, NULL,
                       /* inherit handles */ TRUE, 0,
                       NULL, NULL,
                       &startup_info, &process_info)) {

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -19,7 +19,7 @@
 namespace {
 
 #ifdef _WIN32
-const char* kSimpleCommand = "dir \\";
+const char* kSimpleCommand = "cmd /c dir \\";
 #else
 const char* kSimpleCommand = "ls /";
 #endif
@@ -33,7 +33,7 @@ struct SubprocessTest : public testing::Test {
 // Run a command that fails and emits to stderr.
 TEST_F(SubprocessTest, BadCommandStderr) {
   Subprocess* subproc = new Subprocess;
-  EXPECT_TRUE(subproc->Start(&subprocs_, "ninja_no_such_command"));
+  EXPECT_TRUE(subproc->Start(&subprocs_, "cmd /c ninja_no_such_command"));
   subprocs_.Add(subproc);
 
   while (!subproc->Done()) {
@@ -64,8 +64,8 @@ TEST_F(SubprocessTest, SetWithMulti) {
   const char* kCommands[3] = {
     kSimpleCommand,
 #ifdef _WIN32
-    "echo hi",
-    "time /t",
+    "cmd /c echo hi",
+    "cmd /c time /t",
 #else
     "whoami",
     "pwd",


### PR DESCRIPTION
```
- remove 'cmd /c' prepend from SubProcess::Start()

- fix the subprocess tests to prepend 'cmd /c' explicitly
```
