### PR TITLE
'clean' should not try to remove phony targets

### DIFF
--- a/src/clean.cc
+++ b/src/clean.cc
@@ -105,7 +105,7 @@ int Cleaner::CleanAll() {
        e != state_->edges_.end();
        ++e) {
     // Do not try to remove phony targets
-    if( (*e)->rule_->name_ == "phony")
+    if( (*e)->rule_->name_ == State::kPhonyRule.name_)
       continue;
     for (vector<Node*>::iterator out_node = (*e)->outputs_.begin();
          out_node != (*e)->outputs_.end();


### PR DESCRIPTION
If the phony target matches a file on the filesystem, then it is deleted.

If the phony target matches a directory (a common case if you use phony targets as shorthand for projects being built) then RealDiskInterface::RemoveFile() produces an error.

Ninja should ignore phony targets at clean time.
