### PR TITLE
Fix ninja compilation by including a missing disk_interface.h.

### DIFF
--- a/src/test.h
+++ b/src/test.h
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include "disk_interface.h"
 #include "ninja.h"
 
 // Support utilites for tests.


### PR DESCRIPTION
When running ./ninja the compilation fails because test.h uses DiskInterface but
doesn't include disk_interface.h to get the declaration.

Signed-off-by: Thiago Farina tfarina@chromium.org
