### PR TITLE
Implement default target statements

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -271,6 +271,30 @@ printed when run, logged (see below), nor do they contribute to the
 command count printed as part of the build process.
 
 
+Default target statements
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, if no targets are specified on the command line, Ninja
+will build every output that is not named as an input elsewhere.
+You can override this behavior using a default target statement.
+A default target statement causes Ninja to build only a given subset
+of output files if none are specified on the command line.
+
+Default target statements begin with the `default` keyword, and have
+the format +default _targets_+.  A default target statement must appear
+after the build statement that declares the target as an output file.
+They are cumulative, so multiple statements may be used to extend
+the list of default targets.  For example:
+
+----------------
+default foo bar
+default baz
+----------------
+
+This causes Ninja to build the `foo`, `bar` and `baz` targets by
+default.
+
+
 The Ninja log
 ~~~~~~~~~~~~~
 
@@ -375,7 +399,9 @@ A file is a series of declarations.  A declaration can be one of:
 
 3. Variable declarations, which look like +_variable_ = _value_+.
 
-4. References to more files, which look like +subninja _path_+ or
+4. Default target statements, which look like +default _target1_ _target2_+.
+
+5. References to more files, which look like +subninja _path_+ or
    +include _path_+.  The difference between these is explained below
    <<ref_scope,in the discussion about scoping>>.
 
@@ -499,8 +525,9 @@ lookup order for a variable referenced in a rule is:
 Variable expansion
 ~~~~~~~~~~~~~~~~~~
 
-Variables are expanded in two cases: in the right side of a `name =
-value` statement and in paths in a `build` statement.
+Variables are expanded in three cases: in the right side of a `name =
+value` statement, in paths in a `build` statement and in paths in
+a `default` statement.
 
 When a `name = value` statement is evaluated, its right-hand side is
 expanded once (according to the above scoping rules) immediately, and
@@ -508,9 +535,10 @@ from then on `$name` expands to the static string as the result of the
 expansion.  It is never the case that you'll need to "double-escape" a
 variable with some syntax like `$$foo`.
 
-A `build` statement is first parsed as a space-separated list of
-filenames and then each name is expanded.  This means that spaces
-within a variable will result in spaces in the expanded filename.
+A `build` or `default` statement is first parsed as a space-separated
+list of filenames and then each name is expanded.  This means that
+spaces within a variable will result in spaces in the expanded
+filename.
 
 ----
 spaced = foo bar

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -113,7 +113,7 @@ struct RealFileReader : public ManifestParser::FileReader {
 bool CollectTargetsFromArgs(State* state, int argc, char* argv[],
                             vector<Node*>* targets, string* err) {
   if (argc == 0) {
-    *targets = state->RootNodes(err);
+    *targets = state->DefaultNodes(err);
     if (!err->empty())
       return false;
   } else {

--- a/src/ninja.h
+++ b/src/ninja.h
@@ -46,9 +46,11 @@ struct State {
   Node* LookupNode(const string& path);
   void AddIn(Edge* edge, const string& path);
   void AddOut(Edge* edge, const string& path);
+  bool AddDefault(const string& path, string* error);
   /// @return the root node(s) of the graph. (Root nodes have no output edges).
   /// @param error where to write the error message if somethings went wrong.
   vector<Node*> RootNodes(string* error);
+  vector<Node*> DefaultNodes(string* error);
 
   StatCache stat_cache_;
   /// All the rules used in the graph.
@@ -56,6 +58,7 @@ struct State {
   /// All the edges of the graph.
   vector<Edge*> edges_;
   BindingEnv bindings_;
+  vector<Node*> defaults_;
   struct BuildLog* build_log_;
 
   static const Rule kPhonyRule;

--- a/src/ninja_jumble.cc
+++ b/src/ninja_jumble.cc
@@ -82,6 +82,16 @@ void State::AddOut(Edge* edge, const string& path) {
   node->in_edge_ = edge;
 }
 
+bool State::AddDefault(const string& path, string* err) {
+  Node* node = LookupNode(path);
+  if (!node) {
+    *err = "unknown target '" + path + "'";
+    return false;
+  } 
+  defaults_.push_back(node);
+  return true;
+}
+
 vector<Node*> State::RootNodes(string* err) {
   vector<Node*> root_nodes;
   // Search for nodes with no output.
@@ -98,4 +108,8 @@ vector<Node*> State::RootNodes(string* err) {
 
   assert(edges_.empty() || !root_nodes.empty());
   return root_nodes;
+}
+
+vector<Node*> State::DefaultNodes(string* err) {
+  return defaults_.empty() ? RootNodes(err) : defaults_;
 }

--- a/src/parsers.h
+++ b/src/parsers.h
@@ -126,6 +126,7 @@ struct ManifestParser {
   /// current env.
   bool ParseLet(string* key, string* val, string* err);
   bool ParseEdge(string* err);
+  bool ParseDefaults(string* err);
 
   /// Parse either a 'subninja' or 'include' line.
   bool ParseFileInclude(string* err);


### PR DESCRIPTION
This introduces a new directive, the default target statement, which
may be used to control the list of targets built by default (i.e. if
no target is named on the command line).
