### PR TITLE
Support for rebuilding and reloading manifest files

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -253,6 +253,10 @@ statement to the rule (for example, if the rule needs "the file
 extension of the first input"), pass that through as an extra
 variable, like how `cflags` is passed above.
 
+If the top-level Ninja file is specified as an output of any build
+statement and it is out of date, Ninja will rebuild and reload it
+before building the targets requested by the user.
+
 
 The `phony` rule
 ~~~~~~~~~~~~~~~~

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -32,6 +32,7 @@ struct Edge;
 ///    from it
 struct BuildLog {
   BuildLog();
+  ~BuildLog() { Close(); }
 
   void SetConfig(BuildConfig* config) { config_ = config; }
   bool OpenForWrite(const string& path, string* err);


### PR DESCRIPTION
This introduces support for rebuilding the top-level manifest file
using a provided build statement, and reloading it before building
the user-requested targets.
