### PR TITLE
subprocess-win32.cc: change named pipe names to contain process ID and subprocess object address.

### DIFF
--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -53,9 +53,9 @@ Subprocess::~Subprocess() {
 }
 
 HANDLE Subprocess::SetupPipe(HANDLE ioport) {
-  char pipe_name[32];
+  char pipe_name[100];
   snprintf(pipe_name, sizeof(pipe_name),
-           "\\\\.\\pipe\\ninja_%p_out", ::GetModuleHandle(NULL));
+           "\\\\.\\pipe\\ninja_pid%u_sp%p", GetProcessId(GetCurrentProcess()), this);
 
   pipe_ = ::CreateNamedPipeA(pipe_name,
                              PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,


### PR DESCRIPTION
subprocess-win32.cc: change named pipe names to contain process ID and subprocess object address.

This should fix issue #93.
