### PR TITLE
Fix windows build by moving mkdtemp() implementation from ninja_test.cc t

### DIFF
--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -25,6 +25,35 @@ using namespace std;
 
 namespace {
 
+#ifdef _WIN32
+#ifndef _mktemp_s
+/// mingw has no mktemp.  Implement one with the same type as the one
+/// found in the Windows API.
+int _mktemp_s(char* templ) {
+  char* ofs = strchr(templ, 'X');
+  sprintf(ofs, "%d", rand() % 1000000);
+  return 0;
+}
+#endif
+
+/// Windows has no mkdtemp.  Implement it in terms of _mktemp_s.
+char* mkdtemp(char* name_template) {
+  int err = _mktemp_s(name_template);
+  if (err < 0) {
+    perror("_mktemp_s");
+    return NULL;
+  }
+
+  err = _mkdir(name_template);
+  if (err < 0) {
+    perror("mkdir");
+    return NULL;
+  }
+
+  return name_template;
+}
+#endif
+
 class DiskInterfaceTest : public testing::Test {
  public:
   virtual void SetUp() {

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -211,32 +211,4 @@ TEST_F(StatTest, Middle) {
   ASSERT_TRUE(GetNode("out")->dirty_);
 }
 
-#ifdef _WIN32
-#ifndef _mktemp_s
-/// mingw has no mktemp.  Implement one with the same type as the one
-/// found in the Windows API.
-int _mktemp_s(char* templ) {
-  char* ofs = strchr(templ, 'X');
-  sprintf(ofs, "%d", rand() % 1000000);
-  return 0;
-}
-#endif
-
-/// Windows has no mkdtemp.  Implement it in terms of _mktemp_s.
-char* mkdtemp(char* name_template) {
-  int err = _mktemp_s(name_template);
-  if (err < 0) {
-    perror("_mktemp_s");
-    return NULL;
-  }
-
-  err = _mkdir(name_template);
-  if (err < 0) {
-    perror("mkdir");
-    return NULL;
-  }
-
-  return name_template;
-}
-#endif
 


### PR DESCRIPTION
Fix windows build by moving mkdtemp() implementation from ninja_test.cc to disk_interface_test.cc

Signed-off-by: Thiago Farina tfarina@chromium.org
