### PR TITLE
Link with pthread so ninja_test can run.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -169,7 +169,7 @@ if options.with_gtest:
     test_libs = libs + [os.path.join(path, 'lib/.libs/lib%s.a' % lib)
                         for lib in ['gtest_main', 'gtest']]
 else:
-    test_libs = libs + ['-lgtest_main', '-lgtest']
+    test_libs = libs + ['-lgtest_main', '-lgtest', '-lpthread']
 
 objs = []
 for name in ['build_test', 'build_log_test', 'disk_interface_test',


### PR DESCRIPTION
Otherwise we get:

./ninja_test: symbol lookup error: /usr/lib/libgtest.so.0: undefined symbol: pthread_key_create

Signed-off-by: Thiago Farina tfarina@chromium.org
