### PR TITLE
Make Cleaner::config_ a reference-to-const instead of copying the value.

### DIFF
--- a/src/clean.cc
+++ b/src/clean.cc
@@ -20,7 +20,6 @@
 #include <string.h>
 #include <sys/stat.h>
 
-#include "build.h"
 #include "disk_interface.h"
 #include "graph.h"
 #include "state.h"

--- a/src/clean.h
+++ b/src/clean.h
@@ -14,15 +14,16 @@
 
 #ifndef NINJA_CLEAN_H_
 #define NINJA_CLEAN_H_
+#pragma once
+
+#include <set>
+#include <string>
 
 #include "build.h"
 
-#include <string>
-#include <set>
 using namespace std;
 
 struct State;
-struct BuildConfig;
 struct Node;
 struct Rule;
 struct DiskInterface;
@@ -92,7 +93,7 @@ class Cleaner {
   void Reset();
 
   State* state_;
-  BuildConfig config_;
+  const BuildConfig& config_;
   set<string> removed_;
   int cleaned_files_count_;
   DiskInterface* disk_interface_;


### PR DESCRIPTION
Signed-off-by: Thiago Farina tfarina@chromium.org
