### PR TITLE
This is C++, there is no need to write 'struct' before the type when decl

### DIFF
--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -88,7 +88,7 @@ HANDLE Subprocess::SetupPipe(HANDLE ioport) {
   return output_write_child;
 }
 
-bool Subprocess::Start(struct SubprocessSet* set, const string& command) {
+bool Subprocess::Start(SubprocessSet* set, const string& command) {
   HANDLE child_pipe = SetupPipe(set->ioport_);
 
   STARTUPINFOA startup_info = {};


### PR DESCRIPTION
This is C++, there is no need to write 'struct' before the type when declaring a variable.

Signed-off-by: Thiago Farina tfarina@chromium.org
