### PR TITLE
Add a "commands" tool

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -382,6 +382,10 @@ than the _depth_ mode.  It returns non-zero if an error occurs.
 one.  It can be used to know which rule name to pass to
 +ninja -t targets rule _name_+.
 
+`commands`:: given a list of targets, print a list of commands which, if
+executed in order, may be used to rebuild those targets, assuming that all
+output files are out of date.
+
 `clean`:: remove built files.  If used like this +ninja -t clean+ it removes
 all the built files, except for those created by the generator.  If used
 like this +ninja -t clean -g+ it also removes built files created by the


### PR DESCRIPTION
This tool performs a post-order traversal of the build graph, starting
from a list of targets specified on the command line, and for each
build statement encountered, prints the evaluated command line.
Use cases include:
- Generating input for a tool which needs to know the full command line
  for every command invoked during a build.  Many static analysis
  and indexing tools require this information.
- Generating a build script which does not depend on Ninja.
  For example, such a script could be used by Ninja to bootstrap
  itself.
