### PR TITLE
Add spelling suggestions for four cases:

### DIFF
--- a/src/edit_distance.cc
+++ b/src/edit_distance.cc
@@ -16,8 +16,6 @@
 
 #include <vector>
 
-#include "string_piece.h"
-
 int EditDistance(const StringPiece& s1,
                  const StringPiece& s2,
                  bool allow_replacements,

--- a/src/edit_distance.h
+++ b/src/edit_distance.h
@@ -15,7 +15,7 @@
 #ifndef NINJA_EDIT_DISTANCE_H_
 #define NINJA_EDIT_DISTANCE_H_
 
-struct StringPiece;
+#include "string_piece.h"
 
 int EditDistance(const StringPiece& s1,
                  const StringPiece& s2,

--- a/src/edit_distance_test.cc
+++ b/src/edit_distance_test.cc
@@ -14,7 +14,6 @@
 
 #include "edit_distance.h"
 
-#include "string_piece.h"
 #include "test.h"
 
 TEST(EditDistanceTest, TestEmpty) {

--- a/src/stat_cache.cc
+++ b/src/stat_cache.cc
@@ -16,6 +16,7 @@
 
 #include <stdio.h>
 
+#include "edit_distance.h"
 #include "graph.h"
 
 FileStat* StatCache::GetFile(const std::string& path) {
@@ -25,6 +26,23 @@ FileStat* StatCache::GetFile(const std::string& path) {
   FileStat* file = new FileStat(path);
   paths_[file->path_.c_str()] = file;
   return file;
+}
+
+FileStat* StatCache::SpellcheckFile(const std::string& path) {
+  const bool kAllowReplacements = true;
+  const int kMaxValidEditDistance = 3;
+
+  int min_distance = kMaxValidEditDistance + 1;
+  FileStat* result = NULL;
+  for (Paths::iterator i = paths_.begin(); i != paths_.end(); ++i) {
+    int distance = EditDistance(
+        i->first, path, kAllowReplacements, kMaxValidEditDistance);
+    if (distance < min_distance && i->second->node_) {
+      min_distance = distance;
+      result = i->second;
+    }
+  }
+  return result;
 }
 
 void StatCache::Dump() {

--- a/src/stat_cache.h
+++ b/src/stat_cache.h
@@ -26,6 +26,7 @@ struct FileStat;
 /// Mapping of path -> FileStat.
 struct StatCache {
   FileStat* GetFile(const std::string& path);
+  FileStat* SpellcheckFile(const std::string& path);
 
   /// Dump the mapping to stdout (useful for debugging).
   void Dump();

--- a/src/state.cc
+++ b/src/state.cc
@@ -59,6 +59,13 @@ Node* State::LookupNode(const string& path) {
   return file->node_;
 }
 
+Node* State::SpellcheckNode(const string& path) {
+  FileStat* file = stat_cache_.SpellcheckFile(path);
+  if (!file || !file->node_)
+    return NULL;
+  return file->node_;
+}
+
 void State::AddIn(Edge* edge, const string& path) {
   Node* node = GetNode(path);
   edge->inputs_.push_back(node);

--- a/src/state.h
+++ b/src/state.h
@@ -41,6 +41,7 @@ struct State {
   Edge* AddEdge(const Rule* rule);
   Node* GetNode(const string& path);
   Node* LookupNode(const string& path);
+  Node* SpellcheckNode(const string& path);
   void AddIn(Edge* edge, const string& path);
   void AddOut(Edge* edge, const string& path);
   bool AddDefault(const string& path, string* error);

--- a/src/util.cc
+++ b/src/util.cc
@@ -37,6 +37,8 @@
 #include <direct.h>  // _mkdir
 #endif
 
+#include "edit_distance.h"
+
 void Fatal(const char* msg, ...) {
   va_list ap;
   fprintf(stderr, "ninja: FATAL: ");
@@ -183,4 +185,27 @@ int64_t GetTimeMillis() {
   gettimeofday(&now, NULL);
   return ((int64_t)now.tv_sec * 1000) + (now.tv_usec / 1000);
 #endif
+}
+
+const char* SpellcheckString(const string& text, ...) {
+  const bool kAllowReplacements = true;
+  const int kMaxValidEditDistance = 3;
+
+  va_list ap;
+  va_start(ap, text);
+  const char* correct_spelling;
+
+  int min_distance = kMaxValidEditDistance + 1;
+  const char* result = NULL;
+  while ((correct_spelling = va_arg(ap, const char*))) {
+    int distance = EditDistance(
+        correct_spelling, text, kAllowReplacements, kMaxValidEditDistance);
+    if (distance < min_distance) {
+      min_distance = distance;
+      result = correct_spelling;
+    }
+  }
+
+  va_end(ap);
+  return result;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -49,6 +49,10 @@ void SetCloseOnExec(int fd);
 /// time.
 int64_t GetTimeMillis();
 
+/// Given a misspelled string and a NULL-terminatd list of correct spellings,
+/// returns the closest match or NULL if there is no close enough match.
+const char* SpellcheckString(const string& text, ...);
+
 #ifdef _WIN32
 #define snprintf _snprintf
 #endif


### PR DESCRIPTION
1. For targets, when invoking ninja to build a target.
2. For targets, when doing a "query" command.
3. For command names.
4. For the subcommands of the "targets" command.

Also change CmdTargets() to call LookupNode() instead of GetNode() --
since the result was checked for NULL, that's probably what was intended
here originally.

This is part 2/2 of https://github.com/martine/ninja/issues/129
