### PR TITLE
Add -Wextra warning flag.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -74,7 +74,7 @@ def cxx(name, **kwargs):
 
 n.variable('builddir', 'build')
 
-cflags = ['-g', '-Wall', '-Wno-deprecated', '-fno-exceptions',
+cflags = ['-g', '-Wall', '-Wextra', '-Wno-deprecated', '-fno-exceptions',
           '-fvisibility=hidden', '-pipe']
 if not options.debug:
     cflags += ['-O2', '-DNDEBUG']

--- a/src/browse.cc
+++ b/src/browse.cc
@@ -20,7 +20,7 @@
 
 #include "../build/browse_py.h"
 
-void RunBrowsePython(State* state, const char* ninja_command,
+void RunBrowsePython(State* /* state */, const char* ninja_command,
                      const char* initial_target) {
   // Fork off a Python process and have it run our code via its stdin.
   // (Actually the Python process becomes the parent.)

--- a/src/build.cc
+++ b/src/build.cc
@@ -419,7 +419,7 @@ struct DryRunCommandRunner : public CommandRunner {
     finished_.push(edge);
     return true;
   }
-  virtual Edge* WaitForCommand(bool* success, string* output) {
+  virtual Edge* WaitForCommand(bool* success, string* /* output */) {
     if (finished_.empty())
       return NULL;
     *success = true;

--- a/src/eval_env.h
+++ b/src/eval_env.h
@@ -45,7 +45,7 @@ struct EvalString {
   string Evaluate(Env* env) const;
 
   const string& unparsed() const { return unparsed_; }
-  const bool empty() const { return unparsed_.empty(); }
+  bool empty() const { return unparsed_.empty(); }
 
   string unparsed_;
   enum TokenType { RAW, SPECIAL };

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -363,7 +363,7 @@ int CmdTargets(State* state, int argc, char* argv[]) {
   }
 }
 
-int CmdRules(State* state, int argc, char* argv[]) {
+int CmdRules(State* state, int /* argc */, char* /* argv */[]) {
   for (map<string, const Rule*>::iterator i = state->rules_.begin();
        i != state->rules_.end(); ++i) {
     if (i->second->description_.unparsed_.empty()) {
@@ -459,7 +459,7 @@ int main(int argc, char** argv) {
 
   const option kLongOptions[] = {
     { "help", no_argument, NULL, 'h' },
-    { }
+    { NULL, 0, NULL, 0 }
   };
 
   int opt;

--- a/src/subprocess.cc
+++ b/src/subprocess.cc
@@ -37,7 +37,7 @@ Subprocess::~Subprocess() {
     Finish();
 }
 
-bool Subprocess::Start(SubprocessSet* set, const string& command) {
+bool Subprocess::Start(SubprocessSet* /* set */, const string& command) {
   int output_pipe[2];
   if (pipe(output_pipe) < 0)
     Fatal("pipe: %s", strerror(errno));


### PR DESCRIPTION
Fix triggered warnings:
- unused parameter
- type qualifiers ignored on function return type
- missing initializer for member
