### PR TITLE
Pass the path of the build file down to `browser.py`.

### DIFF
--- a/src/browse.cc
+++ b/src/browse.cc
@@ -21,7 +21,7 @@
 #include "../build/browse_py.h"
 
 void RunBrowsePython(State* /* state */, const char* ninja_command,
-                     const char* initial_target) {
+                     const char* ninja_file, const char* initial_target) {
   // Fork off a Python process and have it run our code via its stdin.
   // (Actually the Python process becomes the parent.)
   int pipefd[2];
@@ -46,7 +46,7 @@ void RunBrowsePython(State* /* state */, const char* ninja_command,
 
       // exec Python, telling it to run the program from stdin.
       const char* command[] = {
-        "python", "-", ninja_command, initial_target, NULL
+        "python", "-", ninja_command, ninja_file, initial_target, NULL
       };
       execvp(command[0], (char**)command);
       perror("ninja: execvp");

--- a/src/browse.h
+++ b/src/browse.h
@@ -22,6 +22,6 @@ struct State;
 /// \a initial_target is the first target to load.
 /// This function does not return if it runs successfully.
 void RunBrowsePython(State* state, const char* ninja_command,
-                     const char* initial_target);
+                     const char* ninja_file, const char* initial_target);
 
 #endif  // NINJA_BROWSE_H_

--- a/src/browse.py
+++ b/src/browse.py
@@ -106,7 +106,7 @@ ul {
     print '</td></tr></table>'
 
 def ninja_dump(target):
-    proc = subprocess.Popen([sys.argv[1], '-t', 'query', target],
+    proc = subprocess.Popen([sys.argv[1], "-f", sys.argv[2], '-t', 'query', target],
                             stdout=subprocess.PIPE)
     return proc.communicate()[0]
 
@@ -117,7 +117,7 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
         if target == '':
             self.send_response(302)
-            self.send_header('Location', '?' + sys.argv[2])
+            self.send_header('Location', '?' + sys.argv[3])
             self.end_headers()
             return
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -238,14 +238,14 @@ int CmdQuery(State* state, int argc, char* argv[]) {
   return 0;
 }
 
-int CmdBrowse(State* state, const char* ninja_command,
+int CmdBrowse(State* state, const char* ninja_command, const char* ninja_file,
               int argc, char* argv[]) {
 #ifndef WIN32
   if (argc < 1) {
     Error("expected a target to browse");
     return 1;
   }
-  RunBrowsePython(state, ninja_command, argv[0]);
+  RunBrowsePython(state, ninja_command, ninja_file, argv[0]);
 #else
   NINJA_UNUSED_ARG(state);
   NINJA_UNUSED_ARG(ninja_command);
@@ -537,7 +537,7 @@ reload:
     if (tool == "query")
       return CmdQuery(&state, argc, argv);
     if (tool == "browse")
-      return CmdBrowse(&state, ninja_command, argc, argv);
+      return CmdBrowse(&state, ninja_command, input_file, argc, argv);
     if (tool == "targets")
       return CmdTargets(&state, argc, argv);
     if (tool == "rules")


### PR DESCRIPTION
It seems that when the browser plugin is invoked, it runs ninja without passing the build script file path.
Thus in case we invoke ninja with the `-f` flag it is not passed.

I've added a new argument to `browser.py`, just after the ninja executable path.

Conflicts (minor):
    src/browse.cc
