### PR TITLE
Use g++'s -static option instead of specific libs

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -84,7 +84,7 @@ libs = []
 if platform == 'mingw':
     cflags.append('-Igtest-1.6.0/include')
     ldflags.append('-Lgtest-1.6.0/lib/.libs')
-    ldflags.extend(['-static-libgcc', '-static-libstdc++'])
+    ldflags.extend(['-static'])
 else:
     if options.profile == 'gmon':
         cflags.append('-pg')


### PR DESCRIPTION
MinGW g++ recognizes -static as option to avoid the need to specify
individual libraries to be statically linked into the executable.

It also solves the warning of -static-libstdc++ not being recorgnized by
GCC 4.5.2 (TDM build)
