### PR TITLE
visibility=hidden should not be used for Windows

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -82,6 +82,7 @@ ldflags = ['-L$builddir']
 libs = []
 
 if platform == 'mingw':
+    cflags.remove('-fvisibility=hidden');
     cflags.append('-Igtest-1.6.0/include')
     ldflags.append('-Lgtest-1.6.0/lib/.libs')
     ldflags.extend(['-static-libgcc', '-static-libstdc++'])


### PR DESCRIPTION
While GCC 4.x supports the usage of -fvisibility=hidden and the related
pragmas, usage of it under MinGW is a noop and should not be used.

Instead, __declspec(dllexport/dllimport) should be used instead to
indicate exportable functions.

Since Ninja builds a static library, no functions are exported and
visibility, at least under MinGW, is not an issue.
