### PR TITLE
Protect BuildLog data member variables by making them private.

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -35,10 +35,14 @@ namespace {
 const char kFileSignature[] = "# ninja log v%d\n";
 const int kCurrentVersion = 3;
 
-}
+}  // namespace
 
 BuildLog::BuildLog()
   : log_file_(NULL), config_(NULL), needs_recompaction_(false) {}
+
+BuildLog::~BuildLog() {
+  Close();
+}
 
 bool BuildLog::OpenForWrite(const string& path, string* err) {
   if (config_ && config_->dry_run)
@@ -144,7 +148,7 @@ bool BuildLog::Load(const string& path, string* err) {
       end_time = atoi(start);
       start = end + 1;
     }
-    
+
     if (log_version >= 3) {
       // In v3 we log the restat mtime.
       char* end = strchr(start, ' ');

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -34,7 +34,7 @@ struct Edge;
 ///    from it
 struct BuildLog {
   BuildLog();
-  ~BuildLog() { Close(); }
+  ~BuildLog();
 
   void SetConfig(BuildConfig* config) { config_ = config; }
   bool OpenForWrite(const string& path, string* err);
@@ -69,6 +69,7 @@ struct BuildLog {
   /// Rewrite the known log entries, throwing away old data.
   bool Recompact(const string& path, string* err);
 
+ private:
   typedef ExternalStringHashMap<LogEntry*>::Type Log;
   Log log_;
   FILE* log_file_;


### PR DESCRIPTION
They are not accessed outside of BuildLog and there is even a SetConfig function
to set the |config_| variable.

So better to make them private to BuildLog now while nobody is using it outside.

Signed-off-by: Thiago Farina tfarina@chromium.org
