### PR TITLE
Capitalize "error" to match with the other utility functions.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -60,7 +60,7 @@ void Warning(const char* msg, ...) {
 
 void Error(const char* msg, ...) {
   va_list ap;
-  fprintf(stderr, "ninja: error: ");
+  fprintf(stderr, "ninja: ERROR: ");
   va_start(ap, msg);
   vfprintf(stderr, msg, ap);
   va_end(ap);


### PR DESCRIPTION
Fatal and Warning functions already output their strings capitalized,
we were just missing the Error function. So capitalize it now.

Signed-off-by: Thiago Farina tfarina@chromium.org
