### PR TITLE
Fix the TODO in BuildLog class.

### DIFF
--- a/src/build_log.h
+++ b/src/build_log.h
@@ -69,6 +69,8 @@ struct BuildLog {
   bool Recompact(const string& path, string* err);
 
  private:
+  friend class BuildLogTest;
+
   typedef ExternalStringHashMap<LogEntry*>::Type Log;
   Log log_;
   FILE* log_file_;


### PR DESCRIPTION
This is was pretty trivial, since no one was calling |log_|.

Signed-off-by: Thiago Farina tfarina@chromium.org
