### PR TITLE
Use ExitProcess instead of exit in Fatal to allow extra cleanup for MSVC

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -46,7 +46,15 @@ void Fatal(const char* msg, ...) {
   vfprintf(stderr, msg, ap);
   va_end(ap);
   fprintf(stderr, "\n");
+#ifdef WIN32
+  //on Windows, if running under a distribution system which adds extra threads,
+  //possibly with kernel locks or pending IO, exit may hang
+  fflush(stderr);
+  fflush(stdout);
+  ExitProcess(1);
+#else
   exit(1);
+#endif
 }
 
 void Warning(const char* msg, ...) {


### PR DESCRIPTION
We have seen ninja hang on Windows when built with MSVC, when it tried to call exit inside Fatal. This small change gets round the problems we saw.
