### PR TITLE
ninja_syntax.py: Fix passing variables to Writer.build()

### DIFF
--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -66,7 +66,7 @@ class Writer(object):
                                         ' '.join(all_inputs)))
 
         if variables:
-            for key, val in variables:
+            for key, val in variables.iteritems():
                 self.variable(key, val, indent=1)
 
         return outputs

--- a/misc/ninja_test.py
+++ b/misc/ninja_test.py
@@ -111,5 +111,18 @@ foo = a$$ $
 ''',
                          self.out.getvalue())
 
+class TestBuild(unittest.TestCase):
+    def setUp(self):
+        self.out = StringIO()
+        self.n = ninja_syntax.Writer(self.out)
+
+    def test_variables(self):
+        self.n.build('out', 'cc', 'in', variables={'name': 'value'})
+        self.assertEqual('''\
+build out: cc in
+  name = value
+''',
+                         self.out.getvalue())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I dropped my erroneous commit; thanks for pulling the other minor fix. Here is another minor fix, this time for ninja_syntax.py

Without this, I get: 

Traceback (most recent call last):
  File "./ninja_test.py", line 120, in test_variables
    self.n.build('out', 'cc', 'in', variables={'name': 'value'})
  File "/Users/ej/ninja/misc/ninja_syntax.py", line 69, in build
    for key, val in variables:
ValueError: too many values to unpack
