### PR TITLE
ninja_syntax.py: support passing variables as both dicts and lists.

### DIFF
--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -66,7 +66,12 @@ class Writer(object):
                                         ' '.join(all_inputs)))
 
         if variables:
-            for key, val in variables:
+            if isinstance(variables, dict):
+                iterator = variables.iteritems()
+            else:
+                iterator = iter(variables)
+
+            for key, val in iterator:
                 self.variable(key, val, indent=1)
 
         return outputs

--- a/misc/ninja_test.py
+++ b/misc/ninja_test.py
@@ -111,5 +111,26 @@ foo = a$$ $
 ''',
                          self.out.getvalue())
 
+class TestBuild(unittest.TestCase):
+    def setUp(self):
+        self.out = StringIO()
+        self.n = ninja_syntax.Writer(self.out)
+
+    def test_variables_dict(self):
+        self.n.build('out', 'cc', 'in', variables={'name': 'value'})
+        self.assertEqual('''\
+build out: cc in
+  name = value
+''',
+                         self.out.getvalue())
+
+    def test_variables_list(self):
+        self.n.build('out', 'cc', 'in', variables=[('name', 'value')])
+        self.assertEqual('''\
+build out: cc in
+  name = value
+''',
+                         self.out.getvalue())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Oops; I thought I had previously submitted this pull request, but it looks like I must have forgotten to click send?

At any rate: when I looked at this API, I assumed variables should be a dict. This makes it support both dicts and lists, and adds a test for it.
