### PR TITLE
Lexer: include leading whitespace in comments.

### DIFF
--- a/src/lexer.in.cc
+++ b/src/lexer.in.cc
@@ -110,7 +110,7 @@ Lexer::Token Lexer::ReadToken() {
     simple_varname = [a-zA-Z0-9_-]+;
     varname = [a-zA-Z0-9_.-]+;
 
-    "#"[^\000\n]*"\n" { continue; }
+    [ ]*"#"[^\000\n]*"\n" { continue; }
     [\n]       { token = NEWLINE;  break; }
     [ ]+       { token = INDENT;   break; }
     "build"    { token = BUILD;    break; }


### PR DESCRIPTION
This seems to fix the issue with indented comments! I'm actually somewhat surprised that there aren't other unintended consequences, but it seems okay. I did not include the generated lexer.cc here to avoid complicating the change. It passes ninja_test, builds ninja and my own project.
