### PR TITLE
Fixed the formatting of the error message when a the build file does not exist.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -142,7 +142,9 @@ int MakeDir(const string& path) {
 int ReadFile(const string& path, string* contents, string* err) {
   FILE* f = fopen(path.c_str(), "r");
   if (!f) {
-    err->assign(strerror(errno));
+    err->assign("error: " + path + ": ");
+    err->append(strerror(errno));
+    err->append("\n");
     return -errno;
   }
 
@@ -152,7 +154,9 @@ int ReadFile(const string& path, string* contents, string* err) {
     contents->append(buf, len);
   }
   if (ferror(f)) {
-    err->assign(strerror(errno));  // XXX errno?
+    err->assign("error: " + path + ": ");
+    err->append(strerror(errno));  // XXX errno?
+    err->append("\n");
     contents->clear();
     fclose(f);
     return -errno;


### PR DESCRIPTION
This was annoying me. If build.ninja does not exist, ninja would print the following:

jsternberg ~/ninja $ ninja
No such file or directoryjsternberg ~/ninja $

The patch fixes this so it prints:

jsternberg ~/ninja $ ninja
error: build.ninja: No such file or directory
jsternberg ~/ninja $

"build.ninja" will be replaced with whatever the file name that's being loaded is named.
