### PR TITLE
Strip ansi escape sequences from subcommand output when not writing to a...

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -255,3 +255,31 @@ string GetLastErrorString() {
   return msg;
 }
 #endif
+
+static bool islatinalpha(int c) {
+  // isalpha() is locale-dependent.
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+string StripAnsiEscapeCodes(const string& in) {
+  string stripped;
+  stripped.reserve(in.size());
+
+  for (size_t i = 0; i < in.size(); ++i) {
+    if (in[i] != '\33') {
+      // Not an escape code.
+      stripped.push_back(in[i]);
+      continue;
+    }
+
+    // Only strip CSIs for now.
+    if (i + 1 >= in.size()) break;
+    if (in[i + 1] != '[') continue;  // Not a CSI.
+    i += 2;
+
+    // Skip everything up to and including the next [a-zA-Z].
+    while (i < in.size() && !islatinalpha(in[i]))
+      ++i;
+  }
+  return stripped;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -65,6 +65,9 @@ const char* SpellcheckStringV(const string& text, const vector<const char*>& wor
 /// Like SpellcheckStringV, but takes a NULL-terminated list.
 const char* SpellcheckString(const string& text, ...);
 
+/// Removes all Ansi escape codes (http://www.termsys.demon.co.uk/vtansi.htm).
+string StripAnsiEscapeCodes(const string& in);
+
 #ifdef _WIN32
 #define snprintf _snprintf
 #define fileno _fileno

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -73,3 +73,20 @@ TEST(CanonicalizePath, AbsolutePath) {
   EXPECT_TRUE(CanonicalizePath(&path, &err));
   EXPECT_EQ("/usr/include/stdio.h", path);
 }
+
+TEST(StripAnsiEscapeCodes, EscapeAtEnd) {
+  string stripped = StripAnsiEscapeCodes("foo\33");
+  EXPECT_EQ("foo", stripped);
+
+  stripped = StripAnsiEscapeCodes("foo\33[");
+  EXPECT_EQ("foo", stripped);
+}
+
+TEST(StripAnsiEscapeCodes, StripColors) {
+  // An actual clang warning.
+  string input = "\33[1maffixmgr.cxx:286:15: \33[0m\33[0;1;35mwarning: "
+                 "\33[0m\33[1musing the result... [-Wparentheses]\33[0m";
+  string stripped = StripAnsiEscapeCodes(input);
+  EXPECT_EQ("affixmgr.cxx:286:15: warning: using the result... [-Wparentheses]",
+            stripped);
+}


### PR DESCRIPTION
... smart terminal.

I feel that ninja should have an option to disable this (say for use with something like http://www.hanshq.net/ansi2tex.html), but that's for a follow-up.
