### PR TITLE
Some workarounds are only for msvc.

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -709,7 +709,7 @@ reload:
     printf("\n");
     int count = (int)globals.state->paths_.size();
     int buckets =
-#ifdef _WIN32
+#ifdef _MSC_VER
         (int)globals.state->paths_.comp.bucket_size;
 #else
         (int)globals.state->paths_.bucket_count();

--- a/src/util.h
+++ b/src/util.h
@@ -68,12 +68,14 @@ const char* SpellcheckString(const string& text, ...);
 /// Removes all Ansi escape codes (http://www.termsys.demon.co.uk/vtansi.htm).
 string StripAnsiEscapeCodes(const string& in);
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define snprintf _snprintf
 #define fileno _fileno
 #define unlink _unlink
 #define chdir _chdir
+#endif
 
+#ifdef _WIN32
 /// Convert the value returned by GetLastError() into a string.
 string GetLastErrorString();
 #endif


### PR DESCRIPTION
Mingw also sets _WIN32, but the the workarounds are only for msvc.
