### PR TITLE
Fix configure.py for unpacked gtest on Windows platform.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -257,15 +257,15 @@ if options.with_gtest:
 
     gtest_all_incs = '-I%s -I%s' % (path, os.path.join(path, 'include'))
     if platform == 'windows':
-        gtest_cflags = '/EHsc ' + gtest_all_incs
+        gtest_cflags = '/nologo /EHsc ' + gtest_all_incs
     else:
         gtest_cflags = '-fvisibility=hidden ' + gtest_all_incs
     objs += n.build(built('gtest-all' + objext), 'cxx',
                     os.path.join(path, 'src/gtest-all.cc'),
-                    variables=[('cflags', cflags + [gtest_cflags])])
+                    variables=[('cflags', gtest_cflags)])
     objs += n.build(built('gtest_main' + objext), 'cxx',
                     os.path.join(path, 'src/gtest_main.cc'),
-                    variables=[('cflags', cflags + [gtest_cflags])])
+                    variables=[('cflags', gtest_cflags)])
 
     test_cflags = cflags + ['-I%s' % os.path.join(path, 'include')]
 elif platform == 'windows':


### PR DESCRIPTION
-Use /EHsc instead of -fvisibility=hidden
-Use valid objext
-Use cflags + gtest_cflags
