### PR TITLE
Fix cygwin build by including stdio.h here

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -15,7 +15,6 @@
 #include "build_log.h"
 
 #include <errno.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <string>
+#include <stdio.h>
 using namespace std;
 
 #include "hash_map.h"


### PR DESCRIPTION
Trivial. Fixes cygwin build.

build_log.h has a function that uses FILE structure from <cstdio>.
