### PR TITLE
windows: Disable warning C4819

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -103,7 +103,7 @@ else:
 
 if platform == 'windows':
     cflags = ['/nologo', '/Zi', '/W4', '/WX', '/wd4530', '/wd4100', '/wd4706',
-              '/wd4512', '/wd4800', '/wd4702',
+              '/wd4512', '/wd4800', '/wd4702', '/wd4819',
               '/D_CRT_SECURE_NO_WARNINGS',
               "/DNINJA_PYTHON=\"%s\"" % (options.with_python,)]
     ldflags = ['/DEBUG', '/libpath:$builddir']


### PR DESCRIPTION
Fixes MSVC build on non-Latin codepage users.

Warning C4819 is "The file contains a character that cannot be represented in the current code page".
This warning is just useless for cross-platform projects (i.e. source w/o Unicode string literals or Unicode identifiers.)
