### PR TITLE
don't crash when a dot it passed to CanonicalizePath 

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -97,6 +97,10 @@ bool CanonicalizePath(char* path, int* len, string* err) {
     return false;
   }
 
+  // nothing we can do, f.i. path == "."
+  if (*len == 1)
+    return true;
+
   const int kMaxPathComponents = 30;
   char* components[kMaxPathComponents];
   int component_count = 0;

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -54,6 +54,10 @@ TEST(CanonicalizePath, PathSamples) {
   path = "./x/../foo/../../bar.h";
   EXPECT_TRUE(CanonicalizePath(&path, &err));
   EXPECT_EQ("../bar.h", path);
+
+  path = ".";
+  EXPECT_TRUE(CanonicalizePath(&path, &err));
+  EXPECT_EQ(".", path);
 }
 
 TEST(CanonicalizePath, UpDir) {


### PR DESCRIPTION
I don't know if this could happen with valid ninja files, but when a dot is passed to CanonicalizePath  the code ends at #87 with path->resize(-1);
