### PR TITLE
Argument file support

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -401,6 +401,7 @@ bool RealCommandRunner::CanRunMore() {
 bool RealCommandRunner::StartCommand(Edge* edge) {
   string command = edge->EvaluateCommand();
   Subprocess* subproc = new Subprocess;
+  subproc->rsp_files_ = edge->rsp_files_;
   subproc_to_edge_.insert(make_pair(subproc, edge));
   if (!subproc->Start(&subprocs_, command))
     return false;

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 #include "eval_env.h"
+#include "util.h"
+#include <stdio.h>
+
+#define ENABLE_RESPONSE_FILE
+//#define ENABLE_RESPONSE_FILE_TEST
 
 string BindingEnv::LookupVariable(const string& var) {
   map<string, string>::iterator i = bindings_.find(var);
@@ -27,15 +32,136 @@ void BindingEnv::AddBinding(const string& key, const string& val) {
   bindings_[key] = val;
 }
 
-string EvalString::Evaluate(Env* env) const {
-  string result;
+vector<EvalString::TokenList> EvalString::splitChainedCommand() const
+{
+  TokenList cmd;
+  vector<TokenList> cmds;
+
+  // first check if we should start with a chell command
   for (TokenList::const_iterator i = parsed_.begin(); i != parsed_.end(); ++i) {
-    if (i->second == RAW)
+    if (i->second == SPLITTER) {
+#ifdef _WIN32
+      TokenList shell_call;
+      shell_call.push_back(Token("cmd.exe /c ", RAW));
+      cmds.push_back(shell_call);
+#else
+      // shell is always used
+#endif
+      break;
+    }
+  }
+
+  for (TokenList::const_iterator i = parsed_.begin(); i != parsed_.end(); ++i) {
+    if (i->second == SPLITTER) {
+      cmds.push_back(cmd);
+      TokenList splitter;
+      splitter.push_back(*i);
+      cmds.push_back(splitter);
+      cmd.clear();
+    } else {
+      cmd.push_back(*i);
+    }
+  }
+  cmds.push_back(cmd);
+  return cmds;
+}
+
+
+string EvalString::PlainEvaluate(Env* env, const TokenList& tokens) const {
+  string result;
+  for (TokenList::const_iterator i = tokens.begin(); i != tokens.end(); ++i) {
+    if (i->second == RAW || i->second == SPLITTER)
       result.append(i->first);
     else
       result.append(env->LookupVariable(i->first));
   }
   return result;
+}
+
+static size_t maximumCommandLineLength()
+{
+#ifdef ENABLE_RESPONSE_FILE_TEST
+  return 200;
+#endif
+#ifdef _WIN32
+  return 8100;
+#else
+  return 100000;
+#endif
+}
+
+string EvalString::checkForArgumentFile(Env* env, const string& plaincmdstr, const TokenList& tokens) const
+{
+  if (plaincmdstr.size() < maximumCommandLineLength())
+    return plaincmdstr;
+
+  size_t rsp_pos = 0;
+  for (TokenList::const_iterator i = tokens.begin(); i != tokens.end(); ++i) {
+      if (i->first == "rsp")
+        break;
+      rsp_pos++;
+  }
+
+  size_t rsp_behind;
+  if (rsp_pos == tokens.size()) {
+    // no $rsp in build rule
+    // place behind first token
+    rsp_pos = 1;
+    rsp_behind = 1;
+  } else {
+    rsp_behind = rsp_pos + 1;
+  }
+
+  // extract command until response file
+  TokenList cmd;
+  for (size_t i = 0; i < rsp_pos; i++) {
+    cmd.push_back(tokens[i]);
+  }
+
+  // make the rule specific argument file loading option
+  string rspopt = (env->rspopt_.empty() ? " @" : env->rspopt_);
+  cmd.push_back(Token(rspopt, RAW));
+  cmd.push_back(Token("rsp", SPECIAL));
+
+  // remaining arguments
+  TokenList arg;
+  for (size_t i = rsp_behind; i < tokens.size(); i++) {
+    arg.push_back(tokens[i]);
+  }
+
+  string err;
+  const FileInfo tmp = TempFilename(&err);
+  env->current_rsp_file_ = tmp.path;
+  string cmdstr = PlainEvaluate(env, cmd);
+  string argstr = PlainEvaluate(env, arg);
+  WriteFile(tmp, argstr, &err);
+  env->rsp_files_.push_back(env->current_rsp_file_); // TODO not all files are removed
+  env->current_rsp_file_ = "";
+
+#ifdef ENABLE_RESPONSE_FILE_TEST
+  if (argstr.find("ar ") != string::npos)
+    return plaincmdstr;
+  printf("\nwith response file: %s \n", cmdstr.c_str());
+  //printf("\n     :'%s\n'", argstr.c_str());
+#endif
+
+  return cmdstr;
+}
+
+
+string EvalString::Evaluate(Env* env) const {
+#if defined(_WIN32) || defined(ENABLE_RESPONSE_FILE)
+  string result;
+  vector<TokenList> cmds = splitChainedCommand();
+  for (size_t i = 0; i < cmds.size(); i++) {
+      string cmdstr = PlainEvaluate(env, cmds[i]);
+      cmdstr = checkForArgumentFile(env, cmdstr, cmds[i]);
+      result.append(cmdstr);
+  }
+  return result;
+#else
+  return PlainEvaluate(env, parsed_);
+#endif
 }
 
 void EvalString::AddText(StringPiece text) {
@@ -48,6 +174,9 @@ void EvalString::AddText(StringPiece text) {
 }
 void EvalString::AddSpecial(StringPiece text) {
   parsed_.push_back(make_pair(text.AsString(), SPECIAL));
+}
+void EvalString::AddSplitter(StringPiece text) {
+  parsed_.push_back(make_pair(text.AsString(), SPLITTER));
 }
 
 string EvalString::Serialize() const {

--- a/src/eval_env.h
+++ b/src/eval_env.h
@@ -26,6 +26,10 @@ using namespace std;
 struct Env {
   virtual ~Env() {}
   virtual string LookupVariable(const string& var) = 0;
+
+  string rspopt_;
+  string current_rsp_file_;
+  vector<string> rsp_files_;
 };
 
 /// An Env which contains a mapping of variables to values
@@ -52,15 +56,22 @@ struct EvalString {
 
   void AddText(StringPiece text);
   void AddSpecial(StringPiece text);
+  void AddSplitter(StringPiece text);
 
   /// Construct a human-readable representation of the parsed state,
   /// for use in tests.
   string Serialize() const;
 
 private:
-  enum TokenType { RAW, SPECIAL };
-  typedef vector<pair<string, TokenType> > TokenList;
+  enum TokenType { RAW, SPECIAL, SPLITTER };
+  typedef pair<string, TokenType> Token;
+  typedef vector<Token> TokenList;
   TokenList parsed_;
+
+  // chaining/argfile
+  vector<TokenList> splitChainedCommand() const;
+  string PlainEvaluate(Env* env, const TokenList& list) const;
+  string checkForArgumentFile(Env* env, const string& cmdstr, const TokenList& tokens) const;
 };
 
 #endif  // NINJA_EVAL_ENV_H_

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -178,6 +178,8 @@ string EdgeEnv::LookupVariable(const string& var) {
   } else if (var == "out") {
     return MakePathList(edge_->outputs_.begin(),
                         edge_->outputs_.end());
+  } else if (var == "rsp") {
+      return current_rsp_file_;
   } else if (edge_->env_) {
     return edge_->env_->LookupVariable(var);
   } else {
@@ -206,7 +208,10 @@ string EdgeEnv::MakePathList(vector<Node*>::iterator begin,
 
 string Edge::EvaluateCommand() {
   EdgeEnv env(this);
-  return rule_->command().Evaluate(&env);
+  env.rspopt_ = rule_->rspopt().Evaluate(&env);
+  string cmd = rule_->command().Evaluate(&env);
+  rsp_files_ = env.rsp_files_;
+  return cmd;
 }
 
 string Edge::EvaluateDepFile() {

--- a/src/graph.h
+++ b/src/graph.h
@@ -108,6 +108,7 @@ struct Rule {
   EvalString& command() { return command_; }
   const EvalString& description() const { return description_; }
   const EvalString& depfile() const { return depfile_; }
+  const EvalString& rspopt() const { return rspopt_; }
 
   // TODO: private:
 
@@ -122,6 +123,9 @@ struct Rule {
   EvalString command_;
   EvalString description_;
   EvalString depfile_;
+
+private:
+  EvalString rspopt_;
 };
 
 struct BuildLog;
@@ -147,7 +151,17 @@ struct Edge {
   /// Return true if all inputs' in-edges are ready.
   bool AllInputsReady() const;
 
+  /*
+  TODO
+  struct CommandInfo {
+    string cmd;
+    vector<string> rsp_files_;
+  };
+  CommandInfo EvaluateCommand();  
+  */
   string EvaluateCommand();  // XXX move to env, take env ptr
+  vector<string> rsp_files_;
+
   string EvaluateDepFile();
   string GetDescription();
   bool LoadDepFile(State* state, DiskInterface* disk_interface, string* err);

--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -85,6 +85,7 @@ const char* Lexer::TokenName(Token t) {
   case PIPE:     return "'|'";
   case RULE:     return "'rule'";
   case SUBNINJA: return "'subninja'";
+  case SPLITTER: return "splitter";
   case TEOF:     return "eof";
   }
   return NULL;  // not reached
@@ -105,6 +106,7 @@ const char* Lexer::TokenErrorHint(Token t) {
   case PIPE:     return "";
   case RULE:     return "";
   case SUBNINJA: return "";
+  case SPLITTER: return "";
   case TEOF:     return "";
   }
   return "";
@@ -161,62 +163,70 @@ Lexer::Token Lexer::ReadToken() {
 	};
 
 	yych = *p;
-	if (yych <= 'Z') {
-		if (yych <= ',') {
+	if (yych <= '@') {
+		if (yych <= '%') {
 			if (yych <= 0x1F) {
-				if (yych <= 0x00) goto yy21;
+				if (yych <= 0x00) goto yy22;
 				if (yych == '\n') goto yy6;
-				goto yy23;
+				goto yy24;
 			} else {
 				if (yych <= ' ') goto yy2;
 				if (yych == '#') goto yy4;
-				goto yy23;
+				goto yy24;
 			}
 		} else {
-			if (yych <= ':') {
-				if (yych == '/') goto yy23;
-				if (yych <= '9') goto yy20;
-				goto yy14;
+			if (yych <= '/') {
+				if (yych <= '&') goto yy21;
+				if (yych <= ',') goto yy24;
+				if (yych <= '.') goto yy20;
+				goto yy24;
 			} else {
-				if (yych == '=') goto yy12;
-				if (yych <= '@') goto yy23;
-				goto yy20;
+				if (yych <= ':') {
+					if (yych <= '9') goto yy20;
+					goto yy14;
+				} else {
+					if (yych == '=') goto yy12;
+					goto yy24;
+				}
 			}
 		}
 	} else {
-		if (yych <= 'h') {
-			if (yych <= 'a') {
+		if (yych <= 'd') {
+			if (yych <= '`') {
+				if (yych <= 'Z') goto yy20;
 				if (yych == '_') goto yy20;
-				if (yych <= '`') goto yy23;
-				goto yy20;
+				goto yy24;
 			} else {
-				if (yych <= 'b') goto yy8;
-				if (yych == 'd') goto yy11;
-				goto yy20;
+				if (yych == 'b') goto yy8;
+				if (yych <= 'c') goto yy20;
+				goto yy11;
 			}
 		} else {
-			if (yych <= 's') {
-				if (yych <= 'i') goto yy18;
+			if (yych <= 'r') {
+				if (yych == 'i') goto yy18;
 				if (yych <= 'q') goto yy20;
-				if (yych <= 'r') goto yy10;
-				goto yy19;
+				goto yy10;
 			} else {
-				if (yych <= 'z') goto yy20;
-				if (yych == '|') goto yy16;
-				goto yy23;
+				if (yych <= 'z') {
+					if (yych <= 's') goto yy19;
+					goto yy20;
+				} else {
+					if (yych == '|') goto yy16;
+					goto yy24;
+				}
 			}
 		}
 	}
 yy2:
 	yyaccept = 0;
 	yych = *(q = ++p);
-	goto yy65;
+	goto yy68;
 yy3:
 	{ token = INDENT;   break; }
 yy4:
 	yyaccept = 1;
 	yych = *(q = ++p);
-	if (yych >= 0x01) goto yy60;
+	if (yych >= 0x01) goto yy63;
 yy5:
 	{ token = ERROR;    break; }
 yy6:
@@ -225,18 +235,18 @@ yy7:
 	{ token = NEWLINE;  break; }
 yy8:
 	++p;
-	if ((yych = *p) == 'u') goto yy54;
-	goto yy25;
+	if ((yych = *p) == 'u') goto yy57;
+	goto yy28;
 yy9:
 	{ token = IDENT;    break; }
 yy10:
 	yych = *++p;
-	if (yych == 'u') goto yy50;
-	goto yy25;
+	if (yych == 'u') goto yy53;
+	goto yy28;
 yy11:
 	yych = *++p;
-	if (yych == 'e') goto yy43;
-	goto yy25;
+	if (yych == 'e') goto yy46;
+	goto yy28;
 yy12:
 	++p;
 	{ token = EQUALS;   break; }
@@ -245,137 +255,144 @@ yy14:
 	{ token = COLON;    break; }
 yy16:
 	++p;
-	if ((yych = *p) == '|') goto yy41;
+	if ((yych = *p) == '|') goto yy44;
 	{ token = PIPE;     break; }
 yy18:
 	yych = *++p;
-	if (yych == 'n') goto yy34;
-	goto yy25;
+	if (yych == 'n') goto yy37;
+	goto yy28;
 yy19:
 	yych = *++p;
-	if (yych == 'u') goto yy26;
-	goto yy25;
+	if (yych == 'u') goto yy29;
+	goto yy28;
 yy20:
 	yych = *++p;
-	goto yy25;
+	goto yy28;
 yy21:
+	yych = *++p;
+	if (yych == '&') goto yy25;
+	goto yy5;
+yy22:
 	++p;
 	{ token = TEOF;     break; }
-yy23:
+yy24:
 	yych = *++p;
 	goto yy5;
-yy24:
+yy25:
+	++p;
+	{ token = SPLITTER; break; }
+yy27:
 	++p;
 	yych = *p;
-yy25:
+yy28:
 	if (yybm[0+yych] & 32) {
-		goto yy24;
+		goto yy27;
 	}
 	goto yy9;
-yy26:
+yy29:
 	yych = *++p;
-	if (yych != 'b') goto yy25;
+	if (yych != 'b') goto yy28;
 	yych = *++p;
-	if (yych != 'n') goto yy25;
+	if (yych != 'n') goto yy28;
 	yych = *++p;
-	if (yych != 'i') goto yy25;
+	if (yych != 'i') goto yy28;
 	yych = *++p;
-	if (yych != 'n') goto yy25;
+	if (yych != 'n') goto yy28;
 	yych = *++p;
-	if (yych != 'j') goto yy25;
+	if (yych != 'j') goto yy28;
 	yych = *++p;
-	if (yych != 'a') goto yy25;
+	if (yych != 'a') goto yy28;
 	++p;
 	if (yybm[0+(yych = *p)] & 32) {
-		goto yy24;
+		goto yy27;
 	}
 	{ token = SUBNINJA; break; }
-yy34:
+yy37:
 	yych = *++p;
-	if (yych != 'c') goto yy25;
+	if (yych != 'c') goto yy28;
 	yych = *++p;
-	if (yych != 'l') goto yy25;
+	if (yych != 'l') goto yy28;
 	yych = *++p;
-	if (yych != 'u') goto yy25;
+	if (yych != 'u') goto yy28;
 	yych = *++p;
-	if (yych != 'd') goto yy25;
+	if (yych != 'd') goto yy28;
 	yych = *++p;
-	if (yych != 'e') goto yy25;
+	if (yych != 'e') goto yy28;
 	++p;
 	if (yybm[0+(yych = *p)] & 32) {
-		goto yy24;
+		goto yy27;
 	}
 	{ token = INCLUDE;  break; }
-yy41:
+yy44:
 	++p;
 	{ token = PIPE2;    break; }
-yy43:
+yy46:
 	yych = *++p;
-	if (yych != 'f') goto yy25;
+	if (yych != 'f') goto yy28;
 	yych = *++p;
-	if (yych != 'a') goto yy25;
+	if (yych != 'a') goto yy28;
 	yych = *++p;
-	if (yych != 'u') goto yy25;
+	if (yych != 'u') goto yy28;
 	yych = *++p;
-	if (yych != 'l') goto yy25;
+	if (yych != 'l') goto yy28;
 	yych = *++p;
-	if (yych != 't') goto yy25;
+	if (yych != 't') goto yy28;
 	++p;
 	if (yybm[0+(yych = *p)] & 32) {
-		goto yy24;
+		goto yy27;
 	}
 	{ token = DEFAULT;  break; }
-yy50:
+yy53:
 	yych = *++p;
-	if (yych != 'l') goto yy25;
+	if (yych != 'l') goto yy28;
 	yych = *++p;
-	if (yych != 'e') goto yy25;
+	if (yych != 'e') goto yy28;
 	++p;
 	if (yybm[0+(yych = *p)] & 32) {
-		goto yy24;
+		goto yy27;
 	}
 	{ token = RULE;     break; }
-yy54:
+yy57:
 	yych = *++p;
-	if (yych != 'i') goto yy25;
+	if (yych != 'i') goto yy28;
 	yych = *++p;
-	if (yych != 'l') goto yy25;
+	if (yych != 'l') goto yy28;
 	yych = *++p;
-	if (yych != 'd') goto yy25;
+	if (yych != 'd') goto yy28;
 	++p;
 	if (yybm[0+(yych = *p)] & 32) {
-		goto yy24;
+		goto yy27;
 	}
 	{ token = BUILD;    break; }
-yy59:
+yy62:
 	++p;
 	yych = *p;
-yy60:
+yy63:
 	if (yybm[0+yych] & 64) {
-		goto yy59;
+		goto yy62;
 	}
-	if (yych >= 0x01) goto yy62;
+	if (yych >= 0x01) goto yy65;
 	p = q;
 	if (yyaccept <= 0) {
 		goto yy3;
 	} else {
 		goto yy5;
 	}
-yy62:
+yy65:
 	++p;
 	{ continue; }
-yy64:
+yy67:
 	yyaccept = 0;
 	q = ++p;
 	yych = *p;
-yy65:
+yy68:
 	if (yybm[0+yych] & 128) {
-		goto yy64;
+		goto yy67;
 	}
-	if (yych == '\n') goto yy66;
-	if (yych == '#') goto yy59;
+	if (yych == '\n') goto yy69;
+	if (yych == '#') goto yy62;
 	goto yy3;
-yy66:
+yy69:
 	++p;
 	yych = *p;
 	goto yy7;
@@ -441,39 +458,39 @@ void Lexer::EatWhitespace() {
 	};
 	yych = *p;
 	if (yych <= ' ') {
-		if (yych <= 0x00) goto yy73;
-		if (yych <= 0x1F) goto yy75;
+		if (yych <= 0x00) goto yy76;
+		if (yych <= 0x1F) goto yy78;
 	} else {
-		if (yych == '$') goto yy71;
-		goto yy75;
-	}
-	++p;
-	yych = *p;
-	goto yy79;
-yy70:
-	{ continue; }
-yy71:
-	++p;
-	if ((yych = *p) == '\n') goto yy76;
-yy72:
-	{ break; }
-yy73:
-	++p;
-	{ break; }
-yy75:
-	yych = *++p;
-	goto yy72;
-yy76:
-	++p;
-	{ continue; }
-yy78:
-	++p;
-	yych = *p;
-yy79:
-	if (yybm[0+yych] & 128) {
+		if (yych == '$') goto yy74;
 		goto yy78;
 	}
-	goto yy70;
+	++p;
+	yych = *p;
+	goto yy82;
+yy73:
+	{ continue; }
+yy74:
+	++p;
+	if ((yych = *p) == '\n') goto yy79;
+yy75:
+	{ break; }
+yy76:
+	++p;
+	{ break; }
+yy78:
+	yych = *++p;
+	goto yy75;
+yy79:
+	++p;
+	{ continue; }
+yy81:
+	++p;
+	yych = *p;
+yy82:
+	if (yybm[0+yych] & 128) {
+		goto yy81;
+	}
+	goto yy73;
 }
 
   }
@@ -523,40 +540,40 @@ bool Lexer::ReadIdent(string* out) {
 	yych = *p;
 	if (yych <= '@') {
 		if (yych <= '.') {
-			if (yych <= ',') goto yy84;
+			if (yych <= ',') goto yy87;
 		} else {
-			if (yych <= '/') goto yy84;
-			if (yych >= ':') goto yy84;
+			if (yych <= '/') goto yy87;
+			if (yych >= ':') goto yy87;
 		}
 	} else {
 		if (yych <= '_') {
-			if (yych <= 'Z') goto yy82;
-			if (yych <= '^') goto yy84;
+			if (yych <= 'Z') goto yy85;
+			if (yych <= '^') goto yy87;
 		} else {
-			if (yych <= '`') goto yy84;
-			if (yych >= '{') goto yy84;
+			if (yych <= '`') goto yy87;
+			if (yych >= '{') goto yy87;
 		}
 	}
-yy82:
+yy85:
 	++p;
 	yych = *p;
-	goto yy87;
-yy83:
+	goto yy90;
+yy86:
 	{
       out->assign(start, p - start);
       break;
     }
-yy84:
+yy87:
 	++p;
 	{ return false; }
-yy86:
+yy89:
 	++p;
 	yych = *p;
-yy87:
+yy90:
 	if (yybm[0+yych] & 128) {
-		goto yy86;
+		goto yy89;
 	}
-	goto yy83;
+	goto yy86;
 }
 
   }
@@ -609,30 +626,37 @@ bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
 		128, 128, 128, 128, 128, 128, 128, 128, 
 	};
 	yych = *p;
-	if (yych <= '#') {
+	if (yych <= '$') {
 		if (yych <= '\n') {
-			if (yych <= 0x00) goto yy96;
-			if (yych >= '\n') goto yy92;
+			if (yych <= 0x00) goto yy100;
+			if (yych <= '\t') goto yy95;
+			goto yy96;
 		} else {
-			if (yych == ' ') goto yy92;
+			if (yych == ' ') goto yy96;
+			if (yych <= '#') goto yy95;
+			goto yy98;
 		}
 	} else {
-		if (yych <= ':') {
-			if (yych <= '$') goto yy94;
-			if (yych >= ':') goto yy92;
+		if (yych <= '9') {
+			if (yych != '&') goto yy95;
 		} else {
-			if (yych == '|') goto yy92;
+			if (yych <= ':') goto yy96;
+			if (yych == '|') goto yy96;
+			goto yy95;
 		}
 	}
 	++p;
-	yych = *p;
-	goto yy120;
-yy91:
+	if ((yych = *p) == '&') goto yy125;
+	goto yy124;
+yy94:
 	{
       eval->AddText(StringPiece(start, p - start));
       continue;
     }
-yy92:
+yy95:
+	yych = *++p;
+	goto yy124;
+yy96:
 	++p;
 	{
       if (path) {
@@ -645,40 +669,40 @@ yy92:
         continue;
       }
     }
-yy94:
+yy98:
 	++p;
 	if ((yych = *p) <= '/') {
 		if (yych <= ' ') {
-			if (yych == '\n') goto yy109;
-			if (yych <= 0x1F) goto yy98;
-			goto yy100;
+			if (yych == '\n') goto yy113;
+			if (yych <= 0x1F) goto yy102;
+			goto yy104;
 		} else {
 			if (yych <= '$') {
-				if (yych <= '#') goto yy98;
-				goto yy102;
+				if (yych <= '#') goto yy102;
+				goto yy106;
 			} else {
-				if (yych == '-') goto yy104;
-				goto yy98;
+				if (yych == '-') goto yy108;
+				goto yy102;
 			}
 		}
 	} else {
 		if (yych <= '^') {
 			if (yych <= ':') {
-				if (yych <= '9') goto yy104;
-				goto yy106;
+				if (yych <= '9') goto yy108;
+				goto yy110;
 			} else {
-				if (yych <= '@') goto yy98;
-				if (yych <= 'Z') goto yy104;
-				goto yy98;
+				if (yych <= '@') goto yy102;
+				if (yych <= 'Z') goto yy108;
+				goto yy102;
 			}
 		} else {
 			if (yych <= '`') {
-				if (yych <= '_') goto yy104;
-				goto yy98;
+				if (yych <= '_') goto yy108;
+				goto yy102;
 			} else {
-				if (yych <= 'z') goto yy104;
-				if (yych <= '{') goto yy108;
-				goto yy98;
+				if (yych <= 'z') goto yy108;
+				if (yych <= '{') goto yy112;
+				goto yy102;
 			}
 		}
 	}
@@ -686,92 +710,101 @@ yy94:
       last_token_ = start;
       return Error("lexing error", err);
     }
-yy96:
+yy100:
 	++p;
 	{
       last_token_ = start;
       return Error("unexpected EOF", err);
     }
-yy98:
+yy102:
 	++p;
-yy99:
+yy103:
 	{
       last_token_ = start;
       return Error("bad $-escape (literal $ must be written as $$)", err);
     }
-yy100:
+yy104:
 	++p;
 	{
       eval->AddText(StringPiece(" ", 1));
       continue;
     }
-yy102:
+yy106:
 	++p;
 	{
       eval->AddText(StringPiece("$", 1));
       continue;
     }
-yy104:
+yy108:
 	++p;
 	yych = *p;
-	goto yy118;
-yy105:
+	goto yy122;
+yy109:
 	{
       eval->AddSpecial(StringPiece(start + 1, p - start - 1));
       continue;
     }
-yy106:
+yy110:
 	++p;
 	{
       eval->AddText(StringPiece(":", 1));
       continue;
     }
-yy108:
+yy112:
 	yych = *(q = ++p);
 	if (yybm[0+yych] & 32) {
-		goto yy112;
+		goto yy116;
 	}
-	goto yy99;
-yy109:
+	goto yy103;
+yy113:
 	++p;
 	yych = *p;
 	if (yybm[0+yych] & 16) {
-		goto yy109;
+		goto yy113;
 	}
 	{
       continue;
     }
-yy112:
+yy116:
 	++p;
 	yych = *p;
 	if (yybm[0+yych] & 32) {
-		goto yy112;
+		goto yy116;
 	}
-	if (yych == '}') goto yy115;
+	if (yych == '}') goto yy119;
 	p = q;
-	goto yy99;
-yy115:
+	goto yy103;
+yy119:
 	++p;
 	{
       eval->AddSpecial(StringPiece(start + 2, p - start - 3));
       continue;
     }
-yy117:
+yy121:
 	++p;
 	yych = *p;
-yy118:
+yy122:
 	if (yybm[0+yych] & 64) {
-		goto yy117;
+		goto yy121;
 	}
-	goto yy105;
-yy119:
+	goto yy109;
+yy123:
 	++p;
 	yych = *p;
-yy120:
+yy124:
 	if (yybm[0+yych] & 128) {
-		goto yy119;
+		goto yy123;
 	}
-	goto yy91;
+	goto yy94;
+yy125:
+	++p;
+	if (yybm[0+(yych = *p)] & 128) {
+		goto yy123;
+	}
+	{
+      eval->AddSplitter(StringPiece(start, p - start));
+      continue;
+    }
 }
 
   }

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -40,6 +40,7 @@ struct Lexer {
     PIPE2,
     RULE,
     SUBNINJA,
+    SPLITTER,
     TEOF,
   };
 

--- a/src/lexer.in.cc
+++ b/src/lexer.in.cc
@@ -84,6 +84,7 @@ const char* Lexer::TokenName(Token t) {
   case PIPE:     return "'|'";
   case RULE:     return "'rule'";
   case SUBNINJA: return "'subninja'";
+  case SPLITTER: return "splitter";
   case TEOF:     return "eof";
   }
   return NULL;  // not reached
@@ -104,6 +105,7 @@ const char* Lexer::TokenErrorHint(Token t) {
   case PIPE:     return "";
   case RULE:     return "";
   case SUBNINJA: return "";
+  case SPLITTER: return "";
   case TEOF:     return "";
   }
   return "";
@@ -129,6 +131,7 @@ Lexer::Token Lexer::ReadToken() {
     nul = "\000";
     simple_varname = [a-zA-Z0-9_-]+;
     varname = [a-zA-Z0-9_.-]+;
+    splitter = "&&";
 
     [ ]*"#"[^\000\n]*"\n" { continue; }
     [ ]*[\n]   { token = NEWLINE;  break; }
@@ -143,6 +146,7 @@ Lexer::Token Lexer::ReadToken() {
     "include"  { token = INCLUDE;  break; }
     "subninja" { token = SUBNINJA; break; }
     varname    { token = IDENT;    break; }
+    splitter   { token = SPLITTER; break; }
     nul        { token = TEOF;     break; }
     [^]        { token = ERROR;    break; }
     */
@@ -200,6 +204,10 @@ bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
   for (;;) {
     start = p;
     /*!re2c
+    ""splitter"" {
+      eval->AddSplitter(StringPiece(start, p - start));
+      continue;
+    }
     [^$ :\n|\000]+ {
       eval->AddText(StringPiece(start, p - start));
       continue;

--- a/src/parsers.cc
+++ b/src/parsers.cc
@@ -121,6 +121,8 @@ bool ManifestParser::ParseRule(string* err) {
       rule->generator_ = true;
     } else if (key == "restat") {
       rule->restat_ = true;
+    } else if (key == "rspopt") {
+      rule->rspopt_ = value;
     } else {
       // Die on other keyvals for now; revisit if we want to add a
       // scope here.

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 
 #include "util.h"
+#include "disk_interface.h"
 
 namespace {
 
@@ -35,6 +36,11 @@ Subprocess::~Subprocess() {
   // Reap child if forgotten.
   if (child_)
     Finish();
+
+  // cleanup
+  for(size_t i = 0; i < rsp_files_.size(); i++) {
+    RealDiskInterface().RemoveFile(rsp_files_[i]);
+  }
 }
 
 HANDLE Subprocess::SetupPipe(HANDLE ioport) {
@@ -222,3 +228,4 @@ Subprocess* SubprocessSet::NextFinished() {
   finished_.pop();
   return subproc;
 }
+

--- a/src/subprocess.cc
+++ b/src/subprocess.cc
@@ -26,6 +26,7 @@
 #include <sys/wait.h>
 
 #include "util.h"
+#include "disk_interface.h"
 
 Subprocess::Subprocess() : fd_(-1), pid_(-1) {
 }
@@ -35,6 +36,10 @@ Subprocess::~Subprocess() {
   // Reap child if forgotten.
   if (pid_ != -1)
     Finish();
+  // cleanup
+  for(size_t i = 0; i < rsp_files_.size(); i++) {
+    RealDiskInterface().RemoveFile(rsp_files_[i]);
+  }
 }
 
 bool Subprocess::Start(SubprocessSet* set, const string& command) {

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -40,6 +40,8 @@ struct Subprocess {
 
   const string& GetOutput() const;
 
+  vector<string> rsp_files_;
+
  private:
   string buf_;
 

--- a/src/test.cc
+++ b/src/test.cc
@@ -72,10 +72,12 @@ string GetSystemTempDir() {
 
 }  // anonymous namespace
 
-StateTestWithBuiltinRules::StateTestWithBuiltinRules() {
-  AssertParse(&state_,
-"rule cat\n"
-"  command = cat $in > $out\n");
+StateTestWithBuiltinRules::StateTestWithBuiltinRules(bool plain) : plain_(plain) {
+  if (!plain_) {
+    AssertParse(&state_,
+  "rule cat\n"
+  "  command = cat $in > $out\n");
+  }
 }
 
 Node* StateTestWithBuiltinRules::GetNode(const string& path) {

--- a/src/test.h
+++ b/src/test.h
@@ -28,9 +28,10 @@ struct Node;
 /// A base test fixture that includes a State object with a
 /// builtin "cat" rule.
 struct StateTestWithBuiltinRules : public testing::Test {
-  StateTestWithBuiltinRules();
+  StateTestWithBuiltinRules(bool plain = false);
   Node* GetNode(const string& path);
 
+  bool plain_;
   State state_;
 };
 

--- a/src/util.h
+++ b/src/util.h
@@ -50,6 +50,15 @@ int MakeDir(const string& path);
 /// Returns -errno and fills in \a err on error.
 int ReadFile(const string& path, string* contents, string* err);
 
+struct FileInfo {
+  FileInfo() : fd(-1) {}
+  string path;
+  int fd;
+};
+int WriteFile(const FileInfo& info, const string& contents, string* err);
+
+const FileInfo TempFilename(string* err);
+
 /// Mark a file descriptor to not be inherited on exec()s.
 void SetCloseOnExec(int fd);
 


### PR DESCRIPTION
For very long command lines put the arguments into a file.

Each rule can specify where to place the argument file.
On Windows such files are called 'response' files, therefore the abbreviation 'rsp'.
To pass a response file to a command a option must be used which is often '@'.

$rsp indicates the place where to place put the option.
rspopt is a rile-variable which defines the option.

Example:

rule cxx
  command = gcc /Wall $rsp /Wextra $in
  rspopt = @
build out: cxx foo1 foo2 foo3

  -> gcc /Wall @/tmp/ninja_hX7jPD
    with ninja_hX7jPD: /Wextra foo1 foo2 foo3

By default '@' is used after the first token in a command.

Only command chains are supported which use '&&'.
