### PR TITLE
Add a test for empty path in CanonicalizePath().

### DIFF
--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -64,6 +64,9 @@ TEST(CanonicalizePath, EmptyResult) {
   string path;
   string err;
 
+  EXPECT_FALSE(CanonicalizePath(&path, &err));
+  EXPECT_EQ("empty path", err);
+
   path = ".";
   EXPECT_FALSE(CanonicalizePath(&path, &err));
   EXPECT_EQ("path canonicalizes to the empty path", err);


### PR DESCRIPTION
This test covers bug fix introduced by 62e9139740.  However,
reverting this patch does not trigger a test failure.  Maybe, I am
not testing on the right platform (Linux).  Anyway, in all cases
I think this test deserves to be added.
