### PR TITLE
Be more selective about deleting output files when interrupted

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -116,6 +116,9 @@ struct Builder {
   Builder(State* state, const BuildConfig& config);
   ~Builder();
 
+  /// Clean up after interrupted commands by deleting output files.
+  void Cleanup();
+
   Node* AddTarget(const string& name, string* err);
 
   /// Add a target to the build, scanning dependencies.


### PR DESCRIPTION
Specifically, only delete if the file was modified or if the rule uses
a depfile.

Fixes issue #226.
