### PR TITLE
Better status progress line: [unstarted/running/done] 

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -194,7 +194,10 @@ void BuildStatus::PrintStatus(Edge* edge) {
 #endif
   }
 
-  int progress_chars = printf("[%d/%d] ", started_edges_, total_edges_);
+  int running_edges = started_edges_ - finished_edges_;
+  int unstarted_edges = total_edges_ - started_edges_;
+  int progress_chars =
+      printf("[%d/%d/%d] ", unstarted_edges, running_edges, finished_edges_);
 
   if (smart_terminal_ && !force_full_command) {
 #ifndef _WIN32


### PR DESCRIPTION
[Re-issuing https://github.com/martine/ninja/pull/88 because it seems to have gotten cluttered up with unrelated commits]

I've been using this for a few weeks and find it's a nicer dataset than the [started/total] default.
Some of the advantages of it that I like are:
- Explicitly show "currently running" count, to see parallelism easily.
- Rate of LHS running to 0 indicating time-left
- RHS climbing gives me a sense of things getting done / useful work being accomplished.
