### PR TITLE
Mark a phony target with no inputs as outputs-ready

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -96,10 +96,10 @@ bool Edge::RecomputeDirty(State* state, DiskInterface* disk_interface,
       (*i)->MarkDirty();
   }
 
-  // If we're dirty, our outputs are not ready.  (It's possible to be
-  // clean but still have not be ready in the presence of order-only
-  // inputs.)
-  if (dirty)
+  // If we're dirty, our outputs are normally not ready.  (It's possible to be
+  // clean but still not be ready in the presence of order-only inputs.)
+  // But phony edges with no inputs have nothing to do, so are always ready.
+  if (dirty && !(is_phony() && inputs_.empty()))
     outputs_ready_ = false;
 
   return true;


### PR DESCRIPTION
Even if such a target is dirty (i.e. the file does not exist), it
has nothing to do, which makes it safe to mark as outputs-ready.
Without this change, ninja will print no output when rebuilding the
target (or an order-only dependency thereof), instead of reporting
it has "no work to do".
