### PR TITLE
Treat paths of the form "existing-file/something" as non-existent

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -94,7 +94,7 @@ TimeStamp RealDiskInterface::Stat(const string& path) {
 #else
   struct stat st;
   if (stat(path.c_str(), &st) < 0) {
-    if (errno == ENOENT)
+    if (errno == ENOENT || errno == ENOTDIR)
       return 0;
     Error("stat(%s): %s", path.c_str(), strerror(errno));
     return -1;


### PR DESCRIPTION
Some people like to construct phony target names by appending a
"/something" suffix to an existing target "foo".  But if "foo" is an
existing file, stat will report ENOTDIR for this path, causing ninja
to spew errors.  Fix this by treating ENOTDIR in the same way as we
do ENOENT -- as a non-existent path.
