### PR TITLE
Issue #241 - handle depfiles generated by older versions of GCC

### DIFF
--- a/src/depfile_parser.h
+++ b/src/depfile_parser.h
@@ -25,6 +25,6 @@ struct DepfileParser {
   /// pointers within it.
   bool Parse(string* content, string* err);
 
-  StringPiece out_;
+  vector<StringPiece> outs_;
   vector<StringPiece> ins_;
 };

--- a/src/depfile_parser.in.cc
+++ b/src/depfile_parser.in.cc
@@ -31,8 +31,10 @@
 bool DepfileParser::Parse(string* content, string* err) {
   // in: current parser input point.
   // end: end of input.
+  // parsing_targets: whether we are parsing targets or dependencies.
   char* in = &(*content)[0];
   char* end = in + content->size();
+  bool parsing_targets = true;
   while (in < end) {
     // out: current output point (typically same as in, but can fall behind
     // as we de-escape backslashes).
@@ -87,17 +89,20 @@ bool DepfileParser::Parse(string* content, string* err) {
     }
 
     int len = out - filename;
-    if (len > 0 && filename[len - 1] == ':')
+    bool toggle = true;
+    if (len > 0 && filename[len - 1] == ':') {
       len--;  // Strip off trailing colon, if any.
-
-    if (len == 0)
-      continue;
-
-    if (!out_.str_) {
-      out_ = StringPiece(filename, len);
-    } else {
-      ins_.push_back(StringPiece(filename, len));
+      toggle = false;
     }
+
+    if (len) {
+      if (parsing_targets)
+        outs_.push_back(StringPiece(filename, len));
+      else
+        ins_.push_back(StringPiece(filename, len));
+    }
+
+    parsing_targets = parsing_targets && toggle;
   }
   return true;
 }


### PR DESCRIPTION
Older versions of GCC would produce broken depfiles when -MT or -MQ is used
    gcc43 -MT foo.o -MMD -MF foo.o.d -o foo.o -c foo.c
will result in the following depfile
    foo.o foo.o: <dependencies>

Add support to parsing multiple targets and to unify them if needed.
