### PR TITLE
Issue #241 - handle depfiles generated by older versions of GCC

### DIFF
--- a/src/depfile_parser.cc
+++ b/src/depfile_parser.cc
@@ -32,8 +32,10 @@
 bool DepfileParser::Parse(string* content, string* err) {
   // in: current parser input point.
   // end: end of input.
+  // parsing_targets: whether we are parsing targets or dependencies.
   char* in = &(*content)[0];
   char* end = in + content->size();
+  bool parsing_targets = true;
   while (in < end) {
     // out: current output point (typically same as in, but can fall behind
     // as we de-escape backslashes).
@@ -180,16 +182,22 @@ yy13:
     }
 
     int len = out - filename;
-    if (len > 0 && filename[len - 1] == ':')
+    const bool is_target = parsing_targets;
+    if (len > 0 && filename[len - 1] == ':') {
       len--;  // Strip off trailing colon, if any.
+      parsing_targets = false;
+    }
 
     if (len == 0)
       continue;
 
-    if (!out_.str_) {
-      out_ = StringPiece(filename, len);
-    } else {
+    if (!is_target) {
       ins_.push_back(StringPiece(filename, len));
+    } else if (!out_.str_) {
+      out_ = StringPiece(filename, len);
+    } else if (out_ != StringPiece(filename, len)) {
+      *err = "depfile has multiple output paths.";
+      return false;
     }
   }
   return true;

--- a/src/depfile_parser_test.cc
+++ b/src/depfile_parser_test.cc
@@ -102,3 +102,20 @@ TEST_F(DepfileParserTest, Escapes) {
             parser_.out_.AsString());
   ASSERT_EQ(0u, parser_.ins_.size());
 }
+
+TEST_F(DepfileParserTest, UnifyMultupleOutputs) {
+  // check that multiple duplicate targets are properly unified
+  string err;
+  EXPECT_TRUE(Parse("foo foo: x y z", &err));
+  ASSERT_EQ(parser_.out_.AsString(), "foo");
+  ASSERT_EQ(parser_.ins_.size(), 3);
+  EXPECT_EQ("x", parser_.ins_[0].AsString());
+  EXPECT_EQ("y", parser_.ins_[1].AsString());
+  EXPECT_EQ("z", parser_.ins_[2].AsString());
+}
+
+TEST_F(DepfileParserTest, RejectMultipleDifferentOutputs) {
+  // check that multiple different outputs are rejected by the parser
+  string err;
+  EXPECT_FALSE(Parse("foo bar: x y z", &err));
+}


### PR DESCRIPTION
This one supersedes my previous pull request -- implementation is much simpler now, error message should be a bit more clear.

Older versions of GCC would produce broken depfiles when -MT or -MQ is used
    gcc43 -MT foo.o -MMD -MF foo.o.d -o foo.o -c foo.c
will result in the following depfile
    foo.o foo.o: <dependencies>

Parse multiple outputs unifying duplicates and correctly report errors if
they are different.
