### PR TITLE
Fix StatBadPath for Windows 7

### DIFF
--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -61,10 +61,13 @@ TEST_F(DiskInterfaceTest, StatMissingFile) {
 }
 
 TEST_F(DiskInterfaceTest, StatBadPath) {
-  // To test the error code path, use an overlong file name.
-  // Both Windows and Linux appear to object to this.
+#ifdef _WIN32
+  string bad_path("cc:\\foo");
+  EXPECT_EQ(-1, disk_.Stat(bad_path));
+#else
   string too_long_name(512, 'x');
   EXPECT_EQ(-1, disk_.Stat(too_long_name));
+#endif
 }
 
 TEST_F(DiskInterfaceTest, StatExistingFile) {


### PR DESCRIPTION
The StatBadPath test expects both Windows and Linux to reject a
path name with 512 characters. However, it seems that such path
is actually acceptable to Windows 7. This change constructs a
different path name that is invalid on Windows.

Fixes #247
