### PR TITLE
Fix windows build (add #include <io.h>)

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -16,6 +16,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <io.h>
 #endif
 
 #include <errno.h>


### PR DESCRIPTION
This is to fix the windows build broken by #250.
