### PR TITLE
Fix to compile with gtest using -fno-rtti

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -276,6 +276,7 @@ elif platform == 'windows':
     test_libs.extend(['gtest_main.lib', 'gtest.lib'])
 else:
     test_libs.extend(['-lgtest_main', '-lgtest'])
+    test_cflags = cflags + ["-DGTEST_HAS_RTTI=0"]
 
 for name in ['build_log_test',
              'build_test',


### PR DESCRIPTION
Building of ninja_test fails on no Windows platform (e.g. Mac OS X, FreeBSD).
-fno-rtti uses building of ninja, but -fno-rtti don't use building of ninja_test.

A discussion on ninja-build is the origin of this patch.
http://groups.google.com/group/ninja-build/browse_thread/thread/b0c2b1ad6de2d264
