### PR TITLE
fix warning: "comparison between signed and unsigned integer expressions"

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -868,15 +868,15 @@ TEST_F(BuildTest, RspFileSuccess)
   size_t files_removed = fs_.files_removed_.size();
 
   EXPECT_TRUE(builder_.Build(&err));
-  ASSERT_EQ(2, commands_ran_.size()); // cat + cat_rsp
+  ASSERT_EQ(2u, commands_ran_.size()); // cat + cat_rsp
     
   // The RSP file was created
   ASSERT_EQ(files_created + 1, fs_.files_created_.size());
-  ASSERT_EQ(1, fs_.files_created_.count("out2.rsp"));
+  ASSERT_EQ(1u, fs_.files_created_.count("out2.rsp"));
     
   // The RSP file was removed
   ASSERT_EQ(files_removed + 1, fs_.files_removed_.size());
-  ASSERT_EQ(1, fs_.files_removed_.count("out2.rsp"));
+  ASSERT_EQ(1u, fs_.files_removed_.count("out2.rsp"));
 }
 
 // Test that RSP file is created but not removed for commands, which fail
@@ -903,15 +903,15 @@ TEST_F(BuildTest, RspFileFailure) {
 
   EXPECT_FALSE(builder_.Build(&err));
   ASSERT_EQ("subcommand failed", err);
-  ASSERT_EQ(1, commands_ran_.size());
+  ASSERT_EQ(1u, commands_ran_.size());
 
   // The RSP file was created
   ASSERT_EQ(files_created + 1, fs_.files_created_.size());
-  ASSERT_EQ(1, fs_.files_created_.count("out.rsp"));
+  ASSERT_EQ(1u, fs_.files_created_.count("out.rsp"));
 
   // The RSP file was NOT removed
   ASSERT_EQ(files_removed, fs_.files_removed_.size());
-  ASSERT_EQ(0, fs_.files_removed_.count("out.rsp"));
+  ASSERT_EQ(0u, fs_.files_removed_.count("out.rsp"));
 
   // The RSP file contains what it should
   ASSERT_EQ("Another very long command", fs_.files_["out.rsp"].contents);
@@ -939,7 +939,7 @@ TEST_F(BuildWithLogTest, RspFileCmdLineChange) {
 
   // 1. Build for the 1st time (-> populate log)
   EXPECT_TRUE(builder_.Build(&err));
-  ASSERT_EQ(1, commands_ran_.size());
+  ASSERT_EQ(1u, commands_ran_.size());
 
   // 2. Build again (no change)
   commands_ran_.clear();
@@ -960,7 +960,7 @@ TEST_F(BuildWithLogTest, RspFileCmdLineChange) {
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
-  EXPECT_EQ(1, commands_ran_.size());
+  EXPECT_EQ(1u, commands_ran_.size());
 }
 
 TEST_F(BuildTest, InterruptCleanup) {

--- a/src/depfile_parser_test.cc
+++ b/src/depfile_parser_test.cc
@@ -108,7 +108,7 @@ TEST_F(DepfileParserTest, UnifyMultupleOutputs) {
   string err;
   EXPECT_TRUE(Parse("foo foo: x y z", &err));
   ASSERT_EQ(parser_.out_.AsString(), "foo");
-  ASSERT_EQ(parser_.ins_.size(), 3);
+  ASSERT_EQ(parser_.ins_.size(), 3u);
   EXPECT_EQ("x", parser_.ins_[0].AsString());
   EXPECT_EQ("y", parser_.ins_[1].AsString());
   EXPECT_EQ("z", parser_.ins_[2].AsString());

--- a/src/subprocess.cc
+++ b/src/subprocess.cc
@@ -45,7 +45,7 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
 #if !defined(linux)
   // On linux we use ppoll in DoWork(); elsewhere we use pselect and so must
   // avoid overly-large FDs.
-  if (fd_ >= FD_SETSIZE)
+  if (fd_ >= static_cast<int>(FD_SETSIZE))
     Fatal("pipe: %s", strerror(EMFILE));
 #endif  // !linux
   SetCloseOnExec(fd_);


### PR DESCRIPTION
Fix warnings: "comparison between signed and unsigned integer expressions".
