### PR TITLE
Add NOMINMAX macro to fix a compilation error on Win32 

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -65,7 +65,7 @@ if sys.platform.startswith('win32'):
 
 vcdir = os.environ.get('VCINSTALLDIR')
 if vcdir:
-    args = [os.path.join(vcdir, 'bin', 'cl.exe'), '/nologo', '/EHsc']
+    args = [os.path.join(vcdir, 'bin', 'cl.exe'), '/nologo', '/EHsc', '/DNOMINMAX']
 else:
     args = shlex.split(os.environ.get('CXX', 'g++'))
     args.extend(['-Wno-deprecated',

--- a/configure.py
+++ b/configure.py
@@ -104,7 +104,7 @@ else:
 if platform == 'windows':
     cflags = ['/nologo', '/Zi', '/W4', '/WX', '/wd4530', '/wd4100', '/wd4706',
               '/wd4512', '/wd4800', '/wd4702', '/wd4819',
-              '/D_CRT_SECURE_NO_WARNINGS',
+              '/DNOMINMAX', '/D_CRT_SECURE_NO_WARNINGS',
               "/DNINJA_PYTHON=\"%s\"" % (options.with_python,)]
     ldflags = ['/DEBUG', '/libpath:$builddir']
     if not options.debug:


### PR DESCRIPTION
A recent change in ninja.cc introduced a compilation problem for Win32. A NOMINMAX macro is needed to prevent a name collision. 

See
- https://github.com/martine/ninja/commit/866b992459820aa3f6378f26df5b8d3135be98b1
- http://msdn.microsoft.com/en-us/library/windows/desktop/dd941738(v=vs.85).aspx
