### PR TITLE
Explicitly specify target name for gcc depfiles

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -154,7 +154,7 @@ if platform == 'windows':
         description='CXX $out')
 else:
     n.rule('cxx',
-        command='$cxx -MMD -MF $out.d $cflags -c $in -o $out',
+        command='$cxx -MMD -MT $out -MF $out.d $cflags -c $in -o $out',
         depfile='$out.d',
         description='CXX $out')
 n.newline()


### PR DESCRIPTION
Without it depfiles generated by "distcc g++" can't be parsed by ninja
