### PR TITLE
Include unistd.h where needed

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -20,6 +20,7 @@
 #ifdef _WIN32
 #include <windows.h>
 #else
+#include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <sys/termios.h>

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "build.h"
 #include "graph.h"

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -31,6 +31,7 @@
 #include <windows.h>
 #else
 #include <getopt.h>
+#include <unistd.h>
 #endif
 
 #include "browse.h"


### PR DESCRIPTION
GCC 4.7.0 headers no longer include unistd.h from other headers. This patch adds includes to source files that need it.
