### PR TITLE
Fix memory leak in Builder class.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -523,6 +523,8 @@ Builder::Builder(State* state, const BuildConfig& config)
 
 Builder::~Builder() {
   Cleanup();
+  delete status_;
+  status_ = NULL;
 }
 
 void Builder::Cleanup() {

--- a/src/build.h
+++ b/src/build.h
@@ -26,6 +26,7 @@ using namespace std;
 #include "exit_status.h"
 
 struct BuildLog;
+struct BuildStatus;
 struct Edge;
 struct DiskInterface;
 struct Node;
@@ -140,8 +141,8 @@ struct Builder {
   Plan plan_;
   DiskInterface* disk_interface_;
   auto_ptr<CommandRunner> command_runner_;
-  struct BuildStatus* status_;
-  struct BuildLog* log_;
+  BuildStatus* status_;
+  BuildLog* log_;
 
 private:
   // Unimplemented copy ctor and operator= ensure we don't copy the auto_ptr.


### PR DESCRIPTION
This patch makes Builder release its BuildStatus into its destructor, so we
don't leak this resource.

Signed-off-by: Thiago Farina tfarina@chromium.org
