### PR TITLE
Add in "smart" output for cygwin on Windows

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -89,9 +89,9 @@ BuildStatus::BuildStatus(const BuildConfig& config)
 
   if (!smart_terminal_) {
     int length;
-    char term[5];
-    if ((length = GetEnvironmentVariable("TERM", term, 5)) &&
-        (length > 5 || string(term) != "dumb")) {
+    char output_type[6];
+    if ((length = GetEnvironmentVariable("NINJA_OUTPUT", output_type, 6)) &&
+        (length < 6 && string(output_type) == "smart")) {
       console_ = NULL;
       smart_terminal_ = true;
     }


### PR DESCRIPTION
This lets ninja on Windows have the same single-line style output under msys and cygwin as it does on other platforms. Can't check for tty-ness (and cygwin is really bad about answering that question correctly), so the assumption is made that if there's a TERM environment variable and it's not 'dumb' that smart output should be done.
