### PR TITLE
Switch the order of total and avg columns in -d stats output.

### DIFF
--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -102,14 +102,14 @@ void Metrics::Report() {
     width = max((int)(*i)->name.size(), width);
   }
 
-  printf("%-*s\t%-6s\t%9s\t%s\n", width,
-         "metric", "count", "total (ms)" , "avg (us)");
+  printf("%-*s\t%-6s\t%-9s\t%s\n", width,
+         "metric", "count", "avg (us)", "total (ms)");
   for (vector<Metric*>::iterator i = metrics_.begin();
        i != metrics_.end(); ++i) {
     Metric* metric = *i;
     double total = metric->sum / (double)1000;
     double avg = metric->sum / (double)metric->count;
     printf("%-*s\t%-6d\t%-8.1f\t%.1f\n", width, metric->name.c_str(),
-           metric->count, total, avg);
+           metric->count, avg, total);
   }
 }


### PR DESCRIPTION
The current order confuses me every time I use -d stats :-/
