### PR TITLE
removing quotes around -D option when building with mingw in windows

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -117,7 +117,7 @@ else:
               '-fno-rtti',
               '-fno-exceptions',
               '-fvisibility=hidden', '-pipe',
-              "'-DNINJA_PYTHON=\"%s\"'" % (options.with_python,)]
+              "-DNINJA_PYTHON=\"%s\"" % (options.with_python,)]
     if options.debug:
         cflags += ['-D_GLIBCXX_DEBUG', '-D_GLIBCXX_DEBUG_PEDANTIC']
     else:


### PR DESCRIPTION
...e single quotes around -D option.
