### PR TITLE
Fix memory leak in Builder class.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -537,7 +537,7 @@ struct DryRunCommandRunner : public CommandRunner {
 Builder::Builder(State* state, const BuildConfig& config)
     : state_(state), config_(config) {
   disk_interface_ = new RealDiskInterface;
-  status_ = new BuildStatus(config);
+  status_.reset(new BuildStatus(config));
   log_ = state->build_log_;
 }
 

--- a/src/build.h
+++ b/src/build.h
@@ -27,6 +27,7 @@ using namespace std;
 #include "util.h"  // int64_t
 
 struct BuildLog;
+struct BuildStatus;
 struct Edge;
 struct DiskInterface;
 struct Node;
@@ -144,10 +145,10 @@ struct Builder {
   Plan plan_;
   DiskInterface* disk_interface_;
   auto_ptr<CommandRunner> command_runner_;
-  struct BuildStatus* status_;
-  struct BuildLog* log_;
+  auto_ptr<BuildStatus> status_;
+  BuildLog* log_;
 
-private:
+ private:
   // Unimplemented copy ctor and operator= ensure we don't copy the auto_ptr.
   Builder(const Builder &other);        // DO NOT IMPLEMENT
   void operator=(const Builder &other); // DO NOT IMPLEMENT


### PR DESCRIPTION
This patch makes Builder release its BuildStatus into its destructor, so we
don't leak this resource.

Signed-off-by: Thiago Farina tfarina@chromium.org
