### PR TITLE
Don't add `-g` to cflags if --debug wasn't passed

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -111,7 +111,7 @@ if platform == 'windows':
         cflags += ['/Ox', '/DNDEBUG', '/GL']
         ldflags += ['/LTCG', '/OPT:REF', '/OPT:ICF']
 else:
-    cflags = ['-g', '-Wall', '-Wextra',
+    cflags = ['-Wall', '-Wextra',
               '-Wno-deprecated',
               '-Wno-unused-parameter',
               '-fno-rtti',
@@ -119,7 +119,7 @@ else:
               '-fvisibility=hidden', '-pipe',
               "'-DNINJA_PYTHON=\"%s\"'" % (options.with_python,)]
     if options.debug:
-        cflags += ['-D_GLIBCXX_DEBUG', '-D_GLIBCXX_DEBUG_PEDANTIC']
+        cflags += ['-g', '-D_GLIBCXX_DEBUG', '-D_GLIBCXX_DEBUG_PEDANTIC']
     else:
         cflags += ['-O2', '-DNDEBUG']
     ldflags = ['-L$builddir']


### PR DESCRIPTION
I was a bit freaked out when I saw my ninja binary was 1.8MB.

After a bit of investigation, it turns out that `-g` was being added to cflags unconditionally in `configure.py`. This two-line patch makes `-g` be added only if `--debug` is passed on the command line to `configure.py`, which I think is the intended behavior since its description is "enable debugging flags", which would seem to imply that they should otherwise be disabled.

A vanilla build of Ninja now generates a 152K binary.
