### PR TITLE
ninja_syntax.build() returns a list, not a single string.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -246,7 +246,7 @@ n.comment('Main executable is library plus main() function.')
 objs = cxx('ninja')
 ninja = n.build(binary('ninja'), 'link', objs, implicit=ninja_lib,
                 variables=[('libs', libs)])
-if ninja != 'ninja':
+if 'ninja' not in ninja:
   n.build('ninja', 'phony', ninja)
 n.newline()
 all_targets += ninja
@@ -300,7 +300,7 @@ if platform != 'mingw' and platform != 'windows':
 ninja_test = n.build(binary('ninja_test'), 'link', objs, implicit=ninja_lib,
                      variables=[('ldflags', test_ldflags),
                                 ('libs', test_libs)])
-if ninja_test != 'ninja_test':
+if 'ninja_test' not in ninja_test:
   n.build('ninja_test', 'phony', ninja_test)
 n.newline()
 all_targets += ninja_test


### PR DESCRIPTION
Fixes 'multiple rules' warnings on mac/linux.
