### PR TITLE
Add .ninja_log load time to metrics.

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -21,6 +21,7 @@
 
 #include "build.h"
 #include "graph.h"
+#include "metrics.h"
 #include "util.h"
 
 // Implementation details:
@@ -104,6 +105,7 @@ void BuildLog::Close() {
 }
 
 bool BuildLog::Load(const string& path, string* err) {
+  METRIC_RECORD(".ninja_log load");
   FILE* file = fopen(path.c_str(), "r");
   if (!file) {
     if (errno == ENOENT)


### PR DESCRIPTION
On my system, it takes 22% of the empty build time for chrome.

I ran ninja in a profiler today. It showed this function as pretty hot, so it should be in `-d stats` output. Here's how that looks now:

```
tests-MacBook-Pro-2:src test$ time ~/src/ninja/ninja -C out/Release/ chrome -dstats
ninja: Entering directory `out/Release/'
ninja: no work to do.
metric              count   avg (us)    total (ms)
.ninja parse        592     760.3       450.1
canonicalize str    93264   0.3         30.5
canonicalize path   1017405 0.2         209.8
lookup node         1017405 0.1         141.4
.ninja_log load     1       338480.0    338.5
node stat           34936   2.6         91.7
depfile load        8832    72.2        637.9
```
