### PR TITLE
Fix layout width in ninja_syntax.py.

### DIFF
--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -101,7 +101,7 @@ class Writer(object):
     def _line(self, text, indent=0):
         """Write 'text' word-wrapped at self.width characters."""
         leading_space = '  ' * indent
-        while len(text) > self.width:
+        while len(leading_space) + len(text) > self.width:
             # The text is too wide; wrap if possible.
 
             # Find the rightmost space that would obey our width constraint and

--- a/misc/ninja_test.py
+++ b/misc/ninja_test.py
@@ -41,6 +41,18 @@ class TestLineWordWrap(unittest.TestCase):
                                       INDENT + 'y']) + '\n',
                          self.out.getvalue())
 
+    def test_short_words_indented(self):
+        # Test that indent is taking into acount when breaking subsequent lines.
+        # The second line should not be '    to tree', as that's longer than the
+        # test layout width of 8.
+        self.n._line('line_one to tree')
+        self.assertEqual('''\
+line_one $
+    to $
+    tree
+''',
+                         self.out.getvalue())
+
     def test_few_long_words_indented(self):
         # Check wrapping in the presence of indenting.
         self.n._line(' '.join(['x', LONGWORD, 'y']), indent=1)


### PR DESCRIPTION
The last line would sometimes be needlessly longer than the layout
width. One example is line 67 in the build.ninja generated by
ninja's own configure.py: Before this patch, ninja_syntax would
create a 81 character line.
