### PR TITLE
Speed up CanonicalizePath() 11.8% (322ms -> 284ms for chrome/mac empty build).

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -113,28 +113,29 @@ bool CanonicalizePath(char* path, int* len, string* err) {
   }
 
   while (src < end) {
-    const char* sep = (const char*)memchr(src, '/', end - src);
-    if (sep == NULL)
-      sep = end;
-
     if (*src == '.') {
-      if (sep - src == 1) {
+      if (src[1] == '/' || src[1] == '\0') {
         // '.' component; eliminate.
         src += 2;
         continue;
-      } else if (sep - src == 2 && src[1] == '.') {
+      } else if (src[1] == '.' && (src[2] == '/' || src[2] == '\0')) {
         // '..' component.  Back up if possible.
         if (component_count > 0) {
           dst = components[component_count - 1];
           src += 3;
           --component_count;
         } else {
-          while (src <= sep)
-            *dst++ = *src++;
+          *dst++ = *src++;
+          *dst++ = *src++;
+          *dst++ = *src++;
         }
         continue;
       }
     }
+
+    const char* sep = (const char*)memchr(src, '/', end - src);
+    if (sep == NULL)
+      sep = end;
 
     if (sep > src) {
       if (component_count == kMaxPathComponents)

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -58,6 +58,14 @@ TEST(CanonicalizePath, PathSamples) {
   path = "foo/./.";
   EXPECT_TRUE(CanonicalizePath(&path, &err));
   EXPECT_EQ("foo", path);
+
+  path = "foo/bar/..";
+  EXPECT_TRUE(CanonicalizePath(&path, &err));
+  EXPECT_EQ("foo", path);
+
+  path = "foo/.hidden_bar";
+  EXPECT_TRUE(CanonicalizePath(&path, &err));
+  EXPECT_EQ("foo/.hidden_bar", path);
 }
 
 TEST(CanonicalizePath, EmptyResult) {


### PR DESCRIPTION
On Linux, the speedup is 277ms -> 254ms, which is in the same ballpark. 30ms is obviously nothing to get excited about, but I think the code is a bit cleaner too: Now the '.', '..' handling is done at the top of the loop, and the "normal" case is completely below that.
