### PR TITLE
Let configure.py remember its environment for rerunning.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -73,8 +73,9 @@ n.newline()
 n.comment('The arguments passed to configure.py, for rerunning it.')
 n.variable('configure_args', ' '.join(sys.argv[1:]))
 env_keys = set(['CXX', 'AR', 'CFLAGS', 'LDFLAGS'])
-configure_env = [k + '=' + os.environ[k] for k in os.environ if k in env_keys]
-n.variable('configure_env', ' '.join(configure_env))
+configure_env = dict((k, os.environ[k]) for k in os.environ if k in env_keys)
+n.variable('configure_env',
+           ' '.join([k + '=' + configure_env[k] for k in configure_env]))
 n.newline()
 
 objext = '.o'
@@ -101,8 +102,8 @@ if platform == 'windows':
     n.variable('cxx', 'cl')
     n.variable('ar', 'link')
 else:
-    n.variable('cxx', os.environ.get('CXX', 'g++'))
-    n.variable('ar', os.environ.get('AR', 'ar'))
+    n.variable('cxx', configure_env.get('CXX', 'g++'))
+    n.variable('ar', configure_env.get('AR', 'ar'))
 
 if platform == 'windows':
     cflags = ['/nologo', '/Zi', '/W4', '/WX', '/wd4530', '/wd4100', '/wd4706',
@@ -142,11 +143,11 @@ else:
     elif options.profile == 'pprof':
         libs.append('-lprofiler')
 
-if 'CFLAGS' in os.environ:
-    cflags.append(os.environ['CFLAGS'])
+if 'CFLAGS' in configure_env:
+    cflags.append(configure_env['CFLAGS'])
 n.variable('cflags', ' '.join(cflags))
-if 'LDFLAGS' in os.environ:
-    ldflags.append(os.environ['LDFLAGS'])
+if 'LDFLAGS' in configure_env:
+    ldflags.append(configure_env['LDFLAGS'])
 n.variable('ldflags', ' '.join(ldflags))
 n.newline()
 


### PR DESCRIPTION
Without this, CXX is lost when ninja decides that it's time to
regenerate build.ninja, which makes performance tweaking surprising.
