### PR TITLE
Produce colored diagnostics when building ninja with clang.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -78,8 +78,10 @@ n.variable('configure_env',
            ' '.join([k + '=' + configure_env[k] for k in configure_env]))
 n.newline()
 
+CXX = configure_env.get('CXX', 'g++')
 objext = '.o'
 if platform == 'windows':
+    CXX = 'cl'
     objext = '.obj'
 
 def src(filename):
@@ -98,11 +100,10 @@ def binary(name):
     return name
 
 n.variable('builddir', 'build')
+n.variable('cxx', CXX)
 if platform == 'windows':
-    n.variable('cxx', 'cl')
     n.variable('ar', 'link')
 else:
-    n.variable('cxx', configure_env.get('CXX', 'g++'))
     n.variable('ar', configure_env.get('AR', 'ar'))
 
 if platform == 'windows':
@@ -126,6 +127,8 @@ else:
         cflags += ['-D_GLIBCXX_DEBUG', '-D_GLIBCXX_DEBUG_PEDANTIC']
     else:
         cflags += ['-O2', '-DNDEBUG']
+    if 'clang' in os.path.basename(CXX):
+        cflags += ['-fcolor-diagnostics']
     ldflags = ['-L$builddir']
 libs = []
 


### PR DESCRIPTION
This can be disabled by having -fno-color-diagnostics in CFLAGS,
or setting TERM to dumb.
