### PR TITLE
No need to convert log_path to c-string. Two places.

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -739,13 +739,12 @@ reload:
     log_path = build_dir + "/" + kLogPath;
   }
 
-  if (!build_log.Load(log_path.c_str(), &err)) {
-    Error("loading build log %s: %s",
-          log_path.c_str(), err.c_str());
+  if (!build_log.Load(log_path, &err)) {
+    Error("loading build log %s: %s", log_path.c_str(), err.c_str());
     return 1;
   }
 
-  if (!build_log.OpenForWrite(log_path.c_str(), &err)) {
+  if (!build_log.OpenForWrite(log_path, &err)) {
     Error("opening build log: %s", err.c_str());
     return 1;
   }


### PR DESCRIPTION
Signed-off-by: Thiago Farina tfarina@chromium.org
