### PR TITLE
views: Mark single-argument constructors as explicit.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -448,7 +448,7 @@ void Plan::Dump() {
 }
 
 struct RealCommandRunner : public CommandRunner {
-  RealCommandRunner(const BuildConfig& config) : config_(config) {}
+  explicit RealCommandRunner(const BuildConfig& config) : config_(config) {}
   virtual ~RealCommandRunner() {}
   virtual bool CanRunMore();
   virtual bool StartCommand(Edge* edge);

--- a/src/build.h
+++ b/src/build.h
@@ -155,7 +155,7 @@ private:
 
 /// Tracks the status of a build: completion fraction, printing updates.
 struct BuildStatus {
-  BuildStatus(const BuildConfig& config);
+  explicit BuildStatus(const BuildConfig& config);
   void PlanHasTotalEdges(int total);
   void BuildEdgeStarted(Edge* edge);
   void BuildEdgeFinished(Edge* edge, bool success, const string& output,

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -177,7 +177,7 @@ bool Edge::AllInputsReady() const {
 
 /// An Env for an Edge, providing $in and $out.
 struct EdgeEnv : public Env {
-  EdgeEnv(Edge* edge) : edge_(edge) {}
+  explicit EdgeEnv(Edge* edge) : edge_(edge) {}
   virtual string LookupVariable(const string& var);
 
   /// Given a span of Nodes, construct a list of paths suitable for a command

--- a/src/graph.h
+++ b/src/graph.h
@@ -28,8 +28,11 @@ struct Edge;
 /// Information about a node in the dependency graph: the file, whether
 /// it's dirty, mtime, etc.
 struct Node {
-  Node(const string& path) : path_(path), mtime_(-1), dirty_(false),
-                             in_edge_(NULL) {}
+  explicit Node(const string& path)
+      : path_(path),
+        mtime_(-1),
+        dirty_(false),
+        in_edge_(NULL) {}
 
   /// Return true if the file exists (mtime_ got a value).
   bool Stat(DiskInterface* disk_interface);
@@ -97,7 +100,8 @@ private:
 
 /// An invokable build command and associated metadata (description, etc.).
 struct Rule {
-  Rule(const string& name) : name_(name), generator_(false), restat_(false) { }
+  explicit Rule(const string& name)
+      : name_(name), generator_(false), restat_(false) {}
 
   const string& name() const { return name_; }
 


### PR DESCRIPTION
This was reported by cpplint as:

python ~/depot_tools/cpplint.py 2>&1 | grep -v "Done processing" | grep explicit

Signed-off-by: Thiago Farina tfarina@chromium.org
