### PR TITLE
Don't write ninja log header to log on every build on Windows.

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -66,6 +66,10 @@ bool BuildLog::OpenForWrite(const string& path, string* err) {
   setvbuf(log_file_, NULL, _IOLBF, BUFSIZ);
   SetCloseOnExec(fileno(log_file_));
 
+  // Opening a file in append mode doesn't set the file pointer to the file's
+  // end on Windows. Do that explicitly.
+  fseek(log_file_, 0, SEEK_END);
+
   if (ftell(log_file_) == 0) {
     if (fprintf(log_file_, kFileSignature, kCurrentVersion) < 0) {
       *err = strerror(errno);


### PR DESCRIPTION
Problem discovery, explanation, and solution proposal all by @sgraham , I just typed it up.

The included test case fails without the source change on windows, due to the log file containing two "# ninja log v4\n" lines.
