### PR TITLE
Strip leading whitespace from commands on Windows.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -74,8 +74,9 @@ n.comment('The arguments passed to configure.py, for rerunning it.')
 n.variable('configure_args', ' '.join(sys.argv[1:]))
 env_keys = set(['CXX', 'AR', 'CFLAGS', 'LDFLAGS'])
 configure_env = dict((k, os.environ[k]) for k in os.environ if k in env_keys)
-n.variable('configure_env',
-           ' '.join([k + '=' + configure_env[k] for k in configure_env]))
+if configure_env:
+    config_str = ' '.join([k + '=' + configure_env[k] for k in configure_env])
+    n.variable('configure_env', config_str + '$ ')
 n.newline()
 
 CXX = configure_env.get('CXX', 'g++')
@@ -362,7 +363,7 @@ n.newline()
 if host != 'mingw':
     n.comment('Regenerate build files if build script changes.')
     n.rule('configure',
-           command='$configure_env %s configure.py $configure_args' %
+           command='${configure_env}%s configure.py $configure_args' %
                options.with_python,
            generator=True)
     n.build('build.ninja', 'configure',


### PR DESCRIPTION
On Posix, this is done by the shell, so this makes ninja's
behavior on Windows more consistent. This unbreaks auto-execution
of configure.py on Windows, which is done by this rule:

rule configure
  command = $configure_env python.exe configure.py $configure_args
  generator = 1

On Windows, |configure_env| is usually empty, and the leading space
currently makes CreateProcessA fail.
