### PR TITLE
pass subprocesses handle to nul device rather than null handle

### DIFF
--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -1,4 +1,4 @@
-// Copyright 2011 Google Inc. All Rights Reserved.
+// Copyright 2012 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,15 +80,24 @@ HANDLE Subprocess::SetupPipe(HANDLE ioport) {
 bool Subprocess::Start(SubprocessSet* set, const string& command) {
   HANDLE child_pipe = SetupPipe(set->ioport_);
 
+  SECURITY_ATTRIBUTES security_attributes;
+  memset(&security_attributes, 0, sizeof(SECURITY_ATTRIBUTES));
+  security_attributes.nLength = sizeof(SECURITY_ATTRIBUTES);
+  security_attributes.bInheritHandle = TRUE;
+  // Must be inheritable so subprocesses can dup to children.
+  HANDLE nul = CreateFile("NUL", GENERIC_READ,
+          FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+          &security_attributes, OPEN_EXISTING, 0, NULL);
+  if (nul == INVALID_HANDLE_VALUE)
+    Fatal("couldn't open nul");
+
   STARTUPINFOA startup_info;
   memset(&startup_info, 0, sizeof(startup_info));
   startup_info.cb = sizeof(STARTUPINFO);
   startup_info.dwFlags = STARTF_USESTDHANDLES;
+  startup_info.hStdInput = nul;
   startup_info.hStdOutput = child_pipe;
-  // TODO: what does this hook up stdin to?
-  startup_info.hStdInput  = NULL;
-  // TODO: is it ok to reuse pipe like this?
-  startup_info.hStdError  = child_pipe;
+  startup_info.hStdError = child_pipe;
 
   PROCESS_INFORMATION process_info;
   memset(&process_info, 0, sizeof(process_info));
@@ -104,6 +113,7 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
       if (child_pipe)
         CloseHandle(child_pipe);
       CloseHandle(pipe_);
+      CloseHandle(nul);
       pipe_ = NULL;
       // child_ is already NULL;
       buf_ = "CreateProcess failed: The system cannot find the file specified.\n";
@@ -116,6 +126,7 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
   // Close pipe channel only used by the child.
   if (child_pipe)
     CloseHandle(child_pipe);
+  CloseHandle(nul);
 
   CloseHandle(process_info.hThread);
   child_ = process_info.hProcess;


### PR DESCRIPTION
If the subprocess tries to manipulate stdin when it's NULL, it can cause strange errors, so instead pass a valid file handle to the NUL device.
