### PR TITLE
Speed up build log reading (0.5s on Win, 0.1s on Mac, 30ms on Linux)

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -113,24 +113,52 @@ void BuildLog::Close() {
 
 class LineReader {
  public:
-  explicit LineReader(FILE* file) : file_(file) {}
+  explicit LineReader(FILE* file)
+    : file_(file), buf_end_(buf_), line_start_(buf_), line_end_(NULL) {}
 
   // Reads a \n-terminated line from the file passed to the constructor.
   // On return, *line_start points to the beginning of the next line, and
   // *line_end points to the \n at the end of the line. If no newline is seen
   // in a fixed buffer size, *line_end is set to NULL. Returns false on EOF.
   bool ReadLine(char** line_start, char** line_end) {
-    if (!fgets(buf_, sizeof(buf_), file_))
-      return false;
+    if (line_start_ >= buf_end_ || !line_end_) {
+      // Buffer empty, refill.
+      size_t size_read = fread(buf_, 1, sizeof(buf_), file_);
+      if (!size_read)
+        return false;
+      line_start_ = buf_;
+      buf_end_ = buf_ + size_read;
+    } else {
+      // Advance to next line in buffer.
+      line_start_ = line_end_ + 1;
+    }
 
-    *line_start = buf_;
-    *line_end = strchr(buf_, '\n');
+    line_end_ = (char*)memchr(line_start_, '\n', buf_end_ - line_start_);
+    if (!line_end_) {
+      // No newline. Move rest of data to start of buffer, fill rest.
+      size_t already_consumed = line_start_ - buf_;
+      size_t size_rest = (buf_end_ - buf_) - already_consumed;
+      memmove(buf_, line_start_, size_rest);
+
+      size_t read = fread(buf_ + size_rest, 1, sizeof(buf_) - size_rest, file_);
+      buf_end_ = buf_ + size_rest + read;
+      line_start_ = buf_;
+      line_end_ = (char*)memchr(line_start_, '\n', buf_end_ - line_start_);
+    }
+
+    *line_start = line_start_;
+    *line_end = line_end_;
     return true;
   }
 
  private:
   FILE* file_;
   char buf_[256 << 10];
+  char* buf_end_;  // Points one past the last valid byte in |buf_|.
+
+  char* line_start_;
+  // Points at the next \n in buf_ after line_start, or NULL.
+  char* line_end_;
 };
 
 bool BuildLog::Load(const string& path, string* err) {


### PR DESCRIPTION
See the commit log on the second commit for timing details.

I tried several other approaches to make build log loading faster, but this approach looks the most understandable to me. It also has the potential for another .1s speedup on Mac.

https://github.com/nico/ninja/compare/speedup2 is how this change looks if done inline without the extra class (that patch is still missing the s/strstr/memchr/ – else the tests in my other pull request will fail – so that diff looks a bit _too_ small), but I find the code easier to understand with the extra class.

The Linux / Mac speedup is directly visible when doing an empty chrome build. I didn't manage to test on Windows, because that needs all kinds of stuff from Scott's branch apparently.
