### PR TITLE
Use subprocess.call for Python 2.4 compatibility

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -27,10 +27,9 @@ parser.add_option('--verbose', action='store_true',
 (options, conf_args) = parser.parse_args()
 
 def run(*args, **kwargs):
-    try:
-        subprocess.check_call(*args, **kwargs)
-    except subprocess.CalledProcessError, e:
-        sys.exit(e.returncode)
+    returncode = subprocess.call(*args, **kwargs)
+    if returncode != 0:
+        sys.exit(returncode)
 
 # Compute system-specific CFLAGS/LDFLAGS as used in both in the below
 # g++ call as well as in the later configure.py.


### PR DESCRIPTION
`subprocess.check_call` is only available in Python 2.5 and later, so `bootstrap.py` doesn't work with Python 2.4. Thankfully, it's easy to use `subprocess.call` instead.

(Thanks to Andreas Mohr, who reported this issue to me.)
