### PR TITLE
Make $in in response files be \n separated

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -711,7 +711,7 @@ bool Builder::StartEdge(Edge* edge, string* err) {
   // Create response file, if needed
   // XXX: this may also block; do we care?
   if (edge->HasRspFile()) {
-    if (!disk_interface_->WriteFile(edge->GetRspFile(), edge->GetRspFileContent()))
+    if (!disk_interface_->WriteFile(edge->GetRspFile(), edge->GetRspFileContent(true)))
       return false;
   }
 

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -14,12 +14,12 @@
 
 #include "eval_env.h"
 
-string BindingEnv::LookupVariable(const string& var) {
+string BindingEnv::LookupVariable(const string& var, bool for_rspfile) {
   map<string, string>::iterator i = bindings_.find(var);
   if (i != bindings_.end())
     return i->second;
   if (parent_)
-    return parent_->LookupVariable(var);
+    return parent_->LookupVariable(var, for_rspfile);
   return "";
 }
 
@@ -27,13 +27,13 @@ void BindingEnv::AddBinding(const string& key, const string& val) {
   bindings_[key] = val;
 }
 
-string EvalString::Evaluate(Env* env) const {
+string EvalString::Evaluate(Env* env, bool for_rspfile) const {
   string result;
   for (TokenList::const_iterator i = parsed_.begin(); i != parsed_.end(); ++i) {
     if (i->second == RAW)
       result.append(i->first);
     else
-      result.append(env->LookupVariable(i->first));
+      result.append(env->LookupVariable(i->first, for_rspfile));
   }
   return result;
 }

--- a/src/eval_env.h
+++ b/src/eval_env.h
@@ -25,7 +25,7 @@ using namespace std;
 /// An interface for a scope for variable (e.g. "$foo") lookups.
 struct Env {
   virtual ~Env() {}
-  virtual string LookupVariable(const string& var) = 0;
+  virtual string LookupVariable(const string& var, bool for_rspfile) = 0;
 };
 
 /// An Env which contains a mapping of variables to values
@@ -34,7 +34,7 @@ struct BindingEnv : public Env {
   BindingEnv() : parent_(NULL) {}
   explicit BindingEnv(Env* parent) : parent_(parent) {}
   virtual ~BindingEnv() {}
-  virtual string LookupVariable(const string& var);
+  virtual string LookupVariable(const string& var, bool for_rspfile);
   void AddBinding(const string& key, const string& val);
 
 private:
@@ -45,7 +45,7 @@ private:
 /// A tokenized string that contains variable references.
 /// Can be evaluated relative to an Env.
 struct EvalString {
-  string Evaluate(Env* env) const;
+  string Evaluate(Env* env, bool for_rspfile=false) const;
 
   void Clear() { parsed_.clear(); }
   bool empty() const { return parsed_.empty(); }

--- a/src/graph.h
+++ b/src/graph.h
@@ -169,7 +169,7 @@ struct Edge {
   string GetRspFile();
 
   /// Get the contents of the response file
-  string GetRspFileContent();
+  string GetRspFileContent(bool with_newlines);
 
   bool LoadDepFile(State* state, DiskInterface* disk_interface, string* err);
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -735,7 +735,7 @@ reload:
   build_log.SetConfig(&globals.config);
   globals.state->build_log_ = &build_log;
 
-  const string build_dir = globals.state->bindings_.LookupVariable("builddir");
+  const string build_dir = globals.state->bindings_.LookupVariable("builddir", false);
   const char* kLogPath = ".ninja_log";
   string log_path = kLogPath;
   if (!build_dir.empty()) {

--- a/src/parsers_test.cc
+++ b/src/parsers_test.cc
@@ -94,7 +94,7 @@ TEST_F(ParserTest, IgnoreIndentedBlankLines) {
 "variable=1\n"));
 
   // the variable must be in the top level environment
-  EXPECT_EQ("1", state.bindings_.LookupVariable("variable"));
+  EXPECT_EQ("1", state.bindings_.LookupVariable("variable", false));
 }
 
 TEST_F(ParserTest, ResponseFiles) {
@@ -133,7 +133,7 @@ TEST_F(ParserTest, Variables) {
   Edge* edge = state.edges_[0];
   EXPECT_EQ("ld one-letter-test -pthread -under -o a b c",
             edge->EvaluateCommand());
-  EXPECT_EQ("1/2", state.bindings_.LookupVariable("nested2"));
+  EXPECT_EQ("1/2", state.bindings_.LookupVariable("nested2", false));
 
   edge = state.edges_[1];
   EXPECT_EQ("ld one-letter-test 1/2/3 -under -o supernested x",
@@ -177,15 +177,15 @@ TEST_F(ParserTest, Backslash) {
 "foo = bar\\baz\n"
 "foo2 = bar\\ baz\n"
 ));
-  EXPECT_EQ("bar\\baz", state.bindings_.LookupVariable("foo"));
-  EXPECT_EQ("bar\\ baz", state.bindings_.LookupVariable("foo2"));
+  EXPECT_EQ("bar\\baz", state.bindings_.LookupVariable("foo", false));
+  EXPECT_EQ("bar\\ baz", state.bindings_.LookupVariable("foo2", false));
 }
 
 TEST_F(ParserTest, Comment) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(
 "# this is a comment\n"
 "foo = not # a comment\n"));
-  EXPECT_EQ("not # a comment", state.bindings_.LookupVariable("foo"));
+  EXPECT_EQ("not # a comment", state.bindings_.LookupVariable("foo", false));
 }
 
 TEST_F(ParserTest, Dollars) {
@@ -196,7 +196,7 @@ TEST_F(ParserTest, Dollars) {
 "x = $$dollar\n"
 "build $x: foo y\n"
 ));
-  EXPECT_EQ("$dollar", state.bindings_.LookupVariable("x"));
+  EXPECT_EQ("$dollar", state.bindings_.LookupVariable("x", false));
   EXPECT_EQ("$dollarbar$baz$blah", state.edges_[0]->EvaluateCommand());
 }
 
@@ -604,7 +604,7 @@ TEST_F(ParserTest, Include) {
 
   ASSERT_EQ(1u, files_read_.size());
   EXPECT_EQ("include.ninja", files_read_[0]);
-  EXPECT_EQ("inner", state.bindings_.LookupVariable("var"));
+  EXPECT_EQ("inner", state.bindings_.LookupVariable("var", false));
 }
 
 TEST_F(ParserTest, Implicit) {


### PR DESCRIPTION
Primarily for Visual Studio toolchain: link.exe does not accept command lines
longer than 131072 characters, so when linking a large number of object files,
if they're all on one line the link fails.
