### PR TITLE
No need to write 'struct' before type name when declaraing variables in ...

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -27,8 +27,9 @@ using namespace std;
 #include "util.h"  // int64_t
 
 struct BuildLog;
-struct Edge;
+struct BuildStatus;
 struct DiskInterface;
+struct Edge;
 struct Node;
 struct State;
 
@@ -144,10 +145,10 @@ struct Builder {
   Plan plan_;
   DiskInterface* disk_interface_;
   auto_ptr<CommandRunner> command_runner_;
-  struct BuildStatus* status_;
-  struct BuildLog* log_;
+  BuildStatus* status_;
+  BuildLog* log_;
 
-private:
+ private:
   // Unimplemented copy ctor and operator= ensure we don't copy the auto_ptr.
   Builder(const Builder &other);        // DO NOT IMPLEMENT
   void operator=(const Builder &other); // DO NOT IMPLEMENT

--- a/src/state.h
+++ b/src/state.h
@@ -72,7 +72,7 @@ struct State {
 
   BindingEnv bindings_;
   vector<Node*> defaults_;
-  struct BuildLog* build_log_;
+  BuildLog* build_log_;
 };
 
 #endif  // NINJA_STATE_H_


### PR DESCRIPTION
...C++.

Signed-off-by: Thiago Farina tfarina@chromium.org
