### PR TITLE
bootstrap: chdir to bootstrap's directory

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -21,6 +21,8 @@ import errno
 import shlex
 import subprocess
 
+os.chdir(os.path.dirname(sys.argv[0]))
+
 parser = OptionParser()
 parser.add_option('--verbose', action='store_true',
                   help='enable verbose build',)


### PR DESCRIPTION
When integrating ninja into luvit I naively tried calling:

```
./tools/ninja/bootstrap.py
```

This broke because bootstrap expects you to be in the ninja directory
when you call it. This patch makes it possible to run bootstrap.py like
above and have it work.
