### PR TITLE
bootstrap: fix path magic on windows

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -21,7 +21,7 @@ import errno
 import shlex
 import subprocess
 
-os.chdir(os.path.dirname(sys.argv[0]))
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 parser = OptionParser()
 parser.add_option('--verbose', action='store_true',


### PR DESCRIPTION
It was reported that argv[0] doesn't get set on windows. Some research
showed that using abspath(**filename**) should accomplish this.
