### PR TITLE
Prevent multiple definition link error

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -53,6 +53,8 @@ sources = []
 for src in glob.glob('src/*.cc'):
     if src.endswith('test.cc') or src.endswith('.in.cc'):
         continue
+    if src.endswith('bench.cc'):
+        continue
 
     filename = os.path.basename(src)
     if filename == 'browse.cc':  # Depends on generated header.


### PR DESCRIPTION
Globbed inclusion of `src/hash_collision_bench.cc` cause link errors on Linux and Windows (mingw/mingw-w64) due to multiple main definitions
