### PR TITLE
Use higher-resolution timestamps for stat() to remove the need for sleep in tests.

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -1,4 +1,4 @@
-// Copyright 2011 Google Inc. All Rights Reserved.
+// Copyright 2012 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,11 +58,11 @@ uint64_t MurmurHash64A(const void* key, int len) {
   const uint64_t * end = data + (len/8);
   while(data != end) {
     uint64_t k = *data++;
-    k *= m; 
-    k ^= k >> r; 
-    k *= m; 
+    k *= m;
+    k ^= k >> r;
+    k *= m;
     h ^= k;
-    h *= m; 
+    h *= m;
   }
   const unsigned char* data2 = (const unsigned char*)data;
   switch(len & 7)
@@ -80,7 +80,7 @@ uint64_t MurmurHash64A(const void* key, int len) {
   h *= m;
   h ^= h >> r;
   return h;
-} 
+}
 #undef BIG_CONSTANT
 
 
@@ -332,7 +332,7 @@ BuildLog::LogEntry* BuildLog::LookupByOutput(const string& path) {
 }
 
 void BuildLog::WriteEntry(FILE* f, const LogEntry& entry) {
-  fprintf(f, "%d\t%d\t%d\t%s\t%" PRIx64 "\n",
+  fprintf(f, "%d\t%d\t%ld\t%s\t%" PRIx64 "\n",
           entry.start_time, entry.end_time, entry.restat_mtime,
           entry.output.c_str(), entry.command_hash);
 }

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -1,4 +1,4 @@
-// Copyright 2011 Google Inc. All Rights Reserved.
+// Copyright 2012 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ TimeStamp RealDiskInterface::Stat(const string& path) {
     Error("stat(%s): %s", path.c_str(), strerror(errno));
     return -1;
   }
-  return st.st_mtime;
+  return st.st_mtime * 1e9 + st.st_mtim.tv_nsec;
 #endif
 }
 

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -1,4 +1,4 @@
-// Copyright 2011 Google Inc. All Rights Reserved.
+// Copyright 2012 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ bool Edge::RecomputeOutputDirty(BuildLog* build_log,
         return true;
       }
     } else {
-      EXPLAIN("output %s older than most recent input %s (%d vs %d)",
+      EXPLAIN("output %s older than most recent input %s (%ld vs %ld)",
           output->path().c_str(),
           most_recent_node ? most_recent_node->path().c_str() : "",
           output->mtime(), most_recent_input);
@@ -230,7 +230,7 @@ string EdgeEnv::MakePathList(vector<Node*>::iterator begin,
 string Edge::EvaluateCommand(bool incl_rsp_file) {
   EdgeEnv env(this);
   string command = rule_->command().Evaluate(&env);
-  if (incl_rsp_file && HasRspFile()) 
+  if (incl_rsp_file && HasRspFile())
     command += ";rspfile=" + GetRspFileContent();
   return command;
 }

--- a/src/timestamp.h
+++ b/src/timestamp.h
@@ -1,4 +1,4 @@
-// Copyright 2011 Google Inc. All Rights Reserved.
+// Copyright 2012 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +15,12 @@
 #ifndef NINJA_TIMESTAMP_H_
 #define NINJA_TIMESTAMP_H_
 
+#include "util.h"  // For int64_t.
+
 // When considering file modification times we only care to compare
 // them against one another -- we never convert them to an absolute
-// real time.  On POSIX we use time_t (seconds since epoch) and on
-// Windows we use a different value.  Both fit in an int.
-typedef int TimeStamp;
+// real time.  On POSIX we use nanoseconds since epoch (with 1s resolution where
+// nsec isn't available) and on Windows we use a different value.
+typedef int64_t TimeStamp;
 
 #endif  // NINJA_TIMESTAMP_H_


### PR DESCRIPTION
For an example of the kind of sleep that this can obviate, see line 35 of:
https://chromiumcodereview.appspot.com/10578031/diff/14004/test/ninja/solibs_avoid_relinking/gyptest-solibs-avoid-relinking.py
