### PR TITLE
Avoid duplication of output edges when building graph

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -335,3 +335,9 @@ void Edge::Dump() {
 bool Edge::is_phony() const {
   return rule_ == &State::kPhonyRule;
 }
+
+void Node::AddOutEdge(Edge* edge) {
+    if (find(out_edges_.begin(), out_edges_.end(), edge) != out_edges_.end())
+        return;
+    out_edges_.push_back(edge);
+}

--- a/src/graph.h
+++ b/src/graph.h
@@ -75,7 +75,7 @@ struct Node {
   void set_in_edge(Edge* edge) { in_edge_ = edge; }
 
   const vector<Edge*>& out_edges() const { return out_edges_; }
-  void AddOutEdge(Edge* edge) { out_edges_.push_back(edge); }
+  void AddOutEdge(Edge* edge);
 
 private:
   string path_;


### PR DESCRIPTION
Typically, this is not a big issue. But it becomes bigger when
 reloading updated dep files, as edges are duplicated on each reload.

This patch only handles output edges.
