### PR TITLE
Improving Edge::Dump, introducing Node::Dump

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -320,18 +320,37 @@ bool Edge::LoadDepFile(State* state, DiskInterface* disk_interface,
   return true;
 }
 
-void Edge::Dump() {
-  printf("[ ");
-  for (vector<Node*>::iterator i = inputs_.begin(); i != inputs_.end(); ++i) {
+void Edge::Dump(const char* prefix) const {
+  printf("%s[ ", prefix);
+  for (vector<Node*>::const_iterator i = inputs_.begin();
+       i != inputs_.end() && *i != NULL; ++i) {
     printf("%s ", (*i)->path().c_str());
   }
   printf("--%s-> ", rule_->name().c_str());
-  for (vector<Node*>::iterator i = outputs_.begin(); i != outputs_.end(); ++i) {
+  for (vector<Node*>::const_iterator i = outputs_.begin();
+       i != outputs_.end() && *i != NULL; ++i) {
     printf("%s ", (*i)->path().c_str());
   }
-  printf("]\n");
+  printf("] 0x%p\n", this);
 }
 
 bool Edge::is_phony() const {
   return rule_ == &State::kPhonyRule;
+}
+
+void Node::Dump(const char* prefix) const {
+    printf("%s <%s 0x%p> mtime: %d%s, (:%s), ",
+           prefix, path().c_str(), this,
+           mtime(), mtime()?"":" (:missing)",
+           dirty()?" dirty":" clean");
+    if (in_edge()) {
+        in_edge()->Dump("in-edge: ");
+    }else{
+        printf("no in-edge\n");
+    }
+    printf(" out edges:\n");
+    for (vector<Edge*>::const_iterator e = out_edges().begin();
+         e != out_edges().end() && *e != NULL; ++e) {
+        (*e)->Dump(" +- ");
+    }
 }

--- a/src/graph.h
+++ b/src/graph.h
@@ -77,6 +77,8 @@ struct Node {
   const vector<Edge*>& out_edges() const { return out_edges_; }
   void AddOutEdge(Edge* edge) { out_edges_.push_back(edge); }
 
+  void Dump(const char* prefix="") const;
+
 private:
   string path_;
   /// Possible values of mtime_:
@@ -173,7 +175,7 @@ struct Edge {
 
   bool LoadDepFile(State* state, DiskInterface* disk_interface, string* err);
 
-  void Dump();
+  void Dump(const char* prefix="") const;
 
   const Rule* rule_;
   vector<Node*> inputs_;


### PR DESCRIPTION
- Edge::Dump could crash if called while inputs_ is being extended
- Node::Dump prints Node attributes, in-edge and lists of out-edges
- Dump functions now accept "prefix" parameter, printed along with the object
  for easier orientation. For example, edge->Dump("Re-reading deps files").
