### PR TITLE
Delete edge after done with it.

### DIFF
--- a/src/state_test.cc
+++ b/src/state_test.cc
@@ -36,6 +36,8 @@ TEST(State, Basic) {
 
   EXPECT_EQ("cat in1 in2 > out", edge->EvaluateCommand());
 
+  delete edge;
+
   EXPECT_FALSE(state.GetNode("in1")->dirty());
   EXPECT_FALSE(state.GetNode("in2")->dirty());
   EXPECT_FALSE(state.GetNode("out")->dirty());


### PR DESCRIPTION
Looks like State does not own the Edge, but it should?

TEST=ninja_test --gtest_filter=State*

Signed-off-by: Thiago Farina tfarina@chromium.org
