### PR TITLE
Fix missing POLLRDHUP constant on older systems.

### DIFF
--- a/src/subprocess.cc
+++ b/src/subprocess.cc
@@ -25,9 +25,9 @@
 #include <string.h>
 #include <sys/wait.h>
 
-// Older versions of won't find this in <poll.h>.  Some versions keep it in
-// <asm-generic/poll.h>, though attempting to include that will redefine the
-// pollfd structure.
+// Older versions of glibc (like 2.4) won't find this in <poll.h>.  glibc
+// 2.4 keeps it in <asm-generic/poll.h>, though attempting to include that
+// will redefine the pollfd structure.
 #ifndef POLLRDHUP
 #define POLLRDHUP 0x2000
 #endif


### PR DESCRIPTION
Attempting to compile with g++ 4.1.2 failed because the POLLRDHUP constant was not defined when <poll.h> is included.

I'm not actually convinced this is the best way to solve the problem, but it also doesn't seem any worse than anything else I tried.  For the record, I really wish we could use a later version of g++ (and a later linux kernel), but the current situation is kind of constrained, and our build system desperately needs something faster than make.
