### PR TITLE
Add missing include of <sys/resouce.h>

### DIFF
--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -16,6 +16,11 @@
 
 #include "test.h"
 
+#ifdef linux
+// required by SubprocessTest
+#include <sys/resource.h>
+#endif
+
 namespace {
 
 #ifdef _WIN32


### PR DESCRIPTION
subprocess_test.cc fails to build on linux due to missing include file
