### PR TITLE
Don't print 'Entering directory' when running tools.

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -707,7 +707,10 @@ int main(int argc, char** argv) {
     // The formatting of this string, complete with funny quotes, is
     // so Emacs can properly identify that the cwd has changed for
     // subsequent commands.
-    printf("ninja: Entering directory `%s'\n", working_dir);
+    // Don't print this if a tool is being used, so that tool output
+    // can be piped into a file without this string showing up.
+    if (tool == "")
+      printf("ninja: Entering directory `%s'\n", working_dir);
 #ifdef _WIN32
     if (_chdir(working_dir) < 0) {
 #else


### PR DESCRIPTION
The note is useful to tell editors how to resolve error messages to files.

For tools, it's not useful, and makes it hard to pipe the output of a tool into a file.
