### PR TITLE
Disable SubprocessTest.TestWithLots on OS X.

### DIFF
--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -149,7 +149,9 @@ TEST_F(SubprocessTest, SetWithMulti) {
   }
 }
 
-#ifndef _WIN32
+// OS X's process limit is less than 1025 by default
+// (|sysctl kern.maxprocperuid| is 709 on 10.7 and 10.8 and less prior to that).
+#ifdef linux
 TEST_F(SubprocessTest, SetWithLots) {
   // Arbitrary big number; needs to be over 1024 to confirm we're no longer
   // hostage to pselect.
@@ -176,4 +178,4 @@ TEST_F(SubprocessTest, SetWithLots) {
   }
   ASSERT_EQ(kNumProcs, subprocs_.finished_.size());
 }
-#endif  // _WIN32
+#endif  // linux


### PR DESCRIPTION
It fails on OS X, see issue #384.
