### PR TITLE
Include unistd.h in files that use unlink() on OS X.

### DIFF
--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -22,6 +22,10 @@
 #include "util.h"
 #include "metrics.h"
 
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 const char kTestFilename[] = "BuildLogPerfTest-tempfile";
 
 bool WriteTestData(string* err) {

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -20,9 +20,7 @@
 #ifdef _WIN32
 #include <fcntl.h>
 #include <share.h>
-#endif
-
-#ifdef linux
+#else
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
`man unlink` says this is necessary, and according to a report by
Claus Klein, omitting them breaks the build on OS X 10.5 with gcc 4.7.

(On Windows, ninja's util.h includes a define for unlink.)
