### PR TITLE
Mark re2c rules as generator rules.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -235,7 +235,9 @@ if platform not in ('mingw', 'windows'):
 n.comment('the depfile parser and ninja lexers are generated using re2c.')
 n.rule('re2c',
        command='re2c -b -i --no-generation-date -o $out $in',
-       description='RE2C $out')
+       description='RE2C $out',
+       # To make re2c not required as long as the .in.cc files don't change.
+       generator=True)
 # Generate the .cc files in the source directory so we can check them in.
 n.build(src('depfile_parser.cc'), 're2c', src('depfile_parser.in.cc'))
 n.build(src('lexer.cc'), 're2c', src('lexer.in.cc'))


### PR DESCRIPTION
generator=1 has two effects:
1. It suppresses checking if a command changed. b56fe8082b made it so
   that an output that's not in .ninja_log is always considered as
   changed, and hence caused the re2c rules to run. With this change,
   re2c is only executed if one of the .in.cc files change.
2. ninja -t clean won't delete outputs from generator rules, so this
   also addresses issue #157.
