### PR TITLE
Remove -fcolor-diagnostics reference from HACKING

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -108,6 +108,6 @@ it's locked while in use.
 
 ## Clang
 
-Enable colors manually via `-fcolor-diagnostics`:
+To use clang, set `CXX`:
 
-    CXX='/path/to/llvm/Release+Asserts/bin/clang++ -fcolor-diagnostics' ./configure.py
+    CXX=clang++ ./configure.py


### PR DESCRIPTION
configure.py adds that flag automatically if CXX is set to clang.
