### PR TITLE
on windows a network path starts with two backslashes

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -110,8 +110,19 @@ bool CanonicalizePath(char* path, int* len, string* err) {
   const char* end = start + *len;
 
   if (*src == '/') {
+#ifdef _WIN32
+    // network path starts with //
+    if (*len > 1 && *(src + 1) == '/') {
+      src += 2;
+      dst += 2;
+    } else {
+      ++src;
+      ++dst;
+    }
+#else
     ++src;
     ++dst;
+#endif
   }
 
   while (src < end) {

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -66,6 +66,22 @@ TEST(CanonicalizePath, PathSamples) {
   path = "foo/.hidden_bar";
   EXPECT_TRUE(CanonicalizePath(&path, &err));
   EXPECT_EQ("foo/.hidden_bar", path);
+
+  path = "/foo";
+  EXPECT_TRUE(CanonicalizePath(&path, &err));
+  EXPECT_EQ("/foo", path);
+
+  path = "//foo";
+  EXPECT_TRUE(CanonicalizePath(&path, &err));
+#ifdef _WIN32
+  EXPECT_EQ("//foo", path);
+#else
+  EXPECT_EQ("/foo", path);
+#endif
+
+  path = "/";
+  EXPECT_TRUE(CanonicalizePath(&path, &err));
+  EXPECT_EQ("", path);
 }
 
 TEST(CanonicalizePath, EmptyResult) {


### PR DESCRIPTION
Fix parser for .d files like this:

CMakeFiles\foo.dir\main.cpp.obj: \
//Lxde/sandbox/headers/inc.h \

See this thread:
http://www.cmake.org/pipermail/cmake/2012-August/051597.html

('\\' will be replaced by '//' in the .d files)
