### PR TITLE
safer build: consider target dirty if depfile is missing

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -38,8 +38,12 @@ bool Edge::RecomputeDirty(State* state, DiskInterface* disk_interface,
   outputs_ready_ = true;
 
   if (!rule_->depfile().empty()) {
-    if (!LoadDepFile(state, disk_interface, err))
-      return false;
+    if (!LoadDepFile(state, disk_interface, err)) {
+      if (!err->empty())
+          return false;
+      // depfile is missing or empty
+      dirty = true;
+    }
   }
 
   // Visit all inputs; we're dirty if any of the inputs are dirty.
@@ -274,8 +278,9 @@ bool Edge::LoadDepFile(State* state, DiskInterface* disk_interface,
   string content = disk_interface->ReadFile(path, err);
   if (!err->empty())
     return false;
+  // On a missing depfile: return false and empty *err.
   if (content.empty())
-    return true;
+    return false;
 
   DepfileParser depfile;
   string depfile_err;


### PR DESCRIPTION
(copied from 405, fixed the test)

always rebuild target if dep file is missing.

I've considered also another variant (branch: dirty-on-missing-depfile), with comparing mtime of the depfile to target to rebuild on missing or newer depfile to be consistent with the logic in restat clean. But this would add another 'stat' on the critical path, and I don't see the real advantage in this test.
