### PR TITLE
Change rate measurement code.

### DIFF
--- a/src/metrics.h
+++ b/src/metrics.h
@@ -59,19 +59,18 @@ private:
 };
 
 /// Get the current time as relative to some epoch.
-/// Epoch varies between platforms; only useful for measuring elapsed
-/// time.
+/// Epoch varies between platforms; only useful for measuring elapsed time.
 int64_t GetTimeMillis();
 
 
-/// A simple stopwatch which retruns the time
-// in seconds since Restart() was called
+/// A simple stopwatch which returns the time
+/// in seconds since Restart() was called.
 class Stopwatch
 {
 public:
   Stopwatch() : started_(0) {}
 
-  /// Seconds since Restart() call
+  /// Seconds since Restart() call.
   double Elapsed() const { return 1e-6 * static_cast<double>(Now() - started_); }
 
   void Restart() { started_ = Now(); }


### PR DESCRIPTION
For %o, remove a superfluous + 0.5: snprintf("%f") rounds already.
Remove some unnecessary code.

For %c, fix a TODO to add a sliding window and update after every
completed edge. Else, with -j50 and several files that take 3s to
compile each, this number would only update every 150s. Also give
the number one decimal place so that this can measure steps slower
than 1s.
