### PR TITLE
Don't say -h is invalid whereas it is supported.

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -740,7 +740,7 @@ int NinjaMain(int argc, char** argv) {
 
   int opt;
   while (tool_name.empty() &&
-         (opt = getopt_long(argc, argv, "d:f:j:k:l:nt:vC:", kLongOptions,
+         (opt = getopt_long(argc, argv, "d:f:j:k:l:nt:vC:h", kLongOptions,
                             NULL)) != -1) {
     switch (opt) {
       case 'd':


### PR DESCRIPTION
getopt_long(3) was reporting "ninja: invalid option -- h" when "ninja -h" was
called.

Regression most probably introduced by 5fdb12ed5cec4e1c853c64026142d088ff5519e1
