### PR TITLE
Add -d depcheck to check for unsafe dependencies

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -337,7 +337,7 @@ bool DependencyScan::LoadDepFile(Edge* edge, string* err) {
         // The depfile has brought in a dependency which is a generated file
         // (that is, it has a non-phony in-edge). We need to check that this dependency
         // is defined explicitly in the ninja file as well.
-        if (HasNonDepfileDependency(edge, node)) {
+        if (!HasNonDepfileDependency(edge, node)) {
           Fatal("depcheck failed: dependency on generated file (%s -> %s) only exists in depfile",
                   edge->outputs_[0]->path().c_str(), node->path().c_str());
         }

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -188,6 +188,9 @@ TEST_F(GraphTest, DepfileRemoved) {
   EXPECT_TRUE(GetNode("out.o")->dirty());
 }
 
+// Test the HasNonDepfileDependency method used in -d depcheck
+// First present two files depending on a generated header,
+// but only one mentioning that in the .ninja file
 TEST_F(GraphTest, DepCheckSimple) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule catdep\n"
@@ -212,6 +215,8 @@ TEST_F(GraphTest, DepCheckSimple) {
   EXPECT_FALSE(DependencyScan::HasNonDepfileDependency(GetNode("out2.o")->in_edge(), GetNode("normal.h")));
 }
 
+// Extension of DepCheckSimple - now use a "sentinel" in between the header
+// generation and its usage
 TEST_F(GraphTest, DepCheckIndirect) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule catdep\n"
@@ -237,6 +242,8 @@ TEST_F(GraphTest, DepCheckIndirect) {
   EXPECT_TRUE(DependencyScan::HasNonDepfileDependency(GetNode("out3.o")->in_edge(), GetNode("generated.h")));
 }
 
+// Extension of DepCheckIndirect - use the sentinel to mark the dependency in 
+// .ninja file, but depend on a header file, which is its byproduct (sibling)
 TEST_F(GraphTest, DepCheckSiblings) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule cat2\n"

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -594,6 +594,7 @@ bool DebugEnable(const string& name, Globals* globals) {
     printf("debugging modes:\n"
 "  stats    print operation counts/timing info\n"
 "  explain  explain what caused a command to execute\n"
+"  depcheck check depfile discovered dependencies on generated files\n"
 "multiple modes can be enabled via -d FOO -d BAR\n");
     return false;
   } else if (name == "stats") {
@@ -601,6 +602,9 @@ bool DebugEnable(const string& name, Globals* globals) {
     return true;
   } else if (name == "explain") {
     g_explaining = true;
+    return true;
+  } else if (name == "depcheck") {
+    g_depcheck = true;
     return true;
   } else {
     printf("ninja: unknown debug setting '%s'\n", name.c_str());


### PR DESCRIPTION
The (optional) -d depcheck activates a mode, in which ninja would
perform additional safety checks while reading the depfiles. If a file
mentioned in a depfile is at the same time a target of some rule, ninja
will check, whether this dependency is mentioned in the .ninja files
(i.e. whether ninja would know about it in a clean run, without
depfiles). If not, the dependency is not safe and ninja will raise an
error.

Becasue this option has a runtime cost and makes only sense after a
complete build (we must have depfiles to inspect), the typical usage
would be to run this as a sanity chec of the integrity of the build
after the build itself, e.g. on a central CI server.
