### PR TITLE
Allocate disk_interface near where it's needed.

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -825,7 +825,6 @@ int NinjaMain(int argc, char** argv) {
   bool rebuilt_manifest = false;
 
 reload:
-  RealDiskInterface disk_interface;
   RealFileReader file_reader;
   ManifestParser parser(globals.state, &file_reader);
   string err;
@@ -838,6 +837,7 @@ reload:
     return tool->func(&globals, argc, argv);
 
   BuildLog build_log;
+  RealDiskInterface disk_interface;
   if (!OpenLog(&build_log, &globals, &disk_interface))
     return 1;
 


### PR DESCRIPTION
This avoids allocating disk_interface unnecessarily.

Signed-off-by: Thiago Farina tfarina@chromium.org
