### PR TITLE
 Adding a deps tool that returns recursive inputs/outputs

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -276,6 +276,7 @@ for name in ['build',
              'lexer',
              'manifest_parser',
              'metrics',
+             'python_deps',
              'state',
              'util']:
     objs += cxx(name)

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -39,6 +39,7 @@
 #include "graphviz.h"
 #include "manifest_parser.h"
 #include "metrics.h"
+#include "python_deps.h"
 #include "state.h"
 #include "util.h"
 
@@ -234,6 +235,23 @@ int ToolGraph(Globals* globals, int argc, char* argv[]) {
   for (vector<Node*>::const_iterator n = nodes.begin(); n != nodes.end(); ++n)
     graph.AddTarget(*n);
   graph.Finish();
+
+  return 0;
+}
+
+int ToolDeps(Globals* globals, int argc, char* argv[]) {
+  vector<Node*> nodes;
+  string err;
+  if (!CollectTargetsFromArgs(globals->state, argc, argv, &nodes, &err)) {
+    Error("%s", err.c_str());
+    return 1;
+  }
+
+  PythonDeps deps;
+  deps.Start();
+  for (vector<Node*>::const_iterator n = nodes.begin(); n != nodes.end(); ++n)
+    deps.AddTarget(*n);
+  deps.Finish();
 
   return 0;
 }
@@ -547,6 +565,8 @@ int ChooseTool(const string& tool_name, const Tool** tool_out) {
       Tool::RUN_AFTER_LOAD, ToolCommands },
     { "graph", "output graphviz dot file for targets",
       Tool::RUN_AFTER_LOAD, ToolGraph },
+    { "deps", "show recursive inputs/outputs for a path",
+      Tool::RUN_AFTER_LOAD, ToolDeps },
     { "query", "show inputs/outputs for a path",
       Tool::RUN_AFTER_LOAD, ToolQuery },
     { "rules",    "list all rules",

--- a/src/python_deps.cc
+++ b/src/python_deps.cc
@@ -1,0 +1,56 @@
+// Copyright 2012 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "python_deps.h"
+
+#include <stdio.h>
+
+#include "graph.h"
+
+void PythonDeps::AddTarget(Node* node) {
+  Edge* edge = node->in_edge();
+  if (edge) {
+    if (output_nodes_.find(node) != output_nodes_.end())
+      return;
+    output_nodes_.insert(node);
+    for (vector<Node*>::iterator in = edge->inputs_.begin();
+         in != edge->inputs_.end(); ++in) {
+      AddTarget(*in);
+    }
+  } else {
+    if (input_nodes_.find(node) != input_nodes_.end())
+      return;
+    input_nodes_.insert(node);
+  }
+}
+
+void PythonDeps::Start() {
+}
+
+void PythonDeps::Finish() {
+  printf("{\n");
+  printf("  'inputs': [\n");
+  for (set<Node*>::iterator node = input_nodes_.begin();
+       node != input_nodes_.end(); ++node) {
+    printf("    '%s',\n", (*node)->path().c_str());
+  }
+  printf("  ],\n");
+  printf("  'outputs': [\n");
+  for (set<Node*>::iterator node = output_nodes_.begin();
+       node != output_nodes_.end(); ++node) {
+    printf("    '%s',\n", (*node)->path().c_str());
+  }
+  printf("  ],\n");
+  printf("}\n");
+}

--- a/src/python_deps.h
+++ b/src/python_deps.h
@@ -1,0 +1,34 @@
+// Copyright 2012 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NINJA_PYTHON_DEPS_H_
+#define NINJA_PYTHON_DEPS_H_
+
+#include <set>
+using namespace std;
+
+struct Node;
+struct Edge;
+
+/// Runs the process of creating PythonDeps .dot file output.
+struct PythonDeps {
+  void Start();
+  void AddTarget(Node* node);
+  void Finish();
+
+  set<Node*> output_nodes_;
+  set<Node*> input_nodes_;
+};
+
+#endif  // NINJA_PYTHON_DEPS_H_


### PR DESCRIPTION
The deps tool will return a list of inputs/outputs for the given target
in the format of a python dictionary.

 Contrary to query, the inputs are computed recursively.