### PR TITLE
Add "workingdir" as special global build variable, equivalent to -C

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -612,8 +612,17 @@ bool OpenLog(BuildLog* build_log, Globals* globals,
              DiskInterface* disk_interface) {
   const string build_dir =
       globals->state->bindings_.LookupVariable("builddir");
+  const string working_dir =
+      globals->state->bindings_.LookupVariable("workingdir");
   const char* kLogPath = ".ninja_log";
   string log_path = kLogPath;
+
+  if (!working_dir.empty()) {
+    if (chdir(working_dir.c_str()) < 0) {
+      Fatal("chdir to '%s' - %s", working_dir.c_str(), strerror(errno));
+    }
+  }
+
   if (!build_dir.empty()) {
     log_path = build_dir + "/" + kLogPath;
     if (!disk_interface->MakeDirs(log_path) && errno != EEXIST) {


### PR DESCRIPTION
This is used by the Premake ninja generator in https://github.com/rgeary1/premake-dev-rgeary

Similar to the ninjadir variable, the workingdir variable sets the current working directory equivalent to specifying -C on the command line. 

This is very useful in the following case. Suppose you have a master build script with all the edges (buildedges.ninja), and many build.ninja scripts in the code subdirectories. The build.ninja script sets default build edges & subninja's to the buildedges.ninja script. For the build.ninja script to run, it needs to change the working dir to the buildedges.ninja directory. So now the build script generator can insert a "workingdir" variable in the build script to embed this information.