### PR TITLE
Fix clang warning.

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -185,7 +185,7 @@ Node* CollectTarget(State* state, const char* cpath, string* err) {
     if (first_dependent) {
       if (node->out_edges().empty()) {
         *err = "'" + path + "' has no out edge";
-        return false;
+        return NULL;
       }
       Edge* edge = node->out_edges()[0];
       if (edge->outputs_.empty()) {


### PR DESCRIPTION
The return type of CollectTarget() is Node, so we should return NULL in the
failure case instead of false.

src/ninja.cc:188:16: warning: initialization of pointer of type 'Node *' to null from a constant boolean expression [-Wbool-conversion]
        return false;
               ^~~~~

Signed-off-by: Thiago Farina tfarina@chromium.org
