### PR TITLE
Ninja -t browse opens localhost in browser, which doesn't work when using ssh

### DIFF
--- a/src/browse.py
+++ b/src/browse.py
@@ -26,6 +26,8 @@ try:
     import http.server as httpserver
 except ImportError:
     import BaseHTTPServer as httpserver
+import os
+import socket
 import subprocess
 import sys
 import webbrowser
@@ -183,8 +185,10 @@ class RequestHandler(httpserver.BaseHTTPRequestHandler):
 port = 8000
 httpd = httpserver.HTTPServer(('',port), RequestHandler)
 try:
-    print('Web server running on port %d, ctl-C to abort...' % port)
-    webbrowser.open_new('http://localhost:%s' % port)
+    hostname = socket.gethostname()
+    print('Web server running on %s:%d, ctl-C to abort...' % (hostname,port) )
+    print('Web server pid %d' % os.getpid(), file=sys.stderr )
+    webbrowser.open_new('http://%s:%s' % (hostname, port) )
     httpd.serve_forever()
 except KeyboardInterrupt:
     print()


### PR DESCRIPTION
Browse tool should use the real hostname not http://localhost, to allow -t browse when using ssh

Fix attached.
