### PR TITLE
ManifestParser constructor accesses its first argument, don't pass NULL

### DIFF
--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -295,7 +295,8 @@ TEST_F(ParserTest, ReservedWords) {
 
 TEST_F(ParserTest, Errors) {
   {
-    ManifestParser parser(NULL, NULL);
+    State state;
+    ManifestParser parser(&state, NULL);
     string err;
     EXPECT_FALSE(parser.ParseTest("foobar", &err));
     EXPECT_EQ("input:1: expected '=', got eof\n"
@@ -305,7 +306,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    ManifestParser parser(NULL, NULL);
+    State state;
+    ManifestParser parser(&state, NULL);
     string err;
     EXPECT_FALSE(parser.ParseTest("x 3", &err));
     EXPECT_EQ("input:1: expected '=', got identifier\n"
@@ -315,7 +317,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    ManifestParser parser(NULL, NULL);
+    State state;
+    ManifestParser parser(&state, NULL);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = 3", &err));
     EXPECT_EQ("input:1: unexpected EOF\n"


### PR DESCRIPTION
The constructor does

  env_ = &state->bindings_;

so env_ is effectively set to offsetof(ManifestParser, bindings_).  This
will blow up if env_ gets dereferenced -- this doesn't seem to happen in
these tests, but it's less confusing with this patch.  Also, passing &state is
consistent with the rest of this test.
