### PR TITLE
more verbose error (including path) when depfile fails to load

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -284,8 +284,10 @@ bool Edge::GetBindingBool(const string& key) {
 bool DependencyScan::LoadDepFile(Edge* edge, const string& path, string* err) {
   METRIC_RECORD("depfile load");
   string content = disk_interface_->ReadFile(path, err);
-  if (!err->empty())
+  if (!err->empty()) {
+    *err = "loading '" + path + "': " + *err;
     return false;
+  }
   // On a missing depfile: return false and empty *err.
   if (content.empty())
     return false;


### PR DESCRIPTION
Trying to diagnose failures on bot that look like

ninja:error: Permission denied

and this seems like the most likely candidate.
