### PR TITLE
util.cc: Reusing windows workaround for cygwin.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -325,7 +325,7 @@ int GetProcessorCount() {
 }
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 double GetLoadAverage() {
   // TODO(nicolas.despres@gmail.com): Find a way to implement it on Windows.
   // Remember to also update Usage() when this is fixed.


### PR DESCRIPTION
This fixes:
src/util.cc: In function 'double GetLoadAverage()':
src/util.cc:337:28: error: 'getloadavg' was not declared in this scope
