### PR TITLE
Removed unused UnitsWaiting() function from State class.

### DIFF
--- a/src/state.h
+++ b/src/state.h
@@ -66,9 +66,7 @@ struct Pool {
   /// Dump the Pool and its edges (useful for debugging).
   void Dump() const;
 
-private:
-  int UnitsWaiting() { return delayed_.size(); }
-
+ private:
   string name_;
 
   /// |current_use_| is the total of the weights of the edges which are


### PR DESCRIPTION
This function was added at 307f0bbd("and some basic implementation"), but nobody
calls it anymore.

Signed-off-by: Thiago Farina tfarina@chromium.org
