### PR TITLE
Add a check for the VC++ 2012-style 64-bit path.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -85,7 +85,9 @@ if options.windows:
 vcdir = os.environ.get('VCINSTALLDIR')
 if vcdir:
     if options.x64:
-        cl = [os.path.join(vcdir, 'bin', 'amd64', 'cl.exe')]
+        cl = [os.path.join(vcdir, 'bin', 'x86_amd64', 'cl.exe')]
+        if not os.path.exists(cl[0]):
+            cl = [os.path.join(vcdir, 'bin', 'amd64', 'cl.exe')]
     else:
         cl = [os.path.join(vcdir, 'bin', 'cl.exe')]
     args = cl + ['/nologo', '/EHsc', '/DNOMINMAX']


### PR DESCRIPTION
In VS2012 the path to the 64-bit tools has changed to
VCINSTALLDIR\bin\x86_amd64\cl.exe. This change will make the bootstrap
check there to see if it exists before falling back to the old amd64 path.
