### PR TITLE
Remove "Warnings as errors" flags for windows.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -120,7 +120,6 @@ if platform == 'windows':
     cflags = ['/nologo',  # Don't print startup banner.
               '/Zi',  # Create pdb with debug info.
               '/W4',  # Highest warning level.
-              '/WX',  # Warnings as errors.
               '/wd4530', '/wd4100', '/wd4706',
               '/wd4512', '/wd4800', '/wd4702', '/wd4819',
               # Disable warnings about passing "this" during initialization.


### PR DESCRIPTION
The /WX flag causing the build on windows to fail when
compiling version.cc does not produce an object:

[1/3] CXX build\version.obj
FAILED: ninja.bootstrap.exe -t msvc -o build\version.obj -- cl /showIncludes /nologo /Zi /W4 /WX /wd4530 /wd4100 /wd4706 /wd4512 /wd4800 /wd4702 /wd4819 /wd4355 /GR- /wd4267 /DNOMINMAX /D_CRT_SECURE_NO_WARNINGS /DNINJA_PYTHON="python.exe" /Ox /DNDEBUG /GL -c src\version.cc /Fobuild\version.obj
src\version.cc(29) : error C2220: warning treated as error - no 'object' file generated
