### PR TITLE
Fix wrong usage of std::string::find

### DIFF
--- a/src/version.cc
+++ b/src/version.cc
@@ -26,7 +26,7 @@ void ParseVersion(const string& version, int* major, int* minor) {
   *minor = 0;
   if (end != string::npos) {
     size_t start = end + 1;
-    end = version.find(start, '.');
+    end = version.find('.', start);
     *minor = atoi(version.substr(start, end).c_str());
   }
 }
@@ -51,6 +51,7 @@ void CheckNinjaVersion(const string& version) {
           kNinjaVersion, version.c_str());
   }
 }
+
 
 
 


### PR DESCRIPTION
Wrong argument order in find:
http://www.cplusplus.com/reference/string/string/find/
