### PR TITLE
Prevent redundant in-edges on a rule.

### DIFF
--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -15,22 +15,27 @@
 
 #include "lexer.h"
 
+#include <assert.h>
 #include <stdio.h>
 
 #include "eval_env.h"
 #include "util.h"
 
-bool Lexer::Error(const string& message, string* err) {
+bool Lexer::Error(const string& message, string* err, int error_token_offset) {
+  assert(error_token_offset < input_.len_);
+  assert(error_token_offset >= 0);
+  const char * error_token = input_.str_ + error_token_offset;
+
   // Compute line/column.
   int line = 1;
   const char* context = input_.str_;
-  for (const char* p = input_.str_; p < last_token_; ++p) {
+  for (const char* p = input_.str_; p < error_token; ++p) {
     if (*p == '\n') {
       ++line;
       context = p + 1;
     }
   }
-  int col = last_token_ ? (int)(last_token_ - context) : 0;
+  int col = error_token ? (int)(error_token - context) : 0;
 
   char buf[1024];
   snprintf(buf, sizeof(buf), "%s:%d: ", filename_.AsString().c_str(), line);

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -86,8 +86,17 @@ struct Lexer {
     return ReadEvalString(value, false, err);
   }
 
-  /// Construct an error message with context.
-  bool Error(const string& message, string* err);
+  /// Get a offest which is useful for printing Errors with this Lexer.
+  int GetCurrentTokenOffset() { return last_token_ - input_.str_; }
+
+  /// Construct an error message with current context.
+  bool Error(const string& message, string* err) {
+    return Error(message, err, GetCurrentTokenOffset());
+  }
+
+  /// Construct an error message with specified context (see
+  /// GetCurrentTokenOffset).
+  bool Error(const string& message, string* err, int error_token_offset);
 
 private:
   /// Skip past whitespace (called after each read token/ident/etc.).

--- a/src/lexer.in.cc
+++ b/src/lexer.in.cc
@@ -14,22 +14,27 @@
 
 #include "lexer.h"
 
+#include <assert.h>
 #include <stdio.h>
 
 #include "eval_env.h"
 #include "util.h"
 
-bool Lexer::Error(const string& message, string* err) {
+bool Lexer::Error(const string& message, string* err, int error_token_offset) {
+  assert(error_token_offset < input_.len_);
+  assert(error_token_offset >= 0);
+  const char * error_token = input_.str_ + error_token_offset;
+
   // Compute line/column.
   int line = 1;
   const char* context = input_.str_;
-  for (const char* p = input_.str_; p < last_token_; ++p) {
+  for (const char* p = input_.str_; p < error_token; ++p) {
     if (*p == '\n') {
       ++line;
       context = p + 1;
     }
   }
-  int col = last_token_ ? (int)(last_token_ - context) : 0;
+  int col = error_token ? (int)(error_token - context) : 0;
 
   char buf[1024];
   snprintf(buf, sizeof(buf), "%s:%d: ", filename_.AsString().c_str(), line);


### PR DESCRIPTION
This is a 'fix' for the issue brought up here: https://groups.google.com/forum/?fromgroups=#!topic/ninja-build/CNqaIwlTgVo

The minified version of the repro:

```
pool compile
  depth = 1
rule gen_foo
  command = touch foo.cpp
rule echo
  command = echo $out > $out
build foo.cpp.obj: echo foo.cpp || foo.cpp
  pool = compile
build libfoo.a: echo foo.cpp.obj
build foo.cpp: gen_foo
build all: phony libfoo.a
```

Will now result in the error:

```
ninja: error: build.ninja:7: redundant dependency 'foo.cpp'
build foo.cpp.obj: cat foo.cpp || foo.cpp
                                         ^ near here
```

I generated recent chromium/ninja build manifests, and they also have this error :unamused:.

I'm wondering if an Error is too harsh, if a warning+ignore edge with a flag to make it an error would be better instead? 

Alternately, I could fall back to one of the other 'silent ignore' strategies.
