### PR TITLE
Add spell checking for debug flags.

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -629,7 +629,14 @@ bool DebugEnable(const string& name, Globals* globals) {
     g_explaining = true;
     return true;
   } else {
-    printf("ninja: unknown debug setting '%s'\n", name.c_str());
+    const char* suggestion =
+        SpellcheckString(name, "stats", "explain", NULL);
+    if (suggestion) {
+      Error("unknown debug setting '%s', did you mean '%s'?",
+            name.c_str(), suggestion);
+    } else {
+      Error("unknown debug setting '%s'", name.c_str());
+    }
     return false;
   }
 }


### PR DESCRIPTION
I just used `ninja -d stat` and it took me a bit to realize that I missed the
trailing 's'.

While here, move the message printing from printf() to Error(). This makes the
output consistent with other error outputs: The messages are now prefixed with
"ninja: error: " instead of just "ninja: " and they go to stderr instead of
stdout.
