### PR TITLE
Interrupting non-trivial commands on Cygwin

### DIFF
--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -67,8 +67,10 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
     // Track which fd we use to report errors on.
     int error_pipe = output_pipe[1];
     do {
+#     ifndef _CYGWIN_
       if (setpgid(0, 0) < 0)
         break;
+#     endif
 
       if (sigaction(SIGINT, &set->old_act_, 0) < 0)
         break;


### PR DESCRIPTION
Hello

When the user presses Ctrl-C to interrupt a build command on Cygwin Ninja will wait until the /bin/sh child process is killed manually. For some reason only commands with a semicolon cause this error. E.g.:

```
rule test
  command = sleep 10; echo done
build test: test
default test
```

Disabling setpgid(0, 0) on Cygwin appears to fix these problems. I checked it with the given small example and repeatedly interrupted (and restarted) CMake build. No process survived the interruptions. No additional unit tests are broken. (DiskInterfaceTest.StatBadPath fails)

I must admit that I don't understand what I'm doing or what the original code is supposed to accomplish in the first place. It would be great if someone else could examine this issue in more detail.

Kind regards, Paul
