### PR TITLE
Improved bash completion when using tools like '-t clean'

### DIFF
--- a/misc/bash-completion
+++ b/misc/bash-completion
@@ -18,16 +18,23 @@
 _ninja_target() {
     local cur targets dir line targets_command OPTIND
     cur="${COMP_WORDS[COMP_CWORD]}"
-    dir="."
-    line=$(echo ${COMP_LINE} | cut -d" " -f 2-)
-    while getopts C: opt "${line[@]}"; do
-      case $opt in
-        C) dir="$OPTARG" ;;
-      esac
-    done;
-    targets_command="ninja -C ${dir} -t targets all"
-    targets=$((${targets_command} 2>/dev/null) | awk -F: '{print $1}')
-    COMPREPLY=($(compgen -W "$targets" -- "$cur"))
-    return 0
+
+		if [[ "$cur" == "--"* ]]; then
+			# there is currently only one argument that takes --
+			COMPREPLY=($(compgen -P '--' -W 'version' -- "${cur:2}"))
+		else
+			dir="."
+			line=$(echo ${COMP_LINE} | cut -d" " -f 2-)
+			# filter out all non relevant arguments but keep C for dirs
+			while getopts C:f:j:l:k:nvd:t: opt "${line[@]}"; do
+				case $opt in
+					C) dir="$OPTARG" ;;
+				esac
+			done;
+			targets_command="ninja -C ${dir} -t targets all"
+			targets=$((${targets_command} 2>/dev/null) | awk -F: '{print $1}')
+			COMPREPLY=($(compgen -W "$targets" -- "$cur"))
+		fi
+    return
 }
 complete -F _ninja_target ninja


### PR DESCRIPTION
When using 'ninja -t clean <tab>' bash would not complete properly and would give errors about unknown commands.

The needed options were introduced into getopts to fix this.
