### PR TITLE
Make deps=gcc without depfile an error.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -873,7 +873,7 @@ void Builder::FinishCommand(CommandRunner::Result* result) {
   }
 
   if (!deps_type.empty()) {
-    assert(edge->outputs_.size() == 1);
+    assert(edge->outputs_.size() == 1 && "should have been rejected by parser");
     Node* out = edge->outputs_[0];
     // XXX need to restat for restat_mtime.
     scan_.deps_log()->RecordDeps(out, restat_mtime, deps_nodes);
@@ -897,8 +897,10 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
 #endif
   if (deps_type == "gcc") {
     string depfile = result->edge->GetBinding("depfile");
-    if (depfile.empty())
-      return true;  // No dependencies to load.
+    if (depfile.empty()) {
+      *err = string("edge with deps=gcc but no depfile makes no sense\n");
+      return false;
+    }
 
     string content = disk_interface_->ReadFile(depfile, err);
     if (!err->empty())
@@ -920,7 +922,7 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
     }
 
     if (disk_interface_->RemoveFile(depfile) < 0) {
-      *err = string("deleting depfile: ") + strerror(errno);
+      *err = string("deleting depfile: ") + strerror(errno) + string("\n");
       return false;
     }
   } else {

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1358,6 +1358,24 @@ TEST_F(BuildTest, PhonyWithNoInputs) {
   ASSERT_EQ(1u, command_runner_.commands_ran_.size());
 }
 
+TEST_F(BuildTest, DepsGccWithEmptyDeps) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule cc\n"
+"  command = cc\n"
+"  deps = gcc\n"
+"build out: cc\n"));
+  Dirty("out");
+
+  string err;
+  EXPECT_TRUE(builder_.AddTarget("out", &err));
+  ASSERT_EQ("", err);
+  EXPECT_FALSE(builder_.AlreadyUpToDate());
+
+  EXPECT_FALSE(builder_.Build(&err));
+  ASSERT_EQ("subcommand failed", err);
+  ASSERT_EQ(1u, command_runner_.commands_ran_.size());
+}
+
 TEST_F(BuildTest, StatusFormatReplacePlaceholder) {
   EXPECT_EQ("[%/s0/t0/r0/u0/f0]",
             status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]"));


### PR DESCRIPTION
When I first played with depslog, I accidentally removed the depfile attribute
on my cc edges, which had the effect of ninja silently ignoring all depfiles.
Instead, let ninja complain about edges that have deps set to gcc and
depfile set to nothing.

This is done at edge build time, instead of at mainfest load time, because
adding this check to ParseEdge() regressed empty build time for target 'chrome'
by 30ms. The check is only useful for generator authors, regular users should
never see this.
