### PR TITLE
strip /showIncludes even on compile errors to avoid the extra noise

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -789,7 +789,7 @@ void Builder::FinishCommand(CommandRunner::Result* result) {
                                      restat_mtime);
   }
 
-  if (!deps_type.empty() && result->success()) {
+  if (!deps_type.empty()) {
     assert(edge->outputs_.size() == 1 && "should have been rejected by parser");
     Node* out = edge->outputs_[0];
     if (!deps_mtime) {


### PR DESCRIPTION
For issue #536.

I didn't call ExtractDeps as the dependencies shouldn't change on failure. There's a bit of duplication this way though.
