### PR TITLE
Note that version 1.3 of the vim syntax file has been sent upstream.

### DIFF
--- a/misc/ninja.vim
+++ b/misc/ninja.vim
@@ -2,9 +2,9 @@
 " Language: ninja build file as described at
 "           http://martine.github.com/ninja/manual.html
 " Version: 1.3
-" Last Change: 2013/04/09
+" Last Change: 2013/04/16
 " Maintainer: Nicolas Weber <nicolasweber@gmx.de>
-" Version 1.2 of this script is in the upstream vim repository and will be
+" Version 1.3 of this script is in the upstream vim repository and will be
 " included in the next vim release. If you change this, please send your change
 " upstream.
 
@@ -15,6 +15,9 @@
 if exists("b:current_syntax")
   finish
 endif
+
+let s:cpo_save = &cpo
+set cpo&vim
 
 syn case match
 
@@ -73,3 +76,6 @@ hi def link ninjaSimpleVar ninjaVar
 hi def link ninjaVar Identifier
 
 let b:current_syntax = "ninja"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
Also fix an issue noticed by Bram during integration: Make sure to set "cpo"
correctly. This matches other vim syntax files and is required to make sure
that the backslash continuation works with all .vimrc files
(see `:help line-continuation`).
