### PR TITLE
disable failing pool tests, need to be reworked

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -219,7 +219,10 @@ TEST_F(PlanTest, PoolWithDepthOne) {
   ASSERT_EQ(0, edge);
 }
 
-TEST_F(PlanTest, PoolsWithDepthTwo) {
+// TODO(riannucci): Relies on edge order being in input order,
+// which it is not. Fails on Windows (but must set _NO_DEBUG_HEAP=1
+// when running from debugger).
+TEST_F(PlanTest, DISABLED_PoolsWithDepthTwo) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "pool foobar\n"
 "  depth = 2\n"
@@ -303,7 +306,10 @@ TEST_F(PlanTest, PoolsWithDepthTwo) {
   ASSERT_FALSE(plan_.FindWork());
 }
 
-TEST_F(PlanTest, PoolWithRedundantEdges) {
+// TODO(riannucci): Relies on edge order being in input order,
+// which it is not. Fails on Windows (but must set _NO_DEBUG_HEAP=1
+// when running from debugger).
+TEST_F(PlanTest, DISABLED_PoolWithRedundantEdges) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
     "pool compile\n"
     "  depth = 1\n"


### PR DESCRIPTION
@riannucci I poked around a bit, I think these tests need to be reworked.

They're relying on the edges coming out in the order that they're listed in the RHS of the rule, but I don't think that's a safe assumption. I started trying to rewrite them but, I was a little hazy on the details, so am being lazy and punting to you.
