### PR TITLE
don't call Error from Stat during tests

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -75,13 +75,16 @@ bool DiskInterface::MakeDirs(const string& path) {
 
 // RealDiskInterface -----------------------------------------------------------
 
-TimeStamp RealDiskInterface::Stat(const string& path) {
+TimeStamp RealDiskInterface::StatAndPrintError(const string& path,
+                                               bool print_on_error) {
 #ifdef _WIN32
   // MSDN: "Naming Files, Paths, and Namespaces"
   // http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
   if (!path.empty() && path[0] != '\\' && path.size() > MAX_PATH) {
-    Error("Stat(%s): Filename longer than %i characters",
-          path.c_str(), MAX_PATH);
+    if (print_on_error) {
+      Error("Stat(%s): Filename longer than %i characters",
+            path.c_str(), MAX_PATH);
+    }
     return -1;
   }
   WIN32_FILE_ATTRIBUTE_DATA attrs;
@@ -89,8 +92,10 @@ TimeStamp RealDiskInterface::Stat(const string& path) {
     DWORD err = GetLastError();
     if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND)
       return 0;
-    Error("GetFileAttributesEx(%s): %s", path.c_str(),
-          GetLastErrorString().c_str());
+    if (print_on_error) {
+      Error("GetFileAttributesEx(%s): %s",
+            path.c_str(), GetLastErrorString().c_str());
+    }
     return -1;
   }
   const FILETIME& filetime = attrs.ftLastWriteTime;
@@ -107,7 +112,8 @@ TimeStamp RealDiskInterface::Stat(const string& path) {
   if (stat(path.c_str(), &st) < 0) {
     if (errno == ENOENT || errno == ENOTDIR)
       return 0;
-    Error("stat(%s): %s", path.c_str(), strerror(errno));
+    if (print_on_error)
+      Error("stat(%s): %s", path.c_str(), strerror(errno));
     return -1;
   }
   return st.st_mtime;

--- a/src/disk_interface.h
+++ b/src/disk_interface.h
@@ -29,7 +29,12 @@ struct DiskInterface {
 
   /// stat() a file, returning the mtime, or 0 if missing and -1 on
   /// other errors.
-  virtual TimeStamp Stat(const string& path) = 0;
+  virtual TimeStamp StatAndPrintError(const string& path,
+                                      bool print_on_error) = 0;
+
+  virtual TimeStamp Stat(const string& path) {
+    return StatAndPrintError(path, true);
+  }
 
   /// Create a directory, returning false on failure.
   virtual bool MakeDir(const string& path) = 0;
@@ -56,7 +61,7 @@ struct DiskInterface {
 /// Implementation of DiskInterface that actually hits the disk.
 struct RealDiskInterface : public DiskInterface {
   virtual ~RealDiskInterface() {}
-  virtual TimeStamp Stat(const string& path);
+  virtual TimeStamp StatAndPrintError(const string& path, bool print_on_error);
   virtual bool MakeDir(const string& path);
   virtual bool WriteFile(const string& path, const string& contents);
   virtual string ReadFile(const string& path, string* err);

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -62,10 +62,10 @@ TEST_F(DiskInterfaceTest, StatMissingFile) {
 TEST_F(DiskInterfaceTest, StatBadPath) {
 #ifdef _WIN32
   string bad_path("cc:\\foo");
-  EXPECT_EQ(-1, disk_.Stat(bad_path));
+  EXPECT_EQ(-1, disk_.StatAndPrintError(bad_path, false));
 #else
   string too_long_name(512, 'x');
-  EXPECT_EQ(-1, disk_.Stat(too_long_name));
+  EXPECT_EQ(-1, disk_.StatAndPrintError(too_long_name, false));
 #endif
 }
 
@@ -107,7 +107,7 @@ struct StatTest : public StateTestWithBuiltinRules,
   StatTest() : scan_(&state_, NULL, NULL, this) {}
 
   // DiskInterface implementation.
-  virtual TimeStamp Stat(const string& path);
+  virtual TimeStamp StatAndPrintError(const string& path, bool print_on_error);
   virtual bool WriteFile(const string& path, const string& contents) {
     assert(false);
     return true;
@@ -130,7 +130,7 @@ struct StatTest : public StateTestWithBuiltinRules,
   vector<string> stats_;
 };
 
-TimeStamp StatTest::Stat(const string& path) {
+TimeStamp StatTest::StatAndPrintError(const string& path, bool print_on_error) {
   stats_.push_back(path);
   map<string, TimeStamp>::iterator i = mtimes_.find(path);
   if (i == mtimes_.end())

--- a/src/test.cc
+++ b/src/test.cc
@@ -105,7 +105,8 @@ void VirtualFileSystem::Create(const string& path,
   files_created_.insert(path);
 }
 
-TimeStamp VirtualFileSystem::Stat(const string& path) {
+TimeStamp VirtualFileSystem::StatAndPrintError(const string& path,
+                                               bool print_on_error) {
   FileMap::iterator i = files_.find(path);
   if (i != files_.end())
     return i->second.mtime;

--- a/src/test.h
+++ b/src/test.h
@@ -59,7 +59,7 @@ struct VirtualFileSystem : public DiskInterface {
   }
 
   // DiskInterface
-  virtual TimeStamp Stat(const string& path);
+  virtual TimeStamp StatAndPrintError(const string& path, bool print_on_error);
   virtual bool WriteFile(const string& path, const string& contents);
   virtual bool MakeDir(const string& path);
   virtual string ReadFile(const string& path, string* err);


### PR DESCRIPTION
Avoids:

ninja: error: GetFileAttributesEx(cc:\foo): The filename, directory name, or volume label syntax is incorrect.

during DiskInterfaceTest.StatBadPath which otherwise breaks the serenity of the LaconicPrinter.

/cc @nico
