### PR TITLE
Don't crash during deps log recompaction if there's more than one deps entry.

### DIFF
--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -257,6 +257,8 @@ bool DepsLog::Recompact(const string& path, string* err) {
   // Write out all deps again.
   for (int old_id = 0; old_id < (int)deps_.size(); ++old_id) {
     Deps* deps = deps_[old_id];
+    if (!deps) continue;  // If nodes_[old_id] is a leaf, it has no deps.
+
     if (!new_log.RecordDeps(nodes_[old_id], deps->mtime,
                             deps->node_count, deps->nodes)) {
       new_log.Close();

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -137,6 +137,12 @@ TEST_F(DepsLogTest, Recompact) {
     deps.push_back(state.GetNode("foo.h"));
     deps.push_back(state.GetNode("bar.h"));
     log.RecordDeps(state.GetNode("out.o"), 1, deps);
+
+    deps.clear();
+    deps.push_back(state.GetNode("foo.h"));
+    deps.push_back(state.GetNode("baz.h"));
+    log.RecordDeps(state.GetNode("other_out.o"), 1, deps);
+
     log.Close();
 
     struct stat st;


### PR DESCRIPTION
Part of issue #554.
