### PR TITLE
Make sure that recompaction writes a pristine new depslog.

### DIFF
--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -244,6 +244,11 @@ bool DepsLog::Recompact(const string& path, string* err) {
   printf("Recompacting deps...\n");
 
   string temp_path = path + ".recompact";
+
+  // OpenForWrite() opens for append.  Make sure it's not appending to a
+  // left-over file from a previous recompaction attempt that crashed somehow.
+  unlink(temp_path.c_str());
+
   DepsLog new_log;
   if (!new_log.OpenForWrite(temp_path, err))
     return false;


### PR DESCRIPTION
...even if a prior run of DepsLog::Recompact() exited without cleaning
up, for example due to a crash or because someone added a `return true;`
in the middle of the function while debugging.  Or because someone hits
ctrl-c during deps log recompaction.

No test, because I can't think of a way to trigger this scenario
programmatically.

Part of issue #554.
