### PR TITLE
Add "environment" as a special attribute

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -777,7 +777,8 @@ keys.
   is a filename. When `command` is started via
   http://msdn.microsoft.com/en-us/library/windows/desktop/ms682425.aspx[
   CreateProcess], the contents of the named file will be used as the
-  `lpEnvironment` argument. This key is only supported on Windows.
+  `lpEnvironment` argument, and so will completely replace the environment
+  inherited by `command`. This key is only supported on Windows.
 
 `generator`:: if present, specifies that this rule is used to
   re-invoke the generator program.  Files built using `generator`

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -773,6 +773,12 @@ keys.
   the full command or its description; if a command fails, the full command
   line will always be printed before the command's output.
 
+`environment`:: _(Available since Ninja 1.3.)_ The value of this declaration
+  is a filename. When `command` is started via
+  http://msdn.microsoft.com/en-us/library/windows/desktop/ms682425.aspx[
+  CreateProcess], the contents of the named file will be used as the
+  `lpEnvironment` argument. This key is only supported on Windows.
+
 `generator`:: if present, specifies that this rule is used to
   re-invoke the generator program.  Files built using `generator`
   rules are treated specially in two ways: firstly, they will not be

--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -38,13 +38,15 @@ class Writer(object):
 
     def rule(self, name, command, description=None, depfile=None,
              generator=False, pool=None, restat=False, rspfile=None,
-             rspfile_content=None, deps=None):
+             rspfile_content=None, deps=None, environment=None):
         self._line('rule %s' % name)
         self.variable('command', command, indent=1)
         if description:
             self.variable('description', description, indent=1)
         if depfile:
             self.variable('depfile', depfile, indent=1)
+        if environment:
+            self.variable('environment', environment, indent=1)
         if generator:
             self.variable('generator', '1', indent=1)
         if pool:

--- a/src/build.cc
+++ b/src/build.cc
@@ -461,7 +461,7 @@ void Plan::Dump() {
 
 struct RealCommandRunner : public CommandRunner {
   RealCommandRunner(const BuildConfig& config, DiskInterface* disk_interface)
-      : config_(config), disk_interface_(disk_interface_) {}
+      : config_(config), disk_interface_(disk_interface) {}
   virtual ~RealCommandRunner() {}
   virtual bool CanRunMore();
   virtual bool StartCommand(Edge* edge);

--- a/src/build.cc
+++ b/src/build.cc
@@ -490,6 +490,8 @@ void RealCommandRunner::Abort() {
 }
 
 void* RealCommandRunner::GetEnvironmentBlockFromFile(const string& path) {
+  if (path.empty())
+    return NULL;
   map<string, void*>::iterator i = environments_.find(path);
   if (i != environments_.end())
     return i->second;

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -50,6 +50,7 @@ bool Rule::IsReservedBinding(const string& var) {
       var == "depfile" ||
       var == "description" ||
       var == "deps" ||
+      var == "environment" ||
       var == "generator" ||
       var == "pool" ||
       var == "restat" ||

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -73,6 +73,7 @@ TEST_F(ParserTest, RuleAttributes) {
 "  depfile = a\n"
 "  deps = a\n"
 "  description = a\n"
+"  environment = a\n"
 "  generator = a\n"
 "  restat = a\n"
 "  rspfile = a\n"

--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -44,7 +44,10 @@ Subprocess::~Subprocess() {
     Finish();
 }
 
-bool Subprocess::Start(SubprocessSet* set, const string& command) {
+bool Subprocess::Start(SubprocessSet* set,
+                       const string& command,
+                       void* envblock) {
+  assert(!envblock && "envblock only supported on Windows");
   int output_pipe[2];
   if (pipe(output_pipe) < 0)
     Fatal("pipe: %s", strerror(errno));
@@ -179,9 +182,9 @@ SubprocessSet::~SubprocessSet() {
     Fatal("sigprocmask: %s", strerror(errno));
 }
 
-Subprocess *SubprocessSet::Add(const string& command) {
+Subprocess *SubprocessSet::Add(const string& command, void* envblock) {
   Subprocess *subprocess = new Subprocess;
-  if (!subprocess->Start(this, command)) {
+  if (!subprocess->Start(this, command, envblock)) {
     delete subprocess;
     return 0;
   }

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -69,7 +69,9 @@ HANDLE Subprocess::SetupPipe(HANDLE ioport) {
   return output_write_child;
 }
 
-bool Subprocess::Start(SubprocessSet* set, const string& command) {
+bool Subprocess::Start(SubprocessSet* set,
+                       const string& command,
+                       void* envblock) {
   HANDLE child_pipe = SetupPipe(set->ioport_);
 
   SECURITY_ATTRIBUTES security_attributes;
@@ -98,7 +100,7 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
   // lines greater than 8,191 chars.
   if (!CreateProcessA(NULL, (char*)command.c_str(), NULL, NULL,
                       /* inherit handles */ TRUE, CREATE_NEW_PROCESS_GROUP,
-                      NULL, NULL,
+                      envblock, NULL,
                       &startup_info, &process_info)) {
     DWORD error = GetLastError();
     if (error == ERROR_FILE_NOT_FOUND) {
@@ -213,9 +215,9 @@ BOOL WINAPI SubprocessSet::NotifyInterrupted(DWORD dwCtrlType) {
   return FALSE;
 }
 
-Subprocess *SubprocessSet::Add(const string& command) {
+Subprocess *SubprocessSet::Add(const string& command, void* envblock) {
   Subprocess *subprocess = new Subprocess;
-  if (!subprocess->Start(this, command)) {
+  if (!subprocess->Start(this, command, envblock)) {
     delete subprocess;
     return 0;
   }

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -45,7 +45,7 @@ struct Subprocess {
 
  private:
   Subprocess();
-  bool Start(struct SubprocessSet* set, const string& command);
+  bool Start(struct SubprocessSet* set, const string& command, void* envblock);
   void OnPipeReady();
 
   string buf_;
@@ -75,7 +75,10 @@ struct SubprocessSet {
   SubprocessSet();
   ~SubprocessSet();
 
-  Subprocess* Add(const string& command);
+  Subprocess* Add(const string& command, void* envblock);
+  Subprocess* Add(const string& command) {
+    return Add(command, NULL);
+  }
   bool DoWork();
   Subprocess* NextFinished();
   void Clear();

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -195,3 +195,23 @@ TEST_F(SubprocessTest, ReadStdin) {
   ASSERT_EQ(1u, subprocs_.finished_.size());
 }
 #endif  // _WIN32
+
+#ifdef _WIN32
+TEST_F(SubprocessTest, Environment) {
+  // Make sure we read from the parent process without any override.
+  _putenv("FOO=parent");
+  Subprocess* subproc = subprocs_.Add("cmd /c echo foo is %FOO%");
+  while (!subproc->Done()) {
+    subprocs_.DoWork();
+  }
+  EXPECT_EQ("foo is parent\r\n", subproc->GetOutput());
+
+  // Make sure that passing an environment block is handled.
+  char* env_block = "FOO=blorp\0";
+  subproc = subprocs_.Add("cmd /c echo foo is %FOO%", env_block);
+  while (!subproc->Done()) {
+    subprocs_.DoWork();
+  }
+  EXPECT_EQ("foo is blorp\r\n", subproc->GetOutput());
+}
+#endif


### PR DESCRIPTION
Oops, forgot to click pull.

This optionally sets the environment block for Windows subprocesses. Do you think this is a reasonable approach to getting rid of the wrapper on win?
