### PR TITLE
Fix query tool with implicit deps

### DIFF
--- a/src/graph.h
+++ b/src/graph.h
@@ -217,7 +217,7 @@ struct ImplicitDepLoader {
   /// If we don't have a edge that generates this input already,
   /// create one; this makes us not abort if the input is missing,
   /// but instead will rebuild in that circumstance.
-  void CreatePhonyInEdge(Node* node);
+  Edge* CreatePhonyInEdge(Node* node);
 
   State* state_;
   DiskInterface* disk_interface_;


### PR DESCRIPTION
Two basic changes:

 * Move the RUN_AFTER_LOAD to after the Builder is constructed but before the build is run. Also pass Builder to tools.
 * When loading implicit dependencies, assign the dependent node as an output of its dependency.

I've got a generic ninja https://github.com/Valloric/YouCompleteMe `.ycm_extra_conf.py` file  in the works which relies on query actually producing useful information for all files (the file returns the flags necessary to build a given file path, which I would like to have ninja accurately provide for me).