### PR TITLE
drop the remaining usage of std:: qualifiers

### DIFF
--- a/src/hash_map.h
+++ b/src/hash_map.h
@@ -77,8 +77,8 @@ using __gnu_cxx::hash_map;
 
 namespace __gnu_cxx {
 template<>
-struct hash<std::string> {
-  size_t operator()(const std::string& s) const {
+struct hash<string> {
+  size_t operator()(const string& s) const {
     return hash<const char*>()(s.c_str());
   }
 };

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -548,7 +548,7 @@ int ToolUrtle(Globals* globals, int argc, char** argv) {
     if ('0' <= *p && *p <= '9') {
       count = count*10 + *p - '0';
     } else {
-      for (int i = 0; i < std::max(count, 1); ++i)
+      for (int i = 0; i < max(count, 1); ++i)
         printf("%c", *p);
       count = 0;
     }

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -245,7 +245,7 @@ bool SubprocessSet::DoWork() {
 
   if (subproc->Done()) {
     vector<Subprocess*>::iterator end =
-        std::remove(running_.begin(), running_.end(), subproc);
+        remove(running_.begin(), running_.end(), subproc);
     if (running_.end() != end) {
       finished_.push(subproc);
       running_.resize(end - running_.begin());


### PR DESCRIPTION
Signed-off-by: Thiago Farina tfarina@chromium.org
