### PR TITLE
Fix bootstrap on OS X.

### DIFF
--- a/platform_helper.py
+++ b/platform_helper.py
@@ -18,7 +18,8 @@
 import sys
 
 def platforms():
-    return ['linux', 'freebsd', 'openbsd', 'solaris', 'sunos5', 'mingw', 'msvc']
+    return ['linux', 'darwin', 'freebsd', 'openbsd', 'solaris', 'sunos5',
+            'mingw', 'msvc']
 
 class Platform( object ):
     def __init__( self, platform):


### PR DESCRIPTION
This was broken in 4c552c2c3cbc07acce9c1a379fee054a3f680100.
