### PR TITLE
fix truncate compile error in ninja_test on windows

### DIFF
--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -340,7 +340,8 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
   // Shorten the file, corrupting the last record.
   struct stat st;
   ASSERT_EQ(0, stat(kTestFilename, &st));
-  ASSERT_EQ(0, truncate(kTestFilename, st.st_size - 2));
+  string err;
+  ASSERT_TRUE(Truncate(kTestFilename, st.st_size - 2, &err));
 
   // Load the file again, add an entry.
   {


### PR DESCRIPTION
affects 1.3.0, maybe just retag?
