### PR TITLE
don't print output with extra newline

### DIFF
--- a/src/msvc_helper_main-win32.cc
+++ b/src/msvc_helper_main-win32.cc
@@ -123,7 +123,7 @@ int MSVCHelperMain(int argc, char** argv) {
     output = parser.Parse(output);
     WriteDepFileOrDie(output_filename, parser);
   }
-  printf("%s\n", output.c_str());
+  printf("%s", output.c_str());
 
   return exit_code;
 }


### PR DESCRIPTION
This messes up the gyp+.d-emitting case because it's expecting only filename.cc, not an extra newline, so the \n breaks one-line-output.

It doesn't look like there's a good reason to add the \n here in the other case? But I could be wrong.
