### PR TITLE
structs not classes.

### DIFF
--- a/src/line_printer.h
+++ b/src/line_printer.h
@@ -20,8 +20,7 @@ using namespace std;
 
 /// Prints lines of text, possibly overprinting previously printed lines
 /// if the terminal supports it.
-class LinePrinter {
- public:
+struct LinePrinter {
   LinePrinter();
 
   bool is_smart_terminal() const { return smart_terminal_; }

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -31,8 +31,7 @@ string StringPrintf(const char* format, ...) {
 }
 
 /// A test result printer that's less wordy than gtest's default.
-class LaconicPrinter : public testing::EmptyTestEventListener {
- public:
+struct LaconicPrinter : public testing::EmptyTestEventListener {
   LaconicPrinter() : tests_started_(0), test_count_(0), iteration_(0) {}
   virtual void OnTestProgramStart(const testing::UnitTest& unit_test) {
     test_count_ = unit_test.test_to_run_count();


### PR DESCRIPTION
For some reason that I do not, ninja prefers:

struct Foo {
  Foo();

 private:
  void Blah();
};

Rather than

class Foo {
 public:
  Foo();

 private:
  void Blah();
};

This catches the last two usages of "class" in the code base.

Signed-off-by: Thiago Farina tfarina@chromium.org
