### PR TITLE
do not unconditionally use PATH_MAX with getcwd

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -495,9 +495,13 @@ void EncodeJSONString(const char *str) {
 
 int ToolCompilationDatabase(Globals* globals, int argc, char* argv[]) {
   bool first = true;
-  char cwd[PATH_MAX];
+  vector<char> cwd;
 
-  if (!getcwd(cwd, PATH_MAX)) {
+  do {
+    cwd.resize(cwd.size() + 1024);
+    errno = 0;
+  } while (!getcwd(&cwd[0], cwd.size()) && errno == ERANGE);
+  if (errno != 0 && errno != ERANGE) {
     Error("cannot determine working directory: %s", strerror(errno));
     return 1;
   }
@@ -511,7 +515,7 @@ int ToolCompilationDatabase(Globals* globals, int argc, char* argv[]) {
           putchar(',');
 
         printf("\n  {\n    \"directory\": \"");
-        EncodeJSONString(cwd);
+        EncodeJSONString(&cwd[0]);
         printf("\",\n    \"command\": \"");
         EncodeJSONString((*e)->EvaluateCommand().c_str());
         printf("\",\n    \"file\": \"");


### PR DESCRIPTION
Instead, grow a buffer until getcwd either succeeds or fails with an errno different than ERANGE
(meaning the passed buffer was too short to represent the actual path).
Reset errno before calling getcwd to check it eventually did not fail.

This fixes a build failure on GNU/Hurd, which does not provide PATH_MAX (which is optional in POSIX).
