### PR TITLE
don't use PATH_MAX

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -86,7 +86,6 @@ bool Truncate(const string& path, size_t size, string* err);
 #define chdir _chdir
 #define strtoull _strtoui64
 #define getcwd _getcwd
-#define PATH_MAX _MAX_PATH
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
This allows building on Hurd, and fixes path truncation elsewhere.

That silly malloc(*2)/free() dance is required by POSIX, although I know of no system where that code path will be taken: at least glibc, MSVC crt and FreeBSD will malloc() for us.
