### PR TITLE
Added bootstrap/configure option to force pselect

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -36,6 +36,8 @@ parser.add_option('--x64', action='store_true',
 parser.add_option('--platform',
                   help='target platform (' + '/'.join(platform_helper.platforms()) + ')',
                   choices=platform_helper.platforms())
+parser.add_option('--force-pselect', action='store_true',
+                  help="ppoll() is used by default on Linux and OpenBSD, but older versions might need to use pselect instead",)
 (options, conf_args) = parser.parse_args()
 
 
@@ -107,6 +109,10 @@ else:
         cflags.append('-D_WIN32_WINNT=0x0501')
     if options.x64:
         cflags.append('-m64')
+if (platform.is_linux() or platform.is_openbsd()) and not options.force_pselect:
+    cflags.append('-DUSE_PPOLL')
+if options.force_pselect:
+    conf_args.append("--force-pselect")
 args.extend(cflags)
 args.extend(ldflags)
 binary = 'ninja.bootstrap'

--- a/configure.py
+++ b/configure.py
@@ -47,6 +47,8 @@ parser.add_option('--with-gtest', metavar='PATH',
 parser.add_option('--with-python', metavar='EXE',
                   help='use EXE as the Python interpreter',
                   default=os.path.basename(sys.executable))
+parser.add_option('--force-pselect', action='store_true',
+                  help="ppoll() is used by default on Linux and OpenBSD, but older versions might need to use pselect instead",)
 (options, args) = parser.parse_args()
 if args:
     print('ERROR: extra unparsed command-line arguments:', args)
@@ -162,6 +164,9 @@ else:
     elif options.profile == 'pprof':
         cflags.append('-fno-omit-frame-pointer')
         libs.extend(['-Wl,--no-as-needed', '-lprofiler'])
+
+if (platform.is_linux() or platform.is_openbsd()) and not options.force_pselect:
+    cflags.append('-DUSE_PPOLL')
 
 def shell_escape(str):
     """Escape str such that it's interpreted as a single argument by


### PR DESCRIPTION
All modern Linux kernels have ppoll() but sometimes
you might want to compile on something ancient.

This patch adds the possibility to force the use
of pselect() instead by passing --force-pselect
to bootstrap/configure.

The use of ppoll() is still default for Linux
and OpenBSD
