### PR TITLE
Fix mingw based builds. Fixes #587

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -361,7 +361,7 @@ int NinjaMain::ToolBrowse(int argc, char* argv[]) {
 }
 #endif  // _WIN32
 
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 int NinjaMain::ToolMSVC(int argc, char* argv[]) {
   // Reset getopt: push one argument onto the front of argv, reset optind.
   argc++;
@@ -636,7 +636,7 @@ const Tool* ChooseTool(const string& tool_name) {
     { "browse", "browse dependency graph in a web browser",
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolBrowse },
 #endif
-#if defined(_WIN32)
+#if defined(_MSC_VER)
     { "msvc", "build helper for MSVC cl.exe (EXPERIMENTAL)",
       Tool::RUN_AFTER_FLAGS, &NinjaMain::ToolMSVC },
 #endif


### PR DESCRIPTION
Tested with mingw-w64 g++ 4.8.0:

```
C:\Users\Jon\Documents\CDev\ninja-git>python configure.py --platform=mingw
warning: A compatible version of re2c (>= 0.11.3) was not found; changes to src/*.in.cc will not affect your build.
wrote build.ninja.

C:\Users\Jon\Documents\CDev\ninja-git>vim build.ninja

C:\Users\Jon\Documents\CDev\ninja-git>ninja
Recompacting log...
[4/26] CXX build\build_log.o
src\build_log.cc: In member function 'void BuildLog::WriteEntry(FILE*, const BuildLog::LogEntry&)':
src\build_log.cc:347:51: warning: 'I' flag used with '%x' gnu_printf format [-Wformat=]
           entry.output.c_str(), entry.command_hash);
                                                   ^
src\build_log.cc:347:51: warning: format '%x' expects argument of type 'unsigned int', but argument 7 has type 'uint64_t {aka long long unsigned int}' [-Wformat=]
[25/26] AR build\libninja.a
        1 file(s) moved.
[26/26] LINK ninja.exe
```

Tested with winsdk 7.1 

```
C:\Users\Jon\Documents\CDev\ninja-git>cl /?
Microsoft (R) 32-bit C/C++ Optimizing Compiler Version 16.00.30319.01 for 80x86

C:\Users\Jon\Documents\CDev\ninja-git>python configure.py --platform=msvc
warning: A compatible version of re2c (>= 0.11.3) was not found; changes to src/*.in.cc wi
ll not affect your build.
wrote build.ninja.

C:\Users\Jon\Documents\CDev\ninja-git>ninja
[27/27] LINK ninja.exe
Generating code
Finished generating code
```
