### PR TITLE
Fix restat builds with edges generating headers depended on through deps...

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -418,6 +418,7 @@ bool ImplicitDepLoader::LoadDepsFromLog(Edge* edge, TimeStamp* deps_mtime,
       PreallocateSpace(edge, deps->node_count);
   for (int i = 0; i < deps->node_count; ++i, ++implicit_dep) {
     *implicit_dep = deps->nodes[i];
+    deps->nodes[i]->AddOutEdge(edge);
     CreatePhonyInEdge(*implicit_dep);
   }
   return true;


### PR DESCRIPTION
... files

in deps mode.

`ImplicitDepLoader::LoadDepFile()` already adds a depfile edge from every file
mentioned in a depfile to the depfile's output.

`ImplicitDepLoader::LoadDepsFromLog()` didn't do this yet, so add it. Else,
if a restat rule clears a generated .h file, this wouldn't propagate to cc files
depending on that .h file through a depfile.

Fixues issue #590.

Take a careful look, I mostly just debugged why the build got stuck and then noticed that the two ways of loading depfiles are different and made them look the same. I'm not sure if that's the right fix (but it does seem like it).
