### PR TITLE
Don't allow variables to self-reference

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1190,7 +1190,7 @@ TEST_F(BuildTest, RspFileSuccess)
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
     "rule cat_rsp\n"
     "  command = cat $rspfile > $out\n"
-    "  rspfile = $rspfile\n"
+    "  rspfile = rspfile\n"
     "  rspfile_content = $long_command\n"
     "build out1: cat in\n"
     "build out2: cat_rsp in\n"
@@ -1231,7 +1231,7 @@ TEST_F(BuildTest, RspFileFailure) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
     "rule fail\n"
     "  command = fail\n"
-    "  rspfile = $rspfile\n"
+    "  rspfile = rspfile\n"
     "  rspfile_content = $long_command\n"
     "build out: fail in\n"
     "  rspfile = out.rsp\n"
@@ -1270,7 +1270,7 @@ TEST_F(BuildWithLogTest, RspFileCmdLineChange) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
     "rule cat_rsp\n"
     "  command = cat $rspfile > $out\n"
-    "  rspfile = $rspfile\n"
+    "  rspfile = rspfile\n"
     "  rspfile_content = $long_command\n"
     "build out: cat_rsp in\n"
     "  rspfile = out.rsp\n"

--- a/src/clean_test.cc
+++ b/src/clean_test.cc
@@ -283,7 +283,7 @@ TEST_F(CleanTest, CleanRspFile) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule cc\n"
 "  command = cc $in > $out\n"
-"  rspfile = $rspfile\n"
+"  rspfile = rspfile\n"
 "  rspfile_content=$in\n"
 "build out1: cc in1\n"
 "  rspfile = cc1.rsp\n"
@@ -301,7 +301,7 @@ TEST_F(CleanTest, CleanRsp) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule cat_rsp \n"
 "  command = cat $rspfile > $out\n"
-"  rspfile = $rspfile\n"
+"  rspfile = rspfile\n"
 "  rspfile_content = $in\n"
 "build in1: cat src1\n"
 "build out1: cat in1\n"

--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -592,7 +592,8 @@ yy92:
   return true;
 }
 
-bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
+bool Lexer::ReadEvalString(const StringPiece* varname, EvalString* eval,
+                           bool path, string* err) {
   const char* p = ofs_;
   const char* q;
   const char* start;
@@ -749,7 +750,11 @@ yy110:
 	goto yy124;
 yy111:
 	{
-      eval->AddSpecial(StringPiece(start + 1, p - start - 1));
+      StringPiece var(start + 1, p - start - 1);
+      if (varname && var == *varname) {
+        return Error("variable cannot use itself in definition", err);
+      }
+      eval->AddSpecial(var);
       continue;
     }
 yy112:
@@ -785,7 +790,11 @@ yy118:
 yy121:
 	++p;
 	{
-      eval->AddSpecial(StringPiece(start + 2, p - start - 3));
+      StringPiece var(start + 2, p - start - 3);
+      if (varname && var == *varname) {
+        return Error("variable cannot use itself in definition", err);
+      }
+      eval->AddSpecial(var);
       continue;
     }
 yy123:

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -77,13 +77,13 @@ struct Lexer {
   /// Returns false only on error, returned path may be empty if a delimiter
   /// (space, newline) is hit.
   bool ReadPath(EvalString* path, string* err) {
-    return ReadEvalString(path, true, err);
+    return ReadEvalString(NULL, path, true, err);
   }
 
   /// Read the value side of a var = value line (complete with $escapes).
   /// Returns false only on error.
-  bool ReadVarValue(EvalString* value, string* err) {
-    return ReadEvalString(value, false, err);
+  bool ReadVarValue(const StringPiece& varname, EvalString* value, string* err) {
+    return ReadEvalString(&varname, value, false, err);
   }
 
   /// Construct an error message with context.
@@ -94,7 +94,8 @@ private:
   void EatWhitespace();
 
   /// Read a $-escaped string.
-  bool ReadEvalString(EvalString* eval, bool path, string* err);
+  bool ReadEvalString(const StringPiece* varname, EvalString* eval, bool path,
+                      string* err);
 
   StringPiece filename_;
   StringPiece input_;

--- a/src/lexer.in.cc
+++ b/src/lexer.in.cc
@@ -196,7 +196,8 @@ bool Lexer::ReadIdent(string* out) {
   return true;
 }
 
-bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
+bool Lexer::ReadEvalString(const StringPiece* varname, EvalString* eval,
+                           bool path, string* err) {
   const char* p = ofs_;
   const char* q;
   const char* start;
@@ -230,11 +231,19 @@ bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
       continue;
     }
     "${"varname"}" {
-      eval->AddSpecial(StringPiece(start + 2, p - start - 3));
+      StringPiece var(start + 2, p - start - 3);
+      if (varname && var == *varname) {
+        return Error("variable cannot use itself in definition", err);
+      }
+      eval->AddSpecial(var);
       continue;
     }
     "$"simple_varname {
-      eval->AddSpecial(StringPiece(start + 1, p - start - 1));
+      StringPiece var(start + 1, p - start - 1);
+      if (varname && var == *varname) {
+        return Error("variable cannot use itself in definition", err);
+      }
+      eval->AddSpecial(var);
       continue;
     }
     "$:" {

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -185,7 +185,7 @@ bool ManifestParser::ParseLet(string* key, EvalString* value, string* err) {
     return false;
   if (!ExpectToken(Lexer::EQUALS, err))
     return false;
-  if (!lexer_.ReadVarValue(value, err))
+  if (!lexer_.ReadVarValue(*key, value, err))
     return false;
   return true;
 }

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -121,7 +121,7 @@ TEST_F(ParserTest, ResponseFiles) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(
 "rule cat_rsp\n"
 "  command = cat $rspfile > $out\n"
-"  rspfile = $rspfile\n"
+"  rspfile = rspfile\n"
 "  rspfile_content = $in\n"
 "\n"
 "build out: cat_rsp in\n"
@@ -132,7 +132,7 @@ TEST_F(ParserTest, ResponseFiles) {
   EXPECT_EQ("cat_rsp", rule->name());
   EXPECT_EQ("[cat ][$rspfile][ > ][$out]",
             rule->GetBinding("command")->Serialize());
-  EXPECT_EQ("[$rspfile]", rule->GetBinding("rspfile")->Serialize());
+  EXPECT_EQ("[rspfile]", rule->GetBinding("rspfile")->Serialize());
   EXPECT_EQ("[$in]", rule->GetBinding("rspfile_content")->Serialize());
 }
 


### PR DESCRIPTION
It might be useful for variables to be able to reference their
parent's scope, but this is simpler.

Fixes issue #594.
