### PR TITLE
Add stdlib.h include for atol().

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -15,6 +15,7 @@
 #include "manifest_parser.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <vector>
 
 #include "graph.h"


### PR DESCRIPTION
This attempts to fix issue #600. `man atol` claims that atol() is in
stdlib.h, which wasn't included yet.
