### PR TITLE
Make width of failure printouts configurable.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -118,8 +118,12 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
     PrintStatus(edge);
 
   // Print the command that is spewing before printing its output.
-  if (!success)
-    printer_.PrintOnNewLine("FAILED: " + edge->EvaluateCommand() + "\n");
+  if (!success) {
+    string error_msg = "FAILED: " + edge->EvaluateCommand() + "\n";
+    if (config_.max_error_width)
+      error_msg = ElideMiddle(error_msg, config_.max_error_width);
+    printer_.PrintOnNewLine(error_msg);
+  }
 
   if (!output.empty()) {
     // ninja sets stdout and stderr of subprocesses to a pipe, to be able to

--- a/src/build.h
+++ b/src/build.h
@@ -123,7 +123,8 @@ struct CommandRunner {
 /// Options (e.g. verbosity, parallelism) passed to a build.
 struct BuildConfig {
   BuildConfig() : verbosity(NORMAL), dry_run(false), parallelism(1),
-                  failures_allowed(1), max_load_average(-0.0f) {}
+                  failures_allowed(1), max_load_average(-0.0f),
+                  max_error_width(0) {}
 
   enum Verbosity {
     NORMAL,
@@ -137,6 +138,8 @@ struct BuildConfig {
   /// The maximum load average we must not exceed. A negative value
   /// means that we do not have any limit.
   double max_load_average;
+  /// Maximum width of error output lines.
+  int max_error_width;
 };
 
 /// Builder wraps the build process: starting commands, updating status.

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -185,7 +185,8 @@ void Usage(const BuildConfig& config) {
 "\n"
 "  -d MODE  enable debugging (use -d list to list modes)\n"
 "  -t TOOL  run a subtool (use -t list to list subtools)\n"
-"    terminates toplevel options; further flags are passed to the tool\n",
+"    terminates toplevel options; further flags are passed to the tool\n"
+"  -W WIDTH maximum line length of output for errors.\n",
           kNinjaVersion, config.parallelism);
 }
 
@@ -863,7 +864,7 @@ int ReadFlags(int* argc, char*** argv,
 
   int opt;
   while (!options->tool &&
-         (opt = getopt_long(*argc, *argv, "d:f:j:k:l:nt:vC:h", kLongOptions,
+         (opt = getopt_long(*argc, *argv, "d:f:j:k:l:nt:vC:W:h", kLongOptions,
                             NULL)) != -1) {
     switch (opt) {
       case 'd':
@@ -918,6 +919,14 @@ int ReadFlags(int* argc, char*** argv,
       case OPT_VERSION:
         printf("%s\n", kNinjaVersion);
         return 0;
+      case 'W': {
+        char* end;
+        int value = strtol(optarg, &end, 10);
+        if (end == optarg)
+          Fatal("-W parameter not numeric.");
+        config->max_error_width = value;
+        break;
+      }
       case 'h':
       default:
         Usage(*config);


### PR DESCRIPTION
On some terminals (I'm looking at you, emacs) react very poorly to
extremely wide lines. Add a -W command line option to request failure
messages are trimmed for faster display.
