### PR TITLE
make build/manual.xml xmllint clean

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -236,10 +236,10 @@ generates an image for Ninja itself.  If no target is given generate a
 graph for all root targets.
 
 `targets`:: output a list of targets either by rule or by depth.  If used
-like +ninja -t targets rule _name_+ it prints the list of targets
+like +ninja -t targets rule name+ it prints the list of targets
 using the given rule to be built.  If no rule is given, it prints the source
 files (the leaves of the graph).  If used like
-+ninja -t targets depth _digit_+ it
++ninja -t targets depth digit+ it
 prints the list of targets in a depth-first manner starting by the root
 targets (the ones with no outputs). Indentation is used to mark dependencies.
 If the depth is zero it prints all targets. If no arguments are provided
@@ -259,7 +259,7 @@ reference for the +generator+ attribute>>).  Additional arguments are
 targets, which removes the given targets and recursively all files
 built for them.
 +
-If used like +ninja -t clean -r _rules_+ it removes all files built using
+If used like +ninja -t clean -r rules+ it removes all files built using
 the given rules.
 +
 Files created but not referenced in the graph are not removed. This
@@ -357,7 +357,7 @@ Build statements
 
 Build statements declare a relationship between input and output
 files.  They begin with the `build` keyword, and have the format
-+build _outputs_: _rulename_ _inputs_+.  Such a declaration says that
++build outputs: rulename inputs+.  Such a declaration says that
 all of the output files are derived from the input files.  When the
 output files are missing or when the inputs change, Ninja will run the
 rule to regenerate the outputs.
@@ -450,7 +450,7 @@ A default target statement causes Ninja to build only a given subset
 of output files if none are specified on the command line.
 
 Default target statements begin with the `default` keyword, and have
-the format +default _targets_+.  A default target statement must appear
+the format +default targets+.  A default target statement must appear
 after the build statement that declares the target as an output file.
 They are cumulative, so multiple statements may be used to extend
 the list of default targets.  For example:
@@ -649,23 +649,23 @@ Ninja file reference
 
 A file is a series of declarations.  A declaration can be one of:
 
-1. A rule declaration, which begins with +rule _rulename_+, and
+1. A rule declaration, which begins with +rule rulename+, and
    then has a series of indented lines defining variables.
 
-2. A build edge, which looks like +build _output1_ _output2_:
-   _rulename_ _input1_ _input2_+. +
+2. A build edge, which looks like +build output1 output2:
+   rulename input1 input2+. +
    Implicit dependencies may be tacked on the end with +|
-   _dependency1_ _dependency2_+. +
+   dependency1 dependency2+. +
    Order-only dependencies may be tacked on the end with +||
-   _dependency1_ _dependency2_+.  (See <<ref_dependencies,the reference on
+   dependency1 dependency2+.  (See <<ref_dependencies,the reference on
    dependency types>>.)
 
-3. Variable declarations, which look like +_variable_ = _value_+.
+3. Variable declarations, which look like +variable = value+.
 
-4. Default target statements, which look like +default _target1_ _target2_+.
+4. Default target statements, which look like +default target1 target2+.
 
-5. References to more files, which look like +subninja _path_+ or
-   +include _path_+.  The difference between these is explained below
+5. References to more files, which look like +subninja path+ or
+   +include path+.  The difference between these is explained below
    <<ref_scope,in the discussion about scoping>>.
 
 Lexical syntax
@@ -834,8 +834,8 @@ This is the standard form of dependency to be used for e.g. the
 source file of a compile command.
 
 2. _Implicit dependencies_, either as picked up from
-   a `depfile` attribute on a rule or from the syntax +| _dep1_
-   _dep2_+ on the end of a build line.  The semantics are identical to
+   a `depfile` attribute on a rule or from the syntax +| dep1
+   dep2+ on the end of a build line.  The semantics are identical to
    explicit dependencies, the only difference is that implicit dependencies
    don't show up in the `$in` variable.
 +
@@ -847,8 +847,8 @@ changes to the script should cause the output to rebuild.
 Note that dependencies as loaded through depfiles have slightly different
 semantics, as described in the <<ref_rule,rule reference>>.
 
-3. _Order-only dependencies_, expressed with the syntax +|| _dep1_
-   _dep2_+ on the end of a build line.  When these are out of date, the
+3. _Order-only dependencies_, expressed with the syntax +|| dep1
+   dep2+ on the end of a build line.  When these are out of date, the
    output is not rebuilt until they are built, but changes in order-only
    dependencies alone do not cause the output to be rebuilt.
 +


### PR DESCRIPTION
doc/manual.asciidoc had various instances of emphasis inside of a literal
block that the docbook dtd declares as invalid.  By removing them, the output
build/manual.xml is now xmllint clean.

You can verify the errors via "xmllint --noout --valid build/manual.xml"
