### PR TITLE
Use fwrite to print whatever the subcommand wrote

### DIFF
--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -104,6 +104,10 @@ void LinePrinter::Print(string to_print, LineType type) {
 void LinePrinter::PrintOnNewLine(const string& to_print) {
   if (!have_blank_line_)
     printf("\n");
-  printf("%s", to_print.c_str());
+  if (!to_print.empty()) {
+    // Avoid printf and C strings, since the actual output might contain null
+    // bytes like UTF-16 does (yuck).
+    fwrite(&to_print[0], sizeof(char), to_print.size(), stdout);
+  }
   have_blank_line_ = to_print.empty() || *to_print.rbegin() == '\n';
 }


### PR DESCRIPTION
Subcommands can write things like UTF-16, which some terminals can
understand.  printf() will interpret the null bytes as the end of the
string.

In particular, MSVC's assert() will print wide characters by default,
and I can't find a way to disable it, leading to clang assertion
failures looking like:
  FAILED: ...clang.exe ...
  Aninja: build stopped: subcommand failed.

With this fix, I get the desired:
  FAILED: ...clang.exe ...
  Assertion failed: SymbolMap...
  ninja: build stopped: subcommand failed.
