### PR TITLE
Add a 'recompact' tool, which forces recompaction of the build and deps ...

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -109,7 +109,6 @@ BuildLog::~BuildLog() {
 
 bool BuildLog::OpenForWrite(const string& path, string* err) {
   if (needs_recompaction_) {
-    Close();
     if (!Recompact(path, err))
       return false;
   }
@@ -351,6 +350,7 @@ bool BuildLog::Recompact(const string& path, string* err) {
   METRIC_RECORD(".ninja_log recompact");
   printf("Recompacting log...\n");
 
+  Close();
   string temp_path = path + ".recompact";
   FILE* f = fopen(temp_path.c_str(), "wb");
   if (!f) {

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -43,7 +43,6 @@ DepsLog::~DepsLog() {
 
 bool DepsLog::OpenForWrite(const string& path, string* err) {
   if (needs_recompaction_) {
-    Close();
     if (!Recompact(path, err))
       return false;
   }
@@ -265,6 +264,7 @@ bool DepsLog::Recompact(const string& path, string* err) {
   METRIC_RECORD(".ninja_deps recompact");
   printf("Recompacting deps...\n");
 
+  Close();
   string temp_path = path + ".recompact";
 
   // OpenForWrite() opens for append.  Make sure it's not appending to a

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -110,15 +110,16 @@ struct NinjaMain {
   int ToolCommands(int argc, char* argv[]);
   int ToolClean(int argc, char* argv[]);
   int ToolCompilationDatabase(int argc, char* argv[]);
+  int ToolRecompact(int argc, char* argv[]);
   int ToolUrtle(int argc, char** argv);
 
   /// Open the build log.
   /// @return false on error.
-  bool OpenBuildLog();
+  bool OpenBuildLog(bool recompact_only = false);
 
   /// Open the deps log: load it, then open for writing.
   /// @return false on error.
-  bool OpenDepsLog();
+  bool OpenDepsLog(bool recompact_only = false);
 
   /// Ensure the build directory exists, creating it if necessary.
   /// @return false on error.
@@ -602,6 +603,17 @@ int NinjaMain::ToolCompilationDatabase(int argc, char* argv[]) {
   return 0;
 }
 
+int NinjaMain::ToolRecompact(int argc, char* argv[]) {
+  if (!EnsureBuildDirExists())
+    return 1;
+
+  if (!OpenBuildLog(/*recompact_only=*/true) ||
+      !OpenDepsLog(/*recompact_only=*/true))
+    return 1;
+
+  return 0;
+}
+
 int NinjaMain::ToolUrtle(int argc, char** argv) {
   // RLE encoded.
   const char* urtle =
@@ -652,6 +664,8 @@ const Tool* ChooseTool(const string& tool_name) {
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolTargets },
     { "compdb",  "dump JSON compilation database to stdout",
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolCompilationDatabase },
+    { "recompact",  "recompacts ninja-internal data structures",
+      Tool::RUN_AFTER_LOAD, &NinjaMain::ToolRecompact },
     { "urtle", NULL,
       Tool::RUN_AFTER_FLAGS, &NinjaMain::ToolUrtle },
     { NULL, NULL, Tool::RUN_AFTER_FLAGS, NULL }
@@ -712,7 +726,7 @@ bool DebugEnable(const string& name) {
   }
 }
 
-bool NinjaMain::OpenBuildLog() {
+bool NinjaMain::OpenBuildLog(bool recompact_only) {
   string log_path = ".ninja_log";
   if (!build_dir_.empty())
     log_path = build_dir_ + "/" + log_path;
@@ -728,6 +742,13 @@ bool NinjaMain::OpenBuildLog() {
     err.clear();
   }
 
+  if (recompact_only) {
+    bool success = build_log_.Recompact(log_path, &err);
+    if (!success)
+      Error("failed recompaction: %s", err.c_str());
+    return success;
+  }
+
   if (!config_.dry_run) {
     if (!build_log_.OpenForWrite(log_path, &err)) {
       Error("opening build log: %s", err.c_str());
@@ -740,7 +761,7 @@ bool NinjaMain::OpenBuildLog() {
 
 /// Open the deps log: load it, then open for writing.
 /// @return false on error.
-bool NinjaMain::OpenDepsLog() {
+bool NinjaMain::OpenDepsLog(bool recompact_only) {
   string path = ".ninja_deps";
   if (!build_dir_.empty())
     path = build_dir_ + "/" + path;
@@ -754,6 +775,13 @@ bool NinjaMain::OpenDepsLog() {
     // Hack: Load() can return a warning via err by returning true.
     Warning("%s", err.c_str());
     err.clear();
+  }
+
+  if (recompact_only) {
+    bool success = deps_log_.Recompact(path, &err);
+    if (!success)
+      Error("failed recompaction: %s", err.c_str());
+    return success;
   }
 
   if (!config_.dry_run) {


### PR DESCRIPTION
...logs.

This is useful for performance comparisons between two build directories.

Not sure if this is generally useful. Maybe it should be a -d option instead, or maybe it should stay in my repo. Let me know!
