### PR TITLE
Reuse ManifestParser::Load() in ManifestParser::ParseFileInclude().

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -37,6 +37,14 @@ bool ManifestParser::Load(const string& filename, string* err) {
     *err = "loading '" + filename + "': " + read_err;
     return false;
   }
+
+  // The lexer needs a nul byte at the end of its input, to know when it's done.
+  // It takes a StringPiece, and StringPiece's string constructor uses
+  // string::data().  data()'s return value isn't guaranteed to be
+  // null-terminated (although in practice - libc++, libstdc++, msvc's stl --
+  // it is, and C++11 demands that too), so add an explicit nul byte.
+  contents.resize(contents.size() + 1);
+
   return Parse(filename, contents, err);
 }
 


### PR DESCRIPTION
ParseFileInclude() was doing the work that Load() was doing. Instead, just
make it call Load().

Also, remove a FIXME about using ReadPath() in ParseFileInclude() -- it's
already being used. (The FIXME was added in the same commit that added the
call to ReadPath() -- 8a0c96075786c19 -- it probably should've been deleted
before that commit.)

Also, remove a `contents.resize(contents.size() + 10);`. It's not clear what
it's for, but if it was important then ManifestParser::ParseFileInclude()
would have needed that call too, and it didn't have it.

No intended behavior change.
