### PR TITLE
Fix diagnostic formatting regression caused by adaa91a33eb2cf23b88.

### DIFF
--- a/src/manifest_parser.h
+++ b/src/manifest_parser.h
@@ -35,7 +35,7 @@ struct ManifestParser {
   ManifestParser(State* state, FileReader* file_reader);
 
   /// Load and parse a file.
-  bool Load(const string& filename, string* err);
+  bool Load(const string& filename, string* err, Lexer* parent=NULL);
 
   /// Parse a text string of input.  Used by tests.
   bool ParseTest(const string& input, string* err) {

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -762,6 +762,17 @@ TEST_F(ParserTest, Include) {
   EXPECT_EQ("inner", state.bindings_.LookupVariable("var"));
 }
 
+TEST_F(ParserTest, BrokenInclude) {
+  files_["include.ninja"] = "build\n";
+  ManifestParser parser(&state, this);
+  string err;
+  EXPECT_FALSE(parser.ParseTest("include include.ninja\n", &err));
+  EXPECT_EQ("include.ninja:1: expected path\n"
+            "build\n"
+            "     ^ near here"
+            , err);
+}
+
 TEST_F(ParserTest, Implicit) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(
 "rule cat\n"


### PR DESCRIPTION
Ninja regressed to include a location for every file on the include stack for
nested diagnostics, i.e. it would print:

  input:1: include.ninja:1: expected path

Fix this so that it prints only the current file location, like it used to:

  include.ninja:1: expected path

Also add a test for this.
