### PR TITLE
Proposed/still running

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -74,6 +74,7 @@ BuildStatus::BuildStatus(const BuildConfig& config)
     : config_(config),
       start_time_millis_(GetTimeMillis()),
       started_edges_(0), finished_edges_(0), total_edges_(0),
+      next_progress_update_at_(0),
       progress_status_format_(NULL),
       overall_rate_(), current_rate_(config.parallelism) {
 
@@ -95,6 +96,8 @@ void BuildStatus::BuildEdgeStarted(Edge* edge) {
   running_edges_.insert(make_pair(edge, start_time));
   ++started_edges_;
 
+  RestartStillRunningDelay();
+
   PrintStatus(edge);
 }
 
@@ -113,6 +116,8 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
 
   if (config_.verbosity == BuildConfig::QUIET)
     return;
+
+  RestartStillRunningDelay();
 
   if (printer_.is_smart_terminal())
     PrintStatus(edge);
@@ -141,6 +146,28 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
       final_output = output;
     printer_.PrintOnNewLine(final_output);
   }
+}
+
+void BuildStatus::BuildEdgeStillRunning(Edge* edge)
+{
+  if (config_.verbosity == BuildConfig::QUIET || !printer_.is_smart_terminal())
+    return;
+
+  int64_t now = GetTimeMillis();
+  if (next_progress_update_at_ > now)
+    return;
+
+  static int ctr = 0;
+  char status[32];
+  snprintf(status, sizeof(status), " (still running.. %c)", "/-\\|"[ctr++ % 4]);
+
+  PrintStatus(edge, status);
+  next_progress_update_at_ = now + 1000/kStillRunningFPS;
+}
+
+void BuildStatus::RestartStillRunningDelay()
+{
+  next_progress_update_at_ = GetTimeMillis() + kStillRunningDelayMsec;
 }
 
 void BuildStatus::BuildFinished() {
@@ -230,7 +257,7 @@ string BuildStatus::FormatProgressStatus(
   return out;
 }
 
-void BuildStatus::PrintStatus(Edge* edge) {
+void BuildStatus::PrintStatus(Edge* edge, const char* trailer) {
   if (config_.verbosity == BuildConfig::QUIET)
     return;
 
@@ -244,7 +271,7 @@ void BuildStatus::PrintStatus(Edge* edge) {
     overall_rate_.Restart();
     current_rate_.Restart();
   }
-  to_print = FormatProgressStatus(progress_status_format_) + to_print;
+  to_print = FormatProgressStatus(progress_status_format_) + to_print + trailer;
 
   printer_.Print(to_print,
                  force_full_command ? LinePrinter::FULL : LinePrinter::ELIDE);
@@ -505,6 +532,9 @@ bool RealCommandRunner::WaitForCommand(Result* result) {
     bool interrupted = subprocs_.DoWork();
     if (interrupted)
       return false;
+
+    result->status = ExitTimeout;
+    return true;
   }
 
   result->status = subproc->Finish();
@@ -636,6 +666,11 @@ bool Builder::Build(string* err) {
         status_->BuildFinished();
         *err = "interrupted by user";
         return false;
+      }
+
+      if (result.status == ExitTimeout) {
+        ReportProgress();
+        continue;
       }
 
       --pending_commands;
@@ -801,6 +836,14 @@ bool Builder::FinishCommand(CommandRunner::Result* result, string* err) {
     }
   }
   return true;
+}
+
+void Builder::ReportProgress(void)
+{
+  vector<Edge*> active_edges = command_runner_->GetActiveEdges();
+  if (active_edges.size() < 1)
+    return;
+  status_->BuildEdgeStillRunning(active_edges[0]);
 }
 
 bool Builder::ExtractDeps(CommandRunner::Result* result,

--- a/src/exit_status.h
+++ b/src/exit_status.h
@@ -18,7 +18,8 @@
 enum ExitStatus {
   ExitSuccess,
   ExitFailure,
-  ExitInterrupted
+  ExitInterrupted,
+  ExitTimeout
 };
 
 #endif  // NINJA_EXIT_STATUS_H_

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -111,3 +111,11 @@ void LinePrinter::PrintOnNewLine(const string& to_print) {
   }
   have_blank_line_ = to_print.empty() || *to_print.rbegin() == '\n';
 }
+
+void LinePrinter::PrintRaw(const string& to_print) {
+  if (to_print.empty())
+    return;
+  fwrite(to_print.c_str(), to_print.size(), 1, stdout);
+  fflush(stdout);
+  have_blank_line_ =  (*to_print.rbegin() == '\n');
+}

--- a/src/line_printer.h
+++ b/src/line_printer.h
@@ -37,6 +37,10 @@ struct LinePrinter {
   /// Prints a string on a new line, not overprinting previous output.
   void PrintOnNewLine(const string& to_print);
 
+  /// Prints the string at current cursor position as-is, not overprinting
+  /// previous output and flushes the stdout.
+  void PrintRaw(const string& to_print);
+
  private:
   /// Whether we can do fancy terminal control codes.
   bool smart_terminal_;

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -95,4 +95,9 @@ struct SubprocessSet {
 #endif
 };
 
+/// SubprocessSet::DoWork() may return on a timeout
+///  after waiting for kPollTimeoutNano ns, allowing
+///  ninja to update progress of long-running tasks.
+const long kPollTimeoutNano = 1000000000L/20; // = 20Hz
+
 #endif // NINJA_SUBPROCESS_H_


### PR DESCRIPTION
Due to a somewhat popular demand..

There is currently no infrastructure to test this with gtest, but to avoid "great" being an enemy of "good" publishing this anyway. I did tested it manually using the following manifest: git show 22aa5f3:tst4.ninja, for what it worth (building different targets in separate and together)..

This pull request provides the following features:
- If ninja is running one or more commands lasting longer than 3 sec w/o status being updated (e.g., nothing starts/finishes) ninja starts printing "xxx (still running ) with '\' spinning moderately (test with: './ninja -f tst.ninja e5').
- If only one command is currently running, and no new commands can be started and the command emits output while running (e.g., a long-running generator), then ninja starts dumping the output immediately, in real-time, w/o waiting for the command to finish (test with: './ninja -f tst.ninja e6').
