### PR TITLE
Fix tabs/spaces inconsistency.

### DIFF
--- a/platform_helper.py
+++ b/platform_helper.py
@@ -41,9 +41,8 @@ class Platform( object ):
             self._platform = 'mingw'
         elif self._platform.startswith('win'):
             self._platform = 'msvc'
-	elif self._platform.startswith('bitrig'):
-	    self._platform = 'bitrig'
-
+        elif self._platform.startswith('bitrig'):
+            self._platform = 'bitrig'
 
     def platform(self):
         return self._platform


### PR DESCRIPTION
boostrap.py failed with a traceback due to tabs/spaces inconsistency in platform_helper.py.

Works fine with this change applied.
