### PR TITLE
Fix for #638 incorrect number of total edges in the status message

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -362,11 +362,8 @@ void Plan::ResumeDelayedJobs(Edge* edge) {
 void Plan::EdgeFinished(Edge* edge) {
   map<Edge*, bool>::iterator i = want_.find(edge);
   assert(i != want_.end());
-  if (i->second) {
+  if (i->second)
     --wanted_edges_;
-    if (!edge->is_phony())
-      --command_edges_;
-  }
   want_.erase(i);
   edge->outputs_ready_ = true;
 

--- a/src/build.h
+++ b/src/build.h
@@ -51,7 +51,7 @@ struct Plan {
   Edge* FindWork();
 
   /// Returns true if there's more work to be done.
-  bool more_to_do() const { return (command_edges_ > 0); }
+  bool more_to_do() const { return (wanted_edges_ > 0) && (command_edges_ > 0); }
 
   /// Dumps the current state of the plan.
   void Dump();


### PR DESCRIPTION
My previous pull request #633 (ref #424) had a bug in it which caused incorrect total edge counts whilst building in some restat cases, issue #638. 
The fix reverts the change to the command_edges_ behaviour, and amends the more_to_do function to solving both #633 / #424 and #638.

The variable command_edges_ is the total number of non-phony (command) edges, not the total number of remaining command edges as I had implied from reading the code.
