### PR TITLE
Add a test for issue #638.

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1018,6 +1018,7 @@ TEST_F(BuildWithLogTest, RestatTest) {
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
   ASSERT_EQ("", err);
+  EXPECT_EQ("[3/3]", builder_.status_->FormatProgressStatus("[%s/%t]"));
   command_runner_.commands_ran_.clear();
   state_.Reset();
 


### PR DESCRIPTION
Without the fix in #639, the test would fail with

```
[47/169] BuildWithLogTest.RestatTest
*** Failure in src/build_test.cc:1021
Value of: builder_.status_->FormatProgressStatus("[%s/%t]")
  Actual: "[3/2]"
Expected: "[3/3]"
```
