### PR TITLE
Suffix depslog path records with their expected index.

### DIFF
--- a/src/deps_log.h
+++ b/src/deps_log.h
@@ -52,7 +52,9 @@ struct State;
 /// Concretely, a record is:
 ///    two bytes record length, high bit indicates record type
 ///      (implies max record length 32k)
-///    path records contain just the string name of the path
+///    path records contain the string name of the path, followed by the
+///      one's complement of the expected index of the record (to detect
+///      concurrent writes of multiple ninja processes to the log).
 ///    dependency records are an array of 4-byte integers
 ///      [output path id, output path mtime, input path id, input path id...]
 ///      (The mtime is compared against the on-disk output path mtime


### PR DESCRIPTION
ninja assumes that numbering path entries in the deps log in order produces
valid dense integer ids.  If two ninja processes write to the same deps log
concurrently, this is not true.  Store the expected indices of path records
in the log and treat the rest of a deps log as invalid if the dense id of a
path record doesn't match the expected id stored in the log.  Addresses the
rest of issue #595.

This requires bumping the deps log file format version.  Do not migrate the
old version to the new, as the old format did not have this protection, and
might hence contain invalid data.  (Unlikely, but possible.)

Also store the record id as one's complement, to make them look less like
regular deps record values.  Since each record is written atomically this
isn't really necessary, but it makes the format somewhat more robust (and
easier to read in a hex editor).
