### PR TITLE
Fix for build test for BuildWithDepsLogTest.RestatMissingDepfileDepslog

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -487,7 +487,10 @@ void BuildTest::RebuildTarget(const string& target, const char* manifest,
 
   command_runner_.commands_ran_.clear();
   builder.command_runner_.reset(&command_runner_);
-  bool build_res = builder.Build(&err);
+  bool build_res = true;
+  if (!builder.AlreadyUpToDate()) {
+    build_res = builder.Build(&err);
+  }
   builder.command_runner_.release();
   EXPECT_TRUE(build_res) << "builder.Build(&err)";
 }


### PR DESCRIPTION
Fix for the failing BuildWithDepsLogTest.RestatMissingDepfileDepslog build test. The test performed a build which was an expected no-op, but the builder API requires you to call AlreadyUpToDate first.
