### PR TITLE
Use ANSI escapes to output to Cygwin-based terminals

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -190,10 +190,11 @@ you don't need to pass `-j`.)
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 
-Ninja supports one environment variable to control its behavior:
-`NINJA_STATUS`, the progress status printed before the rule being run.
+The output of ninja can be controlled with two environment variables.
+`NINJA_STATUS` controls the progress status printed before the rule being run,
+and `NINJA_TERM` can be used to override ninja's tty detection logic.
 
-Several placeholders are available:
+Several `NINJA_STATUS` placeholders are available:
 
 `%s`:: The number of started edges.
 `%t`:: The total number of edges that must be run to complete the build.
@@ -210,6 +211,11 @@ specified by `-j` or its default)
 The default progress status is `"[%s/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status
 could be `"[%u/%r/%f] "`.
+
+The possible values of `NINJA_TERM` are currently "ansi", "dumb", and "cmd"
+(only on Windows).  On Windows, there are many terminals that support ANSI
+codes, but are not easy to detect.  Setting `NINJA_TERM=ansi` in the environment
+allows the user to override ninja's detection logic.
 
 Extra tools
 ~~~~~~~~~~~

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -27,11 +27,7 @@
 
 #include "util.h"
 
-#ifdef _WIN32
-static bool IsCygwinTTY(HANDLE Handle);
-#endif
-
-LinePrinter::LinePrinter() : have_blank_line_(true), terminal_type_(TERM_DUMB) {
+LinePrinter::LinePrinter() : have_blank_line_(true) {
 #ifndef _WIN32
   const char* term = getenv("TERM");
   bool smart = isatty(1) && term && string(term) != "dumb";
@@ -43,13 +39,21 @@ LinePrinter::LinePrinter() : have_blank_line_(true), terminal_type_(TERM_DUMB) {
   // - Full Buffering."
   setvbuf(stdout, NULL, _IONBF, 0);
   console_ = GetStdHandle(STD_OUTPUT_HANDLE);
-  CONSOLE_SCREEN_BUFFER_INFO csbi;
-  bool is_cmd = GetConsoleScreenBufferInfo(console_, &csbi);
-  if (is_cmd) {
-    terminal_type_ = TERM_CMD;
-  } else if (IsCygwinTTY(console_)) {
-    // Cygwin uses mintty by default these days, and it understands ANSI codes.
-    terminal_type_ = TERM_ANSI;
+
+  // Allow the user to override our terminal type auto-detection.
+  const char* ninja_term = getenv("NINJA_TERM");
+  if (!ninja_term || ninja_term[0] == '\0') {
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    bool is_cmd = GetConsoleScreenBufferInfo(console_, &csbi);
+    terminal_type_ = is_cmd ? TERM_CMD : TERM_DUMB;
+  } else {
+    if (strcmp("cmd", ninja_term) == 0) {
+      terminal_type_ = TERM_CMD;
+    } else if (strcmp("ansi", ninja_term) == 0) {
+      terminal_type_ = TERM_ANSI;
+    } else {
+      terminal_type_ = TERM_DUMB;
+    }
   }
 #endif
 }
@@ -128,68 +132,3 @@ void LinePrinter::PrintOnNewLine(const string& to_print) {
   }
   have_blank_line_ = to_print.empty() || *to_print.rbegin() == '\n';
 }
-
-#ifdef _WIN32
-// Hide these types in an anonymous namespace so we don't conflict with whatever
-// comes out of windows.h.
-namespace {
-
-struct UNICODE_STRING {
-  USHORT Length;
-  USHORT MaximumLength;
-  PWSTR  Buffer;
-};
-
-// This is a custom definition.
-struct OBJECT_NAME_INFORMATION {
-  UNICODE_STRING          Name;
-  WCHAR                   NameBuffer[MAX_PATH];
-};
-
-enum OBJECT_INFORMATION_CLASS { ObjectNameInformation = 1 };
-
-typedef NTSTATUS (__stdcall *NtQueryObjectType)(
-    /* IN  */ HANDLE ObjectHandle,
-    /* IN  */ OBJECT_INFORMATION_CLASS ObjectInformationClass,
-    /* OUT */ PVOID ObjectInformation,
-    /* IN  */ ULONG ObjectInformationLength,
-    /* OUT */ ULONG *ReturnLength);
-
-}
-
-// Figures out if the given handle points to a pipe pty created by a Cygwin
-// shell.  Cygwin sets stdout to a named pipe with a name in a parsable format,
-// which is how it later decides if stdout is a tty or not.
-// TODO: Make this work for MSys bash.
-static bool IsCygwinTTY(HANDLE handle) {
-  // Use GetProcAddress to find NtQueryObject so we don't have to link against
-  // ntdll directly, which is only present in the WDK or Win8 SDK.
-  HMODULE mod = LoadLibrary("ntdll");
-  if (!mod)
-    return false;
-  NtQueryObjectType query =
-      NtQueryObjectType(GetProcAddress(mod, "NtQueryObject"));
-  if (!query)
-    return false;
-
-  // The result is a UNICODE_STRING where the storage for the name directly
-  // follows the struct.  We pass the size of the whole thing into
-  // NtQueryObject.
-  OBJECT_NAME_INFORMATION name_info;
-  ULONG len;
-  NTSTATUS status = query(handle, ObjectNameInformation, (void *)&name_info,
-                          sizeof(name_info), &len);
-  if (status != 0)
-    return false;
-
-  // If the handle represents a named pipe starting with "cygwin-", this was
-  // created by Cygwin.
-  wchar_t pty_prefix[] = L"\\Device\\NamedPipe\\cygwin-";
-  if (wcsncmp(name_info.NameBuffer, pty_prefix, wcslen(pty_prefix)) != 0)
-    return false;
-
-  // If it also has "-pty" in it, that's a strong signal that it's a pseudo-tty.
-  return wcsstr(name_info.NameBuffer, L"-pty");
-}
-
-#endif

--- a/src/line_printer.h
+++ b/src/line_printer.h
@@ -23,8 +23,16 @@ using namespace std;
 struct LinePrinter {
   LinePrinter();
 
-  bool is_smart_terminal() const { return smart_terminal_; }
-  void set_smart_terminal(bool smart) { smart_terminal_ = smart; }
+  enum TerminalType {
+    TERM_DUMB,
+#ifdef _WIN32
+    TERM_CMD,
+#endif
+    TERM_ANSI
+  };
+
+  bool is_smart_terminal() const { return terminal_type_ != TERM_DUMB; }
+  void set_smart_terminal(bool smart) { terminal_type_ = TERM_DUMB; }
 
   enum LineType {
     FULL,
@@ -39,7 +47,7 @@ struct LinePrinter {
 
  private:
   /// Whether we can do fancy terminal control codes.
-  bool smart_terminal_;
+  TerminalType terminal_type_;
 
   /// Whether the caret is at the beginning of a blank line.
   bool have_blank_line_;


### PR DESCRIPTION
Cygwin detects ttys by looking at the name of the pipe the parent
process created for it.  It also uses the NtQueryObject API to get the
pipe name.

This enables terse output with mintty avoids stripping ANSI escape codes
from the output of subprocesses like clang.

This does _not_ enable the ellipsis insertion code because that code
doesn't compile on Windows.
