### PR TITLE
add option to limit job execution dependant on memory consumption (-m)

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -186,6 +186,14 @@ match those of Make; e.g `ninja -C build -j 20` changes into the
 Ninja defaults to running commands in parallel anyway, so typically
 you don't need to pass `-j`.)
 
+In certain environments it might be helpful to dynamically limit the
+amount of running jobs depending on the currently available resources.
+Thus `ninja` can be started with `-l` and/or `-m` options to prevent
+from starting new jobs in case load average or memory usage exceed
+the defined limit. `-l` takes one single numeric argument defining
+the limit for the typical unix load average. `-m` takes one single
+numeric argument within [0,100] as a percentage of the memory usage
+(reduced by caches) on the host.
 
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/build.cc
+++ b/src/build.cc
@@ -481,9 +481,13 @@ void RealCommandRunner::Abort() {
 }
 
 bool RealCommandRunner::CanRunMore() {
-  return ((int)subprocs_.running_.size()) < config_.parallelism
-    && ((subprocs_.running_.empty() || config_.max_load_average <= 0.0f)
-        || GetLoadAverage() < config_.max_load_average);
+  bool r = true;
+  r=r && ((int)subprocs_.running_.size()) < config_.parallelism;
+  r=r && ((subprocs_.running_.empty() || config_.max_memory_usage <= 0.0f)
+                        || GetMemoryUsage() < config_.max_memory_usage);
+  r=r && ((subprocs_.running_.empty() || config_.max_load_average <= 0.0f)
+                        || GetLoadAverage() < config_.max_load_average);
+  return r;
 }
 
 bool RealCommandRunner::StartCommand(Edge* edge) {

--- a/src/build.h
+++ b/src/build.h
@@ -123,7 +123,8 @@ struct CommandRunner {
 /// Options (e.g. verbosity, parallelism) passed to a build.
 struct BuildConfig {
   BuildConfig() : verbosity(NORMAL), dry_run(false), parallelism(1),
-                  failures_allowed(1), max_load_average(-0.0f) {}
+                  failures_allowed(1), max_load_average(-0.0f),
+                  max_memory_usage(-0.0f) {}
 
   enum Verbosity {
     NORMAL,
@@ -137,6 +138,10 @@ struct BuildConfig {
   /// The maximum load average we must not exceed. A negative value
   /// means that we do not have any limit.
   double max_load_average;
+  /// The maximum memory usage we must not exceed. The value is
+  /// defined within [0.0,1.0]. A negative values indicates that we do
+  /// not have any limit.
+  double max_memory_usage;
 };
 
 /// Builder wraps the build process: starting commands, updating status.

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -181,6 +181,10 @@ void Usage(const BuildConfig& config) {
 #ifdef _WIN32
 "           (not yet implemented on Windows)\n"
 #endif
+"  -m N     do not start new jobs if the memory usage exceeds N percent\n"
+#if !(defined(__APPLE__) || defined(linux) || defined(_WIN32))
+"           (not yet implemented on this platform)\n"
+#endif
 "  -k N     keep going until N jobs fail [default=1]\n"
 "  -n       dry run (don't run commands but act like they succeeded)\n"
 "  -v       show all command lines while building\n"
@@ -937,7 +941,7 @@ int ReadFlags(int* argc, char*** argv,
 
   int opt;
   while (!options->tool &&
-         (opt = getopt_long(*argc, *argv, "d:f:j:k:l:nt:vC:h", kLongOptions,
+         (opt = getopt_long(*argc, *argv, "d:f:j:k:l:m:nt:vC:h", kLongOptions,
                             NULL)) != -1) {
     switch (opt) {
       case 'd':
@@ -973,6 +977,14 @@ int ReadFlags(int* argc, char*** argv,
         if (end == optarg)
           Fatal("-l parameter not numeric: did you mean -l 0.0?");
         config->max_load_average = value;
+        break;
+      }
+      case 'm': {
+        char* end;
+        const int value = strtol(optarg, &end, 10);
+        if (end == optarg || value < 0 || value > 100)
+          Fatal("-m parameter is invalid: allowed range is [0,100]");
+        config->max_memory_usage = value/100.0; // map to [0.0,100.0]
         break;
       }
       case 'n':

--- a/src/util.cc
+++ b/src/util.cc
@@ -16,6 +16,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <Psapi.h>
 #include <io.h>
 #include <share.h>
 #endif
@@ -36,6 +37,7 @@
 
 #include <vector>
 
+// to determine the load average
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #elif defined(__SVR4) && defined(__sun)
@@ -43,6 +45,13 @@
 #include <sys/loadavg.h>
 #elif defined(linux) || defined(__GLIBC__)
 #include <sys/sysinfo.h>
+#endif
+
+// to determine the memory usage
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#elif defined(linux)
+#include <fstream>
 #endif
 
 #include "edit_distance.h"
@@ -328,6 +337,63 @@ double GetLoadAverage() {
 }
 #endif // _WIN32
 
+double GetMemoryUsage() {
+#if defined(__APPLE__)
+  // total memory
+  uint64_t physical_memory;
+  {
+    size_t length = sizeof(physical_memory);
+    if (!(sysctlbyname("hw.memsize",
+                       &physical_memory, &length, NULL, 0) == 0)) {
+      return -0.0f;
+    }
+  }
+
+  // pagesize
+  unsigned pagesize = 0;
+  {
+    size_t length = sizeof(pagesize);
+    if (!(sysctlbyname("hw.pagesize",
+                       &pagesize, &length, NULL, 0) == 0)) {
+      return -0.0f;
+    }
+  }
+
+  // current free memory
+  vm_statistics_data_t vm;
+  mach_msg_type_number_t ic = HOST_VM_INFO_COUNT;
+  host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t) &vm, &ic);
+
+  return 1.0 - static_cast<double>(pagesize) * vm.free_count / physical_memory;
+#elif defined(linux)
+  ifstream meminfo("/proc/meminfo", ifstream::in);
+  string token;
+  uint64_t free(0), total(0), cached(0);
+  while (meminfo >> token) {
+    if (token == "MemFree:") {
+      meminfo >> free;
+    } else if (token == "Cached:") {
+      meminfo >> cached;
+    } else if (token == "MemTotal:") {
+      meminfo >> total;
+    } else {
+      continue;
+    }
+    if (free > 0 && cached > 0 && total > 0) {
+      return 1.0 - (double(free+cached)/total);
+    }
+  }
+  return -0.0f; // this is the fallback in case the API has changed
+#elif (_WIN32)
+  PERFORMANCE_INFORMATION perf;
+  GetPerformanceInfo(&perf, sizeof(PERFORMANCE_INFORMATION));
+  return 1.0 - static_cast<double>(perf.PhysicalAvailable) /
+               static_cast<double>(perf.PhysicalTotal);
+#else // any unsupported platform
+  return -0.0f;
+#endif
+}
+
 string ElideMiddle(const string& str, size_t width) {
   const int kMargin = 3;  // Space for "...".
   string result = str;
@@ -357,3 +423,5 @@ bool Truncate(const string& path, size_t size, string* err) {
   }
   return true;
 }
+
+// vim: et sts=2 st=2 sw=2:

--- a/src/util.h
+++ b/src/util.h
@@ -69,8 +69,12 @@ string StripAnsiEscapeCodes(const string& in);
 int GetProcessorCount();
 
 /// @return the load average of the machine. A negative value is returned
-/// on error.
+/// on error or if the feature is not supported on this platform.
 double GetLoadAverage();
+
+/// @return the memory usage of the machine. A negative value is returned
+/// on error or if the feature is not supported on this platform.
+double GetMemoryUsage();
 
 /// Elide the given string @a str with '...' in the middle if the length
 /// exceeds @a width.


### PR DESCRIPTION
Setting a value in range [0,100] for -m limits starting of new jobs. once
the limit has been exceeded at most one single job is run at a time.

This aims at C++ make projects that run into memory limitations when
building expensive (in regards to memory) compilation units, e.g. caused
by massive template instantiations.

The implementation currently covers support for Apple, Linux and Windows.

Signed-off-by: Matthias Maennich matthias@maennich.net
