### PR TITLE
speedup searching for space

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -245,6 +245,17 @@ string EdgeEnv::LookupVariable(const string& var) {
   return edge_->env_->LookupWithFallback(var, eval, this);
 }
 
+static inline bool ContainsSpace(const string& str)
+{
+  const char* ptr = str.c_str();
+  const char*const end = ptr + str.size();
+  for (; ptr < end; ptr++) {
+    if (*ptr == ' ')
+      return true;
+  }
+  return false;
+}
+
 string EdgeEnv::MakePathList(vector<Node*>::iterator begin,
                              vector<Node*>::iterator end,
                              char sep) {
@@ -253,7 +264,7 @@ string EdgeEnv::MakePathList(vector<Node*>::iterator begin,
     if (!result.empty())
       result.push_back(sep);
     const string& path = (*i)->path();
-    if (path.find(" ") != string::npos) {
+    if (ContainsSpace(path)) {
       result.append("\"");
       result.append(path);
       result.append("\"");


### PR DESCRIPTION
It's ugly but faster by 1%-2%

Numbers from empty clang builds:
- std::find()
  $ measure.py 200 ninja
  sampling: ...
  best: 164ms
  mean: 173ms +- 8.7ms
- ContainsSpace()
  $ measure.py 200 ninja
  sampling: ...
  best: 161ms
  mean: 169ms +- 6.0ms
