### PR TITLE
only canonicalize if needed

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -112,8 +112,19 @@ bool CanonicalizePath(char* path, size_t* len, string* err) {
   char* start = path;
   char* dst = start;
   const char* src = start;
-  const char* end = start + *len;
+  const char*const end = start + *len;
 
+  bool nothing_todo = true;
+  for (;src < end - 1; src++) {
+    if (*src == '.' && src[1] == '.') {
+      nothing_todo = false;
+      break;
+    }
+  }
+  if (nothing_todo)
+    return true;
+
+  src = start;
   if (*src == '/') {
 #ifdef _WIN32
     // network path starts with //


### PR DESCRIPTION
empty build about 3% faster
- patched:
  $ measure.py 200 ninja
  sampling: ...
  best: 147ms
  mean: 156ms +- 6.2ms
- unpatched:
  $ measure.py 200 ninja
  sampling: ...
  best: 152ms
  mean: 161ms +- 6.1ms
