### PR TITLE
Fix compilation on VS2013

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -125,6 +125,8 @@ if platform.is_msvc():
               '/DNOMINMAX', '/D_CRT_SECURE_NO_WARNINGS',
               '/D_VARIADIC_MAX=10',
               '/DNINJA_PYTHON="%s"' % options.with_python]
+    if platform.msvc_needs_fs():
+        cflags.append('/FS')
     ldflags = ['/DEBUG', '/libpath:$builddir']
     if not options.debug:
         cflags += ['/Ox', '/DNDEBUG', '/GL']

--- a/platform_helper.py
+++ b/platform_helper.py
@@ -21,8 +21,8 @@ def platforms():
     return ['linux', 'darwin', 'freebsd', 'openbsd', 'solaris', 'sunos5',
             'mingw', 'msvc', 'gnukfreebsd8', 'bitrig']
 
-class Platform( object ):
-    def __init__( self, platform):
+class Platform(object):
+    def __init__(self, platform):
         self._platform = platform
         if not self._platform is None:
             return
@@ -55,6 +55,14 @@ class Platform( object ):
 
     def is_msvc(self):
         return self._platform == 'msvc'
+
+    def msvc_needs_fs(self):
+        import subprocess
+        popen = subprocess.Popen('cl /nologo /?',
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        out, err = popen.communicate()
+        return '/FS ' in out
 
     def is_windows(self):
         return self.is_mingw() or self.is_msvc()

--- a/src/edit_distance.cc
+++ b/src/edit_distance.cc
@@ -14,6 +14,7 @@
 
 #include "edit_distance.h"
 
+#include <algorithm>
 #include <vector>
 
 int EditDistance(const StringPiece& s1,

--- a/src/hash_map.h
+++ b/src/hash_map.h
@@ -15,6 +15,7 @@
 #ifndef NINJA_MAP_H_
 #define NINJA_MAP_H_
 
+#include <algorithm>
 #include <string.h>
 #include "string_piece.h"
 

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -24,6 +24,8 @@
 #include <windows.h>
 #endif
 
+#include <algorithm>
+
 #include "util.h"
 
 Metrics* g_metrics = NULL;


### PR DESCRIPTION
- Add #include of <algorithm> for std::min/max.
- Add new /FS flag to compilation which is newly required when spawning cl.exe in parallel. Needs to be detected because adding that flag on older versions will error out.
