### PR TITLE
configure.py/bootstrap.py — account for CXXFLAGS.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -53,6 +53,10 @@ def run(*args, **kwargs):
 # g++ call as well as in the later configure.py.
 cflags = os.environ.get('CFLAGS', '').split()
 ldflags = os.environ.get('LDFLAGS', '').split()
+cxxflags = os.environ.get('CXXFLAGS', '').split()
+ldflags.extend(cflags)
+cflags.extend(cxxflags)
+ldflags.extend(cxxflags)
 if platform.is_freebsd() or platform.is_openbsd() or platform.is_bitrig():
     cflags.append('-I/usr/local/include')
     ldflags.append('-L/usr/local/lib')

--- a/configure.py
+++ b/configure.py
@@ -72,7 +72,7 @@ n.newline()
 
 n.comment('The arguments passed to configure.py, for rerunning it.')
 n.variable('configure_args', ' '.join(sys.argv[1:]))
-env_keys = set(['CXX', 'AR', 'CFLAGS', 'LDFLAGS'])
+env_keys = set(['CXX', 'AR', 'CFLAGS', 'CXXFLAGS', 'LDFLAGS'])
 configure_env = dict((k, os.environ[k]) for k in os.environ if k in env_keys)
 if configure_env:
     config_str = ' '.join([k + '=' + configure_env[k] for k in configure_env])
@@ -183,9 +183,14 @@ def shell_escape(str):
 
 if 'CFLAGS' in configure_env:
     cflags.append(configure_env['CFLAGS'])
+    ldflags.append(configure_env['CFLAGS'])
 n.variable('cflags', ' '.join(shell_escape(flag) for flag in cflags))
 if 'LDFLAGS' in configure_env:
     ldflags.append(configure_env['LDFLAGS'])
+if 'CXXFLAGS' in configure_env:
+    cflags.append(configure_env['CXXFLAGS'])
+    ldflags.append(configure_env['CXXFLAGS'])
+n.variable('cflags', ' '.join(shell_escape(flag) for flag in cflags))
 n.variable('ldflags', ' '.join(shell_escape(flag) for flag in ldflags))
 n.newline()
 


### PR DESCRIPTION
Take into account CXXFLAGS in the environment in the bootstrap and configure scripts. I've tried to ensure this doesn't interfere with existing workflows which depend on using CFLAGS (only) by appending to, rather than replacing, CFLAGS; this may lead to some extraneous duplicates, but it seems better than the alternative.

Also, CXXFLAGS (and CFLAGS) are added to LDFLAGS with this change; this is to account for some special flags (like clang's `-stdlib`) which modify the behavior of both the compiler and the linker.
