### PR TITLE
print "still waiting" for long running commands if we serialize on them

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -208,7 +208,7 @@ struct BuildStatus {
   string FormatProgressStatus(const char* progress_status_format) const;
 
  private:
-  void PrintStatus(Edge* edge);
+  void PrintStatus(Edge* edge, bool waiting_for);
 
   const BuildConfig& config_;
 


### PR DESCRIPTION
Heuristic: if the currently-running count drops to 1, and that process has been running for 3s+, then print-and-shame.

It won't work if soon-to-be-long-running process just started with at least one other process, and then before 3s has elapsed, all the other processes terminate.

Similar to https://github.com/martine/ninja/issues/111 but I didn't see a simple way of doing exactly that (because if nothing's happening I think we're blocked waiting for processes?). I might be misreading though.