### PR TITLE
Add a test that shows that there is a single global namespace for rules.

### DIFF
--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -762,6 +762,21 @@ TEST_F(ParserTest, MissingSubNinja) {
             , err);
 }
 
+TEST_F(ParserTest, DuplicateRuleInDifferentSubninjas) {
+  // Test that rules live in a global namespace and aren't scoped to subninjas.
+  files_["test.ninja"] = "rule cat\n"
+                         "  command = cat\n";
+  ManifestParser parser(&state, this);
+  string err;
+  EXPECT_FALSE(parser.ParseTest("rule cat\n"
+                                "  command = cat\n"
+                                "subninja test.ninja\n", &err));
+  EXPECT_EQ("test.ninja:1: duplicate rule 'cat'\n"
+            "rule cat\n"
+            "        ^ near here"
+            , err);
+}
+
 TEST_F(ParserTest, Include) {
   files_["include.ninja"] = "var = inner\n";
   ASSERT_NO_FATAL_FAILURE(AssertParse(


### PR DESCRIPTION
No functionality change. I couldn't find an existing test for this.
