### PR TITLE
Update search to work with latest python

### DIFF
--- a/platform_helper.py
+++ b/platform_helper.py
@@ -62,7 +62,7 @@ class Platform(object):
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         out, err = popen.communicate()
-        return '/FS ' in out
+        return '/FS ' in out.decode("utf-8", "ignore")
 
     def is_windows(self):
         return self.is_mingw() or self.is_msvc()


### PR DESCRIPTION
There is a problem. On windows 7 station, with Python 3.3.2 and russian VisualStudio installed, if you are trying to build ninja, you have an error  message
"File "platform_helper.py", line 65, in msvc_needs_fs return '/FS ' in out TypeError: Type str doesn't support the buffer API".
So there is attempt to fix this by decoding byte array and ignoring symbols, that could not be decoded. Apparently only non english letters will  be decoded and function will return required result.