### PR TITLE
Order-only dependencies trigger unneeded actions

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -85,6 +85,10 @@ bool DependencyScan::RecomputeDirty(Edge* edge, string* err) {
       }
     }
 
+    // Ignore dirty order-only inputs if normal (and implicit) inputs are clean
+    if (edge->is_order_only(i - edge->inputs_.begin()) && edge->outputs_ready_)
+      continue;
+
     // If an input is not ready, neither are our outputs.
     if (Edge* in_edge = (*i)->in_edge()) {
       if (!in_edge->outputs_ready_)


### PR DESCRIPTION
Here is very artificial example:

```
rule CC
    command = gcc -c -o $out $in
build b.o: CC b.c
build c.o: CC c.c || b.o
```

Example of what's going wrong:

``` shell
touch b.c c.c
ninja
touch b.c
ninja -v c.o
```

Second ninja invocation triggers completely unnecessary rebuild of `c.o`
