### PR TITLE
Fix up platform_helper for MSVC

### DIFF
--- a/platform_helper.py
+++ b/platform_helper.py
@@ -58,7 +58,7 @@ class Platform(object):
 
     def msvc_needs_fs(self):
         import subprocess
-        popen = subprocess.Popen('cl /nologo /?',
+        popen = subprocess.Popen(['cl', '/nologo', '/?'],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         out, err = popen.communicate()


### PR DESCRIPTION
With Python 2.6.8 the arguments to `subprocess.Popen` have to be in a list, or you have to set Shell to true if you are using spaces in a string. Compiling with MSVC 2008, Cygwin, Windows, and `./boostrap.py --platform=msvc` failed before this patch, and worked smoothly after it.
