### PR TITLE
remove abandoned outputs (mostly done)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ TAGS
 # Ninja output
 .ninja_deps
 .ninja_log
+.ninja_regen
+

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -34,7 +34,8 @@ struct DiskInterface;
 /// 2) timing information, perhaps for generating reports
 /// 3) restat information
 struct BuildLog {
-  BuildLog(DiskInterface* disk_interface);
+  BuildLog(DiskInterface* disk_interface,
+           bool files_must_exist = true);
   ~BuildLog();
 
   bool OpenForWrite(const string& path, string* err);
@@ -86,6 +87,9 @@ struct BuildLog {
   FILE* log_file_;
   bool needs_recompaction_;
   DiskInterface* disk_interface_;
+  /// Controls whether output files are tested for existence,
+  /// before adding a corresponding log entry.
+  const bool files_must_exist_;
 };
 
 #endif // NINJA_BUILD_LOG_H_

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -35,7 +35,7 @@ struct DiskInterface;
 /// 3) restat information
 struct BuildLog {
   BuildLog(DiskInterface* disk_interface,
-           bool files_must_exist = true);
+           bool files_must_exist = false);
   ~BuildLog();
 
   bool OpenForWrite(const string& path, string* err);

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -24,6 +24,7 @@ using namespace std;
 #include "util.h"  // uint64_t
 
 struct Edge;
+struct DiskInterface;
 
 /// Store a log of every command ran for every build.
 /// It has a few uses:
@@ -33,7 +34,7 @@ struct Edge;
 /// 2) timing information, perhaps for generating reports
 /// 3) restat information
 struct BuildLog {
-  BuildLog();
+  BuildLog(DiskInterface* disk_interface);
   ~BuildLog();
 
   bool OpenForWrite(const string& path, string* err);
@@ -78,9 +79,13 @@ struct BuildLog {
   const Entries& entries() const { return entries_; }
 
  private:
+  void ClearEntries();
+
+ private:
   Entries entries_;
   FILE* log_file_;
   bool needs_recompaction_;
+  DiskInterface* disk_interface_;
 };
 
 #endif // NINJA_BUILD_LOG_H_

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -79,6 +79,8 @@ struct BuildLog {
   typedef ExternalStringHashMap<LogEntry*>::Type Entries;
   const Entries& entries() const { return entries_; }
 
+  void FilesMustExist(bool value) { files_must_exist_ = value; }
+
  private:
   void ClearEntries();
 
@@ -89,7 +91,7 @@ struct BuildLog {
   DiskInterface* disk_interface_;
   /// Controls whether output files are tested for existence,
   /// before adding a corresponding log entry.
-  const bool files_must_exist_;
+  bool files_must_exist_;
 };
 
 #endif // NINJA_BUILD_LOG_H_

--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -21,6 +21,7 @@
 #include "state.h"
 #include "util.h"
 #include "metrics.h"
+#include "disk_interface.h"
 
 #ifndef _WIN32
 #include <unistd.h>
@@ -29,7 +30,8 @@
 const char kTestFilename[] = "BuildLogPerfTest-tempfile";
 
 bool WriteTestData(string* err) {
-  BuildLog log;
+  RealDiskInterface fs;
+  BuildLog log(&fs);
 
   if (!log.OpenForWrite(kTestFilename, err))
     return false;
@@ -104,7 +106,8 @@ int main() {
 
   {
     // Read once to warm up disk cache.
-    BuildLog log;
+    RealDiskInterface fs;
+    BuildLog log(&fs);
     if (!log.Load(kTestFilename, &err)) {
       fprintf(stderr, "Failed to read test data: %s\n", err.c_str());
       return 1;
@@ -113,7 +116,8 @@ int main() {
   const int kNumRepetitions = 5;
   for (int i = 0; i < kNumRepetitions; ++i) {
     int64_t start = GetTimeMillis();
-    BuildLog log;
+    RealDiskInterface fs;
+    BuildLog log(&fs);
     if (!log.Load(kTestFilename, &err)) {
       fprintf(stderr, "Failed to read test data: %s\n", err.c_str());
       return 1;

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -466,7 +466,7 @@ void BuildTest::RebuildTarget(const string& target, const char* manifest,
   AssertParse(&state, manifest);
 
   string err;
-  BuildLog build_log, *pbuild_log = NULL;
+  BuildLog build_log(&fs_), *pbuild_log = NULL;
   if (log_path) {
     ASSERT_TRUE(build_log.Load(log_path, &err));
     ASSERT_TRUE(build_log.OpenForWrite(log_path, &err));
@@ -1000,7 +1000,7 @@ TEST_F(BuildTest, SwallowFailuresLimit) {
 }
 
 struct BuildWithLogTest : public BuildTest {
-  BuildWithLogTest() {
+  BuildWithLogTest() : build_log_(&fs_) {
     builder_.SetBuildLog(&build_log_);
   }
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -135,7 +135,7 @@ struct NinjaMain {
   /// Remove all previously declared outputs that are no longer produced
   /// or referenced.  Performed by diffing build log with current build graph.
   /// @return Number of stale outputs removed.
-  int RemoveOrphanedOutputs();
+  int RemoveAbandonedOutputs();
 
   /// Recompact build log, then reopen for normal writing.
   bool RecompactAndReopenBuildLog();
@@ -879,7 +879,7 @@ bool NinjaMain::EnsureBuildDirExists() {
   return true;
 }
 
-int NinjaMain::RemoveOrphanedOutputs() {
+int NinjaMain::RemoveAbandonedOutputs() {
   int unlink_count = 0;
   for (BuildLog::Entries::const_iterator i = build_log_.entries().begin();
        i != build_log_.entries().end(); ++i) {
@@ -890,7 +890,7 @@ int NinjaMain::RemoveOrphanedOutputs() {
     }
 
     if (config_.verbosity == BuildConfig::VERBOSE) {
-      printf("ninja removing orphaned output: %s\n", log_entry->output.c_str());
+      printf("ninja removing abandoned output: %s\n", log_entry->output.c_str());
     }
     if (!config_.dry_run) {
       disk_interface_.RemoveFile(log_entry->output.c_str());
@@ -1111,7 +1111,7 @@ int real_main(int argc, char** argv) {
       }
     }
 
-    int unlink_count = ninja.RemoveOrphanedOutputs();
+    int unlink_count = ninja.RemoveAbandonedOutputs();
     if (unlink_count) {
       if (!ninja.RecompactAndReopenBuildLog())
         return 1;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1069,6 +1069,8 @@ int ReadFlags(int* argc, char*** argv,
         int value = strtol(optarg, &end, 10);
         if (*end != 0)
           Fatal("-r parameter not numeric; did you mean -r 0?");
+        if (value != 0 && value != 1)
+          Fatal("-r parameter must be 0 or 1 if supplied");
         options->remove_abandoned_outputs = !!value;
         break;
       }

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -653,10 +653,6 @@ int NinjaMain::ToolRecompact(int argc, char* argv[]) {
   if (!EnsureBuildDirExists())
     return 1;
 
-  // Make recompacting non-destructive, so that abandoned outputs can
-  // still be removed upon the next build.
-  build_log_.FilesMustExist(false);
-
   if (!OpenBuildLog(/*recompact_only=*/true) ||
       !OpenDepsLog(/*recompact_only=*/true))
     return 1;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -656,6 +656,10 @@ int NinjaMain::ToolRecompact(int argc, char* argv[]) {
   if (!EnsureBuildDirExists())
     return 1;
 
+  // Make recompacting non-destructive, so that abandoned outputs can
+  // still be removed upon the next build.
+  build_log_.FilesMustExist(false);
+
   if (!OpenBuildLog(/*recompact_only=*/true) ||
       !OpenDepsLog(/*recompact_only=*/true))
     return 1;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -64,6 +64,9 @@ struct Options {
 
   /// Tool to run rather than building.
   const Tool* tool;
+
+  /// If true, remove outputs that are no longer produced.
+  bool remove_abandoned_outputs;
 };
 
 /// The Ninja main() loads up a series of data structures; various tools need
@@ -1064,6 +1067,7 @@ int ReadFlags(int* argc, char*** argv,
   *argv += optind;
   *argc -= optind;
 
+  options->remove_abandoned_outputs = !!getenv("NINJA_RAO");
   return -1;
 }
 
@@ -1136,7 +1140,9 @@ int real_main(int argc, char** argv) {
       }
     }
 
-    ninja.RemoveAbandonedOutputs();
+    if (options.remove_abandoned_outputs) {
+      ninja.RemoveAbandonedOutputs();
+    }
 
     int result = ninja.RunBuild(argc, argv);
     if (g_metrics)

--- a/src/util.cc
+++ b/src/util.cc
@@ -357,3 +357,19 @@ bool Truncate(const string& path, size_t size, string* err) {
   }
   return true;
 }
+
+string BaseName(const char* path, size_t length)
+{
+  size_t i = length;
+  while (i --> 0) {
+    if (path[i] == '/' || path[i] == '\\') {
+      break;
+    }
+  }
+  return string(&path[i+1]);
+}
+
+string BaseName(const char* path)
+{
+  return BaseName(path, strlen(path));
+}

--- a/src/util.h
+++ b/src/util.h
@@ -79,6 +79,8 @@ string ElideMiddle(const string& str, size_t width);
 /// Truncates a file to the given size.
 bool Truncate(const string& path, size_t size, string* err);
 
+string BaseName(const char* path);
+
 #ifdef _MSC_VER
 #define snprintf _snprintf
 #define fileno _fileno


### PR DESCRIPTION
This implements "remove abandoned outputs" (RAO) mostly as I'd intend.
Missing are commandline argument to control it, and a merge squash for less messy commit history.
I was thinking RAO could be default enabled, thus a command switch would disable it.

Please also see discussion in https://groups.google.com/forum/#!topic/ninja-build/zQa5-K8XJfE
