### PR TITLE
don't fail if trying to mkdir when the dir already exists

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -146,6 +146,9 @@ bool RealDiskInterface::WriteFile(const string& path, const string& contents) {
 
 bool RealDiskInterface::MakeDir(const string& path) {
   if (::MakeDir(path) < 0) {
+    if (errno == EEXIST) {
+      return true;
+    }
     Error("mkdir(%s): %s", path.c_str(), strerror(errno));
     return false;
   }


### PR DESCRIPTION
When ninja tries to do the equivalent of "mkdir -p", it will fail if another process (or possibly another ninja task) creates one of the intermediate dirs in the meantime. This can be quite annoying, but it's fairly simple to catch.

NinjaMain::EnsureBuildDirExists doesn't fail in case of EEXIST (the check would be redundant if this patch is landed), but Builder::StartEdge does.  Perhaps we should just check for EEXIST in Builder::StartEdge?
