### PR TITLE
Don’t unnecessarily escape backslashes in Win32 paths

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -194,7 +194,6 @@ static inline bool IsKnownShellSafeCharacter(char ch) {
 
 static inline bool IsKnownWin32SafeCharacter(char ch) {
   switch (ch) {
-    case '\\':
     case ' ':
     case '"':
       return false;

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -159,6 +159,14 @@ TEST(PathEscaping, SensiblePathsAreNotNeedlesslyEscaped) {
   EXPECT_EQ(path, result);
 }
 
+TEST(PathEscaping, SensibleWin32PathsAreNotNeedlesslyEscaped) {
+  const char* path = "some\\sensible\\path\\without\\crazy\\characters.cc";
+  string result;
+
+  GetWin32EscapedString(path, &result);
+  EXPECT_EQ(path, result);
+}
+
 TEST(StripAnsiEscapeCodes, EscapeAtEnd) {
   string stripped = StripAnsiEscapeCodes("foo\33");
   EXPECT_EQ("foo", stripped);


### PR DESCRIPTION
Under ::CommandLineToArgvW() rules, the backslash character only gets special treatment if it's part of a sequence of backslashes terminated by a double-quote. So when checking to see if a string needs Win32 escaping, it’s sufficient to just simply check for the presence of a double quote character.

This allows paths like "foo\bar" to be recognised as “sensible” paths, which don’t require the full escaping.

Fixes #700
