### PR TITLE
emacs: Fix a warning

### DIFF
--- a/misc/ninja-mode.el
+++ b/misc/ninja-mode.el
@@ -15,7 +15,7 @@
 ;; Simple emacs mode for editing .ninja files.
 ;; Just some syntax highlighting for now.
 
-(setq ninja-keywords
+(defvar ninja-keywords
       (list
        '("^#.*" . font-lock-comment-face)
        (cons (concat "^" (regexp-opt '("rule" "build" "subninja" "include"


### PR DESCRIPTION
Fix a following `byte-compile` warning:

> ninja-mode.el:18:7:Warning: assignment to free variable `ninja-keywords'
