### PR TITLE
emacs: Place provide form at end of file

### DIFF
--- a/misc/ninja-mode.el
+++ b/misc/ninja-mode.el
@@ -35,8 +35,8 @@
   (setq font-lock-defaults '(ninja-keywords t))
   )
 
-(provide 'ninja-mode)
-
 ;; Run ninja-mode for files ending in .ninja.
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.ninja$" . ninja-mode))
+
+(provide 'ninja-mode)


### PR DESCRIPTION
Any errors in the code after "provide" will leave the feature registered, so it should always be at the end.
