### PR TITLE
emacs: Add autoload cookie to ninja-mode

### DIFF
--- a/misc/ninja-mode.el
+++ b/misc/ninja-mode.el
@@ -34,6 +34,8 @@
        ;; Rule names
        '("rule \\([[:alnum:]_]+\\)" . (1 font-lock-function-name-face))
        ))
+
+;;;###autoload
 (define-derived-mode ninja-mode fundamental-mode "ninja"
   (setq comment-start "#")
   ; Pass extra "t" to turn off syntax-based fontification -- we don't want


### PR DESCRIPTION
This commit ensures that users who have installed `ninja-mode.el` from [MELPA](http://melpa.milkbox.net/)  will be able to automatically turn on `ninja-mode` when visiting a `.ninja` file without explicitly requiring the library first.
