### PR TITLE
A proof of concept direct io implementation.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -488,7 +488,8 @@ bool RealCommandRunner::CanRunMore() {
 
 bool RealCommandRunner::StartCommand(Edge* edge) {
   string command = edge->EvaluateCommand();
-  Subprocess* subproc = subprocs_.Add(command);
+  bool directio = edge->GetBindingBool("directio");
+  Subprocess* subproc = subprocs_.Add(command, directio);
   if (!subproc)
     return false;
   subproc_to_edge_.insert(make_pair(subproc, edge));
@@ -505,7 +506,9 @@ bool RealCommandRunner::WaitForCommand(Result* result) {
   }
 
   result->status = subproc->Finish();
-  result->output = subproc->GetOutput();
+  if (!subproc->IsDirectIO()) {
+      result->output = subproc->GetOutput();
+  }
 
   map<Subprocess*, Edge*>::iterator i = subproc_to_edge_.find(subproc);
   result->edge = i->second;

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -54,7 +54,8 @@ bool Rule::IsReservedBinding(const string& var) {
       var == "pool" ||
       var == "restat" ||
       var == "rspfile" ||
-      var == "rspfile_content";
+      var == "rspfile_content" ||
+      var == "directio";
 }
 
 bool DependencyScan::RecomputeDirty(Edge* edge, string* err) {

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -42,13 +42,15 @@ struct Subprocess {
   bool Done() const;
 
   const string& GetOutput() const;
+  bool IsDirectIO() const { return directio_; }
 
- private:
+private:
   Subprocess();
-  bool Start(struct SubprocessSet* set, const string& command);
+  bool Start(struct SubprocessSet* set, const string& command, bool directio);
   void OnPipeReady();
 
   string buf_;
+  bool directio_;
 
 #ifdef _WIN32
   /// Set up pipe_ as the parent-side pipe of the subprocess; return the
@@ -75,7 +77,7 @@ struct SubprocessSet {
   SubprocessSet();
   ~SubprocessSet();
 
-  Subprocess* Add(const string& command);
+  Subprocess* Add(const string& command, bool directio);
   bool DoWork();
   Subprocess* NextFinished();
   void Clear();

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -39,7 +39,7 @@ struct SubprocessTest : public testing::Test {
 
 // Run a command that fails and emits to stderr.
 TEST_F(SubprocessTest, BadCommandStderr) {
-  Subprocess* subproc = subprocs_.Add("cmd /c ninja_no_such_command");
+  Subprocess* subproc = subprocs_.Add("cmd /c ninja_no_such_command", false);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -53,7 +53,7 @@ TEST_F(SubprocessTest, BadCommandStderr) {
 
 // Run a command that does not exist
 TEST_F(SubprocessTest, NoSuchCommand) {
-  Subprocess* subproc = subprocs_.Add("ninja_no_such_command");
+  Subprocess* subproc = subprocs_.Add("ninja_no_such_command", false);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -72,7 +72,7 @@ TEST_F(SubprocessTest, NoSuchCommand) {
 #ifndef _WIN32
 
 TEST_F(SubprocessTest, InterruptChild) {
-  Subprocess* subproc = subprocs_.Add("kill -INT $$");
+  Subprocess* subproc = subprocs_.Add("kill -INT $$", false);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -83,7 +83,7 @@ TEST_F(SubprocessTest, InterruptChild) {
 }
 
 TEST_F(SubprocessTest, InterruptParent) {
-  Subprocess* subproc = subprocs_.Add("kill -INT $PPID ; sleep 1");
+  Subprocess* subproc = subprocs_.Add("kill -INT $PPID ; sleep 1", false);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -98,7 +98,7 @@ TEST_F(SubprocessTest, InterruptParent) {
 #endif
 
 TEST_F(SubprocessTest, SetWithSingle) {
-  Subprocess* subproc = subprocs_.Add(kSimpleCommand);
+  Subprocess* subproc = subprocs_.Add(kSimpleCommand, false);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -124,7 +124,7 @@ TEST_F(SubprocessTest, SetWithMulti) {
   };
 
   for (int i = 0; i < 3; ++i) {
-    processes[i] = subprocs_.Add(kCommands[i]);
+    processes[i] = subprocs_.Add(kCommands[i], false);
     ASSERT_NE((Subprocess *) 0, processes[i]);
   }
 
@@ -167,7 +167,7 @@ TEST_F(SubprocessTest, SetWithLots) {
 
   vector<Subprocess*> procs;
   for (size_t i = 0; i < kNumProcs; ++i) {
-    Subprocess* subproc = subprocs_.Add("/bin/echo");
+    Subprocess* subproc = subprocs_.Add("/bin/echo", false);
     ASSERT_NE((Subprocess *) 0, subproc);
     procs.push_back(subproc);
   }
@@ -187,7 +187,7 @@ TEST_F(SubprocessTest, SetWithLots) {
 // Verify that a command that attempts to read stdin correctly thinks
 // that stdin is closed.
 TEST_F(SubprocessTest, ReadStdin) {
-  Subprocess* subproc = subprocs_.Add("cat -");
+  Subprocess* subproc = subprocs_.Add("cat -", false);
   while (!subproc->Done()) {
     subprocs_.DoWork();
   }


### PR DESCRIPTION
This is a proof of concept patch to make it possible to tag certain rules as direct io. This causes Ninja to print the output immediately rather than buffering it. For deep rationale see issue 545. Not buffering io is useful when running a slow running command that is not run in parallel with any other build rule. The two canonical examples are running a unit test suite and regenerating build files.

This patch is just a proof of concept, it should not be merged as is. It only patches the posix side, stores the output inside itself even though it is not used, and so on. It works by adding a new variable for rules called directio. If set to 1, Ninja will print the output on screen immediately. It is the responsibility of the Ninja file generator to ensure that only one directio rule is invoked at a time (or suffer the consequences of interleaved output).
