### PR TITLE
Keep sub-processes in ninja's process group.

### DIFF
--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -58,9 +58,6 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
     // Track which fd we use to report errors on.
     int error_pipe = output_pipe[1];
     do {
-      if (setpgid(0, 0) < 0)
-        break;
-
       if (sigaction(SIGINT, &set->old_act_, 0) < 0)
         break;
       if (sigprocmask(SIG_SETMASK, &set->old_mask_, 0) < 0)


### PR DESCRIPTION
When all processes are part of the same group one can sends signals
such as (SIGSTOP/SIGCONT) to the whole group which is very convenient.
Currently each sub-process has its own group thus, this patch fix this.
