### PR TITLE
Support both slashes on Windows when making output dirs

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -14,6 +14,8 @@
 
 #include "disk_interface.h"
 
+#include <algorithm>
+
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -31,15 +33,16 @@ namespace {
 
 string DirName(const string& path) {
 #ifdef _WIN32
-  const char kPathSeparator = '\\';
+  const char kPathSeparators[] = "\\/";
 #else
-  const char kPathSeparator = '/';
+  const char kPathSeparators[] = "/";
 #endif
-
-  string::size_type slash_pos = path.rfind(kPathSeparator);
+  string::size_type slash_pos = path.find_last_of(kPathSeparators);
   if (slash_pos == string::npos)
     return string();  // Nothing to do.
-  while (slash_pos > 0 && path[slash_pos - 1] == kPathSeparator)
+  const char* const kEnd = kPathSeparators + strlen(kPathSeparators);
+  while (slash_pos > 0 &&
+         std::find(kPathSeparators, kEnd, path[slash_pos - 1]) != kEnd)
     --slash_pos;
   return path.substr(0, slash_pos);
 }

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -93,7 +93,18 @@ TEST_F(DiskInterfaceTest, ReadFile) {
 }
 
 TEST_F(DiskInterfaceTest, MakeDirs) {
-  EXPECT_TRUE(disk_.MakeDirs("path/with/double//slash/"));
+  string path = "path/with/double//slash/";
+  EXPECT_TRUE(disk_.MakeDirs(path.c_str()));
+  FILE* f = fopen((path + "a_file").c_str(), "w");
+  EXPECT_TRUE(f);
+  EXPECT_EQ(0, fclose(f));
+#ifdef _WIN32
+  string path2 = "another\\with\\back\\\\slashes\\";
+  EXPECT_TRUE(disk_.MakeDirs(path2.c_str()));
+  FILE* f2 = fopen((path2 + "a_file").c_str(), "w");
+  EXPECT_TRUE(f2);
+  EXPECT_EQ(0, fclose(f2));
+#endif
 }
 
 TEST_F(DiskInterfaceTest, RemoveFile) {


### PR DESCRIPTION
The test was previously just early-outing because it felt there was "no directories" in that path.
