### PR TITLE
Support building Ninja on Cygwin

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -99,7 +99,7 @@ def cc(name, **kwargs):
 def cxx(name, **kwargs):
     return n.build(built(name + objext), 'cxx', src(name + '.cc'), **kwargs)
 def binary(name):
-    if platform.is_windows():
+    if platform.is_windows() or platform.is_cygwin():
         exe = name + '.exe'
         n.build(name, 'phony', exe)
         return exe

--- a/platform_helper.py
+++ b/platform_helper.py
@@ -19,7 +19,7 @@ import sys
 
 def platforms():
     return ['linux', 'darwin', 'freebsd', 'openbsd', 'solaris', 'sunos5',
-            'mingw', 'msvc', 'gnukfreebsd8', 'bitrig']
+            'mingw', 'msvc', 'gnukfreebsd8', 'bitrig', 'cygwin']
 
 class Platform(object):
     def __init__(self, platform):
@@ -43,6 +43,8 @@ class Platform(object):
             self._platform = 'msvc'
         elif self._platform.startswith('bitrig'):
             self._platform = 'bitrig'
+        elif self._platform.startswith('cygwin'):
+            self._platform = 'cygwin'
 
     def platform(self):
         return self._platform
@@ -81,3 +83,6 @@ class Platform(object):
 
     def is_bitrig(self):
         return self._platform == 'bitrig'
+
+    def is_cygwin(self):
+        return self._platform == 'cygwin'


### PR DESCRIPTION
On Cygwin I get this error, and I have to run configure.py manually:

```
$ ./bootstrap.py
Building ninja manually...
Building ninja using itself...
Usage: configure.py [options]

configure.py: error: option --platform: invalid choice: 'cygwin' (choose from 'linux', 'darwin', 'freebsd', 'openbsd', 'solaris', 'sunos5', 'mingw', 'msvc', 'gnukfreebsd8', 'bitrig')
```

This adds 'cygwin' to the list in `platform_helper` so bootstrapping works for native Cygwin builds.
