### PR TITLE
Solve the line-wrapping performance problem by shortening lines.

### DIFF
--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -72,8 +72,10 @@ class Writer(object):
             all_inputs.append('||')
             all_inputs.extend(order_only)
 
-        self._line('build %s: %s' % (' '.join(out_outputs),
-                                     ' '.join([rule] + all_inputs)))
+        self.output.write('build ' +
+                          ' $\n    '.join([""] + out_outputs) +
+                          ': $\n    ' +
+                          ' $\n    '.join([rule] + all_inputs) + '\n')
 
         if variables:
             if isinstance(variables, dict):


### PR DESCRIPTION
Avoid joining a list just to split it again.

The main performance problem in the line wrapping came from lines that were
thousands of characters long, and those came from a single location, build.

This patch jumps past _line and the slow code, by emitting the file
list with one file per line. It even becomes easier to read that way.
Everyone is a winner.

This saves about 1 CPU second when running gyp for chromium.

(Not wrapping at all is slightly faster but only by 0.1 second or so).