### PR TITLE
Enable throttling console output using $NINJA_LINES_PER_SECOND.

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -190,10 +190,11 @@ you don't need to pass `-j`.)
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 
-Ninja supports one environment variable to control its behavior:
-`NINJA_STATUS`, the progress status printed before the rule being run.
+Ninja supports environment variables to control its behavior:
+`NINJA_STATUS`:: the progress status printed before the rule being run; and
+`NINJA_LINES_PER_SECOND`:: a cap on how verbose ninja should be.
 
-Several placeholders are available:
+Several placeholders are available for `NINJA_STATUS`:
 
 `%s`:: The number of started edges.
 `%t`:: The total number of edges that must be run to complete the build.
@@ -210,6 +211,10 @@ specified by `-j` or its default)
 The default progress status is `"[%s/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status
 could be `"[%u/%r/%f] "`.
+
+The default for `NINJA_LINES_PER_SECOND` is -1 (no throttling).  A positive
+value means try to emit no more than that many lines per second; a value of 0
+means emit no status lines.
 
 Extra tools
 ~~~~~~~~~~~

--- a/src/build.cc
+++ b/src/build.cc
@@ -75,6 +75,7 @@ BuildStatus::BuildStatus(const BuildConfig& config)
     : config_(config),
       start_time_millis_(GetTimeMillis()),
       started_edges_(0), finished_edges_(0), total_edges_(0),
+      printer_(config.lines_per_second),
       progress_status_format_(NULL),
       overall_rate_(), current_rate_(config.parallelism) {
 

--- a/src/build.h
+++ b/src/build.h
@@ -137,6 +137,9 @@ struct BuildConfig {
   /// The maximum load average we must not exceed. A negative value
   /// means that we do not have any limit.
   double max_load_average;
+  /// The number of emitted lines per second we should not exceed.  A negative
+  /// value means no limit.
+  double lines_per_second;
 };
 
 /// Builder wraps the build process: starting commands, updating status.

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -26,7 +26,9 @@
 
 #include "util.h"
 
-LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
+LinePrinter::LinePrinter(double lines_per_second)
+    : have_blank_line_(true), console_locked_(false),
+      seconds_per_line_(1/lines_per_second) {
 #ifndef _WIN32
   const char* term = getenv("TERM");
   smart_terminal_ = isatty(1) && term && string(term) != "dumb";
@@ -49,6 +51,9 @@ void LinePrinter::Print(string to_print, LineType type) {
     return;
   }
 
+  if (stopwatch_.Elapsed() < seconds_per_line_)
+    return;
+  stopwatch_.Restart();
 #ifdef _WIN32
   CONSOLE_SCREEN_BUFFER_INFO csbi;
   GetConsoleScreenBufferInfo(console_, &csbi);

--- a/src/line_printer.h
+++ b/src/line_printer.h
@@ -17,12 +17,17 @@
 
 #include <stddef.h>
 #include <string>
+#include "metrics.h"
+
 using namespace std;
 
 /// Prints lines of text, possibly overprinting previously printed lines
 /// if the terminal supports it.
 struct LinePrinter {
-  LinePrinter();
+  /// Request this printer emit no more frequently than |lines_per_second|.
+  /// Note that multi-line output can violate this request; it is a soft limit
+  /// only.
+  explicit LinePrinter(double lines_per_second);
 
   bool is_smart_terminal() const { return smart_terminal_; }
   void set_smart_terminal(bool smart) { smart_terminal_ = smart; }
@@ -60,6 +65,11 @@ struct LinePrinter {
 
   /// Buffered console output while console is locked.
   string output_buffer_;
+
+  /// Throttling helpers: the inverse of the contructor-requested limit and the
+  /// Stopwatch that helps enforce it.
+  const double seconds_per_line_;  // \inf==silence, <0==no throttle.
+  Stopwatch stopwatch_;
 
 #ifdef _WIN32
   void* console_;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -938,6 +938,16 @@ int ReadFlags(int* argc, char*** argv,
               Options* options, BuildConfig* config) {
   config->parallelism = GuessParallelism();
 
+  double lines_per_second = -1;
+  const char* ninja_lines_per_second = getenv("NINJA_LINES_PER_SECOND");
+  if (ninja_lines_per_second) {
+    char* endptr = NULL;
+    lines_per_second = strtod(ninja_lines_per_second, &endptr);
+    if (errno || endptr == ninja_lines_per_second || *endptr)
+      Fatal("Invalid NINJA_LINES_PER_SECOND environment variable");
+  }
+  config->lines_per_second = lines_per_second;
+
   enum { OPT_VERSION = 1 };
   const option kLongOptions[] = {
     { "help", no_argument, NULL, 'h' },

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -32,7 +32,8 @@ string StringPrintf(const char* format, ...) {
 
 /// A test result printer that's less wordy than gtest's default.
 struct LaconicPrinter : public testing::EmptyTestEventListener {
-  LaconicPrinter() : tests_started_(0), test_count_(0), iteration_(0) {}
+  LaconicPrinter()
+      : printer_(-1), tests_started_(0), test_count_(0), iteration_(0) {}
   virtual void OnTestProgramStart(const testing::UnitTest& unit_test) {
     test_count_ = unit_test.test_to_run_count();
   }


### PR DESCRIPTION
This addresses https://github.com/martine/ninja/issues/663
(does github have a BUG= equivalent?  \noideadog{me on github})
