### PR TITLE
Fix bash-completion support for -C option to expand tilde

### DIFF
--- a/misc/bash-completion
+++ b/misc/bash-completion
@@ -19,23 +19,23 @@ _ninja_target() {
     local cur targets dir line targets_command OPTIND
     cur="${COMP_WORDS[COMP_CWORD]}"
 
-		if [[ "$cur" == "--"* ]]; then
-			# there is currently only one argument that takes --
-			COMPREPLY=($(compgen -P '--' -W 'version' -- "${cur:2}"))
-		else
-			dir="."
-			line=$(echo ${COMP_LINE} | cut -d" " -f 2-)
-			# filter out all non relevant arguments but keep C for dirs
-			while getopts C:f:j:l:k:nvd:t: opt $line; do
-				case $opt in
-					# eval for tilde expansion
-					C) eval dir="$OPTARG" ;;
-				esac
-			done;
-			targets_command="eval ninja -C \"${dir}\" -t targets all"
-			targets=$((${targets_command} 2>/dev/null) | awk -F: '{print $1}')
-			COMPREPLY=($(compgen -W "$targets" -- "$cur"))
-		fi
+    if [[ "$cur" == "--"* ]]; then
+        # there is currently only one argument that takes --
+	COMPREPLY=($(compgen -P '--' -W 'version' -- "${cur:2}"))
+    else
+	dir="."
+	line=$(echo ${COMP_LINE} | cut -d" " -f 2-)
+        # filter out all non relevant arguments but keep C for dirs
+	while getopts C:f:j:l:k:nvd:t: opt $line; do
+	    case $opt in
+                # eval for tilde expansion
+		C) eval dir="$OPTARG" ;;
+	    esac
+	done;
+	targets_command="eval ninja -C \"${dir}\" -t targets all"
+	targets=$((${targets_command} 2>/dev/null) | awk -F: '{print $1}')
+	COMPREPLY=($(compgen -W "$targets" -- "$cur"))
+    fi
     return
 }
 complete -F _ninja_target ninja


### PR DESCRIPTION
This fixes broken exansion when using -C option with directory paths like ~/foo/bar
