### PR TITLE
Stylistic changes to ninja_syntax.py

### DIFF
--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -8,7 +8,6 @@ use Python.
 """
 
 import textwrap
-import re
 
 def escape_path(word):
     return word.replace('$ ', '$$ ').replace(' ', '$ ').replace(':', '$:')


### PR DESCRIPTION
I was browsing the Ninja source code, and saw some Python indentation inconsistencies. Also, PyLint informed me that the `re` module is not actually used in this file, so no need to import it.
