### PR TITLE
compdb: check that inputs is not empty

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -631,6 +631,8 @@ int NinjaMain::ToolCompilationDatabase(int argc, char* argv[]) {
   putchar('[');
   for (vector<Edge*>::iterator e = state_.edges_.begin();
        e != state_.edges_.end(); ++e) {
+    if ((*e)->inputs_.empty())
+      continue;
     for (int i = 0; i != argc; ++i) {
       if ((*e)->rule_->name() == argv[i]) {
         if (!first)


### PR DESCRIPTION
Ignore rules without inputs when using the `compdb` tool.
