### PR TITLE
Allow + in filenames without escaping

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -183,6 +183,7 @@ static inline bool IsKnownShellSafeCharacter(char ch) {
 
   switch (ch) {
     case '_':
+    case '+':
     case '-':
     case '.':
     case '/':

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -148,7 +148,7 @@ TEST(PathEscaping, TortureTest) {
 }
 
 TEST(PathEscaping, SensiblePathsAreNotNeedlesslyEscaped) {
-  const char* path = "some/sensible/path/without/crazy/characters.cc";
+  const char* path = "some/sensible/path/without/crazy/characters.c++";
   string result;
 
   GetWin32EscapedString(path, &result);
@@ -160,7 +160,7 @@ TEST(PathEscaping, SensiblePathsAreNotNeedlesslyEscaped) {
 }
 
 TEST(PathEscaping, SensibleWin32PathsAreNotNeedlesslyEscaped) {
-  const char* path = "some\\sensible\\path\\without\\crazy\\characters.cc";
+  const char* path = "some\\sensible\\path\\without\\crazy\\characters.c++";
   string result;
 
   GetWin32EscapedString(path, &result);


### PR DESCRIPTION
Due to #690, file.c++ used to be escaped. + seems as safe as -, so allow
it to not be escaped, to keep compile command lines with a fairly common
extension slightly cleaner.
