### PR TITLE
Added highlighting in Emacs for ${...} variables

### DIFF
--- a/misc/ninja-mode.el
+++ b/misc/ninja-mode.el
@@ -31,7 +31,7 @@
        '("\\([[:alnum:]_]+\\) =" . (1 font-lock-variable-name-face))
        ;; Variable expansion.
        '("\\($[[:alnum:]_]+\\)" . (1 font-lock-variable-name-face))
-	   '("\\(${[[:alnum:]_]+}\\)" . (1 font-lock-variable-name-face))
+       '("\\(${[[:alnum:]._]+}\\)" . (1 font-lock-variable-name-face))
        ;; Rule names
        '("rule \\([[:alnum:]_]+\\)" . (1 font-lock-function-name-face))
        ))


### PR DESCRIPTION
This branch adds syntax highlighting in Emacs for variables enclosed in curly brackets, like (from Ninja's own build.ninja) ${configure_env}python
