### PR TITLE
Update ninja-mode for emacs to handle hyphens in rule names

### DIFF
--- a/misc/ninja-mode.el
+++ b/misc/ninja-mode.el
@@ -32,7 +32,7 @@
        ;; Variable expansion.
        '("\\($[[:alnum:]_]+\\)" . (1 font-lock-variable-name-face))
        ;; Rule names
-       '("rule \\([[:alnum:]_]+\\)" . (1 font-lock-function-name-face))
+       '("rule \\([[:alnum:]_-]+\\)" . (1 font-lock-function-name-face))
        ))
 
 ;;;###autoload       


### PR DESCRIPTION
This one character patch means that rule definitions such as `rule do-something` correctly highlight all of the rule name
