### PR TITLE
Add highlighting of rule in build statements

### DIFF
--- a/misc/ninja-mode.el
+++ b/misc/ninja-mode.el
@@ -32,7 +32,11 @@
        ;; Variable expansion.
        '("\\($[[:alnum:]_]+\\)" . (1 font-lock-variable-name-face))
        ;; Rule names
-       '("rule \\([[:alnum:]_-]+\\)" . (1 font-lock-function-name-face))
+       '("rule +\\([[:alnum:]_.-]+\\)" . (1 font-lock-function-name-face))
+       ;; Build Statement - highlight the rule used, allow for escaped $,: in outputs
+       '("build +\\(?:[^:$\n]\\|$[:$]\\)+ *: *\\([[:alnum:]_.-]+\\)" .
+         (1 font-lock-function-name-face))
+       
        ))
 
 ;;;###autoload       


### PR DESCRIPTION
Highlight the rule being used in a build statement.  Also add `.` to acceptable characters in a rule name and relax whitespace matching before the name.
