### PR TITLE
add some parens to silence a gcc warning

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -89,7 +89,7 @@ bool IsWindows7OrLater() {
   if (!GetVersionEx(&version_info))
     Fatal("GetVersionEx: %s", GetLastErrorString().c_str());
   return version_info.dwMajorVersion > 6 ||
-         version_info.dwMajorVersion == 6 && version_info.dwMinorVersion >= 1;
+         (version_info.dwMajorVersion == 6 && version_info.dwMinorVersion >= 1);
 }
 #pragma warning(pop)
 


### PR DESCRIPTION
Found this when building under Wine.  I think the code as written is fine but I also like being warning clean.
