### PR TITLE
Emacs mode: inherit from prog-mode

### DIFF
--- a/misc/ninja-mode.el
+++ b/misc/ninja-mode.el
@@ -39,8 +39,8 @@
        
        ))
 
-;;;###autoload       
-(define-derived-mode ninja-mode fundamental-mode "ninja"
+;;;###autoload
+(define-derived-mode ninja-mode prog-mode "ninja"
   (setq comment-start "#")
   ; Pass extra "t" to turn off syntax-based fontification -- we don't want
   ; quoted strings highlighted.


### PR DESCRIPTION
`prog-mode` ensures a final newline when saving files, which is useful
since ninja fails otherwise.

See `require-final-newline` and `mode-require-final-newline`.
