### PR TITLE
Fix building tests on Windows again.

### DIFF
--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -17,12 +17,12 @@
 #include "util.h"
 #include "test.h"
 
+#include <sys/stat.h>
 #ifdef _WIN32
 #include <fcntl.h>
 #include <share.h>
 #else
 #include <sys/types.h>
-#include <sys/stat.h>
 #include <unistd.h>
 #endif
 

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -14,9 +14,9 @@
 
 #include "deps_log.h"
 
+#include <sys/stat.h>
 #ifndef _WIN32
 #include <unistd.h>
-#include <sys/stat.h>
 #endif
 
 #include "graph.h"

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -299,7 +299,7 @@ getopt_internal (int argc, char **argv, char *shortopts,
           return (optopt = '?');
         }
       has_arg = ((cp[1] == ':')
-                 ? ((cp[2] == ':') ? OPTIONAL_ARG : REQUIRED_ARG) : no_argument);
+                 ? ((cp[2] == ':') ? OPTIONAL_ARG : required_argument) : no_argument);
       possible_arg = argv[optind] + optwhere + 1;
       optopt = *cp;
     }
@@ -318,7 +318,7 @@ getopt_internal (int argc, char **argv, char *shortopts,
       else
         optarg = NULL;
       break;
-    case REQUIRED_ARG:
+    case required_argument:
       if (*possible_arg == '=')
         possible_arg++;
       if (*possible_arg != '\0')

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -4,9 +4,9 @@
 /* include files needed by this include file */
 
 /* macros defined by this include file */
-#define no_argument     0
-#define REQUIRED_ARG    1
-#define OPTIONAL_ARG    2
+#define no_argument       0
+#define required_argument 1
+#define OPTIONAL_ARG      2
 
 /* types defined by this include file */
 

--- a/src/includes_normalize_test.cc
+++ b/src/includes_normalize_test.cc
@@ -14,6 +14,8 @@
 
 #include "includes_normalize.h"
 
+#include <direct.h>
+
 #include "test.h"
 #include "util.h"
 

--- a/src/test.cc
+++ b/src/test.cc
@@ -12,21 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifdef _WIN32
+#include <direct.h>  // Has to be before util.h is included.
+#endif
+
 #include "test.h"
 
 #include <algorithm>
 
 #include <errno.h>
-
-#include "build_log.h"
-#include "manifest_parser.h"
-#include "util.h"
-
 #ifdef _WIN32
 #include <windows.h>
 #else
 #include <unistd.h>
 #endif
+
+#include "build_log.h"
+#include "manifest_parser.h"
+#include "util.h"
 
 namespace {
 


### PR DESCRIPTION
Turns out gtest was pulling in sys/stat.h, and we were
using stat() through that in tests. This doesn't work
with old MSVCs, so we should probably replace that with
RealDiskInterface in a follow-up.
