### PR TITLE
Throttle the number of pending commands by the parallelism configuration

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -488,7 +488,9 @@ void RealCommandRunner::Abort() {
 }
 
 bool RealCommandRunner::CanRunMore() {
-  return ((int)subprocs_.running_.size()) < config_.parallelism
+  size_t subproc_number =
+      subprocs_.running_.size() + subprocs_.finished_.size();
+  return (int)subproc_number < config_.parallelism
     && ((subprocs_.running_.empty() || config_.max_load_average <= 0.0f)
         || GetLoadAverage() < config_.max_load_average);
 }


### PR DESCRIPTION
PTL.

Regarding .ninja_log entries, more than |parallelism| number of build log entries overlap, that confuses profiling tools of the build process.
That is due to Builder to start subsequent build process before finalizing previous one.
Can I throttle the build process when Builder has enough many pending subprocess?
