### PR TITLE
Make auto-reconfiguring work if CFLAGS contains more than one flag.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 
 from optparse import OptionParser
 import os
+import pipes
 import sys
 import platform_helper
 sys.path.insert(0, 'misc')
@@ -77,7 +78,8 @@ n.variable('configure_args', ' '.join(sys.argv[1:]))
 env_keys = set(['CXX', 'AR', 'CFLAGS', 'LDFLAGS'])
 configure_env = dict((k, os.environ[k]) for k in os.environ if k in env_keys)
 if configure_env:
-    config_str = ' '.join([k + '=' + configure_env[k] for k in configure_env])
+    config_str = ' '.join([k + '=' + pipes.quote(configure_env[k])
+                           for k in configure_env])
     n.variable('configure_env', config_str + '$ ')
 n.newline()
 


### PR DESCRIPTION
When using an open-source clang on OS X, one has to pass an isysroot
flag so that it can find system headers (stdio.h), like so:

  CXX=path/to/clang++ CFLAGS="-isysroot $(xcrun -show-sdk-path)" ./configure.py

Previously, configure.py wouldn't quote envvars containing spaces, so
it'd rerun this as

  CXX=path/to/clang++ CFLAGS=-isysroot /sysroot/path ./configure.py

which would then die because /sysroot/path wasn't excecutable.
