### PR TITLE
Suppress warnings from building with MinGW

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -82,8 +82,10 @@ TimeStamp StatSingleFile(const string& path, bool quiet) {
   return TimeStampFromFileTime(attrs.ftLastWriteTime);
 }
 
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4996)  // GetVersionExA is deprecated post SDK 8.1.
+#endif
 bool IsWindows7OrLater() {
   OSVERSIONINFO version_info = { sizeof(version_info) };
   if (!GetVersionEx(&version_info))
@@ -91,7 +93,9 @@ bool IsWindows7OrLater() {
   return version_info.dwMajorVersion > 6 ||
          (version_info.dwMajorVersion == 6 && version_info.dwMinorVersion >= 1);
 }
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif
 
 bool StatAllFilesInDir(const string& dir, map<string, TimeStamp>* stamps,
                        bool quiet) {


### PR DESCRIPTION
Hello,

Just a simple patch. In MinGW g++ there are no `#pragma warning(pop)` etc pragmas. The macro currently detects if it's Windows by doing `#ifdef _WIN32` but MinGW is used through Windows too so the unknown pragma triggers a warning for g++.

All this patch does is surround the pragmas with `#ifdef _MSC_VER` blocks to suppress the warnings in MinGW.
