### PR TITLE
Allow the user to specify what shell to use for commands

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -495,7 +495,7 @@ bool RealCommandRunner::CanRunMore() {
 
 bool RealCommandRunner::StartCommand(Edge* edge) {
   string command = edge->EvaluateCommand();
-  Subprocess* subproc = subprocs_.Add(command, edge->use_console());
+  Subprocess* subproc = subprocs_.Add(command, edge->use_console(), edge->GetBinding("shell"));
   if (!subproc)
     return false;
   subproc_to_edge_.insert(make_pair(subproc, edge));

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -72,7 +72,7 @@ HANDLE Subprocess::SetupPipe(HANDLE ioport) {
   return output_write_child;
 }
 
-bool Subprocess::Start(SubprocessSet* set, const string& command) {
+bool Subprocess::Start(SubprocessSet* set, const string& command, const string& shell) {
   HANDLE child_pipe = SetupPipe(set->ioport_);
 
   SECURITY_ATTRIBUTES security_attributes;

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -45,7 +45,7 @@ struct Subprocess {
 
  private:
   Subprocess(bool use_console);
-  bool Start(struct SubprocessSet* set, const string& command);
+  bool Start(struct SubprocessSet* set, const string& command, const string& shell);
   void OnPipeReady();
 
   string buf_;
@@ -76,7 +76,7 @@ struct SubprocessSet {
   SubprocessSet();
   ~SubprocessSet();
 
-  Subprocess* Add(const string& command, bool use_console = false);
+  Subprocess* Add(const string& command, bool use_console = false, const string& shell = string());
   bool DoWork();
   Subprocess* NextFinished();
   void Clear();


### PR DESCRIPTION
This is done by assigning to the ‘shell’ variable, e.g.:

```
shell = /bin/bash
```

The commit uses the GetBinding function to obtain the value of the shell variable, but ideally it should obtain the value without going through shell escaping.
