### PR TITLE
Add zsh completion for targets in conjunction with -C

### DIFF
--- a/misc/zsh-completion
+++ b/misc/zsh-completion
@@ -17,7 +17,14 @@
 #   . path/to/ninja/misc/zsh-completion
 
 __get_targets() {
-  ninja -t targets 2>/dev/null | while read -r a b; do echo $a | cut -d ':' -f1; done;
+  dir="."
+  if [ -n "${opt_args[-C]}" ];
+  then
+    eval dir="${opt_args[-C]}"
+  fi
+  targets_command="ninja -C \"${dir}\" -t targets"
+  eval ${targets_command} 2>/dev/null | while read -r a b; do echo $a | cut -d ':' -f1; done;
+
 }
 
 __get_tools() {


### PR DESCRIPTION
zsh can now list completions for targets in the directory specified by
the -C option
