### PR TITLE
modify sed commands to handle non-GNU and GNU od

### DIFF
--- a/src/inline.sh
+++ b/src/inline.sh
@@ -22,7 +22,7 @@
 varname="$1"
 echo "const char $varname[] ="
 od -t x1 -A n -v |
-  awk '{printf "\""; for(i=1; i<=NF; i++){ printf "\x"$i}; print "\"";  }'
+  awk '{printf "\""; for(i=1; i<=NF; i++){ printf "\\x"$i}; print "\"";  }'
 echo ";"
 
 


### PR DESCRIPTION
Another one-line fix :) tested on solaris, seems to generate identical browse_py.h
