### PR TITLE
Use strchr in \ conversion in CanonicalizePath on Windows

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -107,9 +107,8 @@ bool CanonicalizePath(char* path, size_t* len, string* err) {
   }
 
 #ifdef _WIN32
-  for (char* c = path; *c; ++c)
-    if (*c == '\\')
-      *c = '/';
+  for (char* c = path; (c = strchr(c, '\\')) != NULL;)
+    *c = '/';
 #endif
 
   const int kMaxPathComponents = 30;


### PR DESCRIPTION
Average of 7 runs with slowest/fastest discarded, each 5x. Lowest average:

Inlined loop: 1216284us
strchr: 1199786us

Not every run is faster, but might be a hair faster overall.
