### PR TITLE
Fix building on Solaris.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -159,7 +159,7 @@ libs = []
 if platform.is_mingw():
     cflags.remove('-fvisibility=hidden');
     ldflags.append('-static')
-elif platform.is_sunos5():
+elif platform.is_solaris():
     cflags.remove('-fvisibility=hidden')
 elif platform.is_msvc():
     pass

--- a/platform_helper.py
+++ b/platform_helper.py
@@ -35,7 +35,7 @@ class Platform(object):
             self._platform = 'freebsd'
         elif self._platform.startswith('openbsd'):
             self._platform = 'openbsd'
-        elif self._platform.startswith('solaris'):
+        elif self._platform.startswith('solaris') or self._platform == 'sunos5':
             self._platform = 'solaris'
         elif self._platform.startswith('mingw'):
             self._platform = 'mingw'
@@ -77,9 +77,6 @@ class Platform(object):
 
     def is_openbsd(self):
         return self._platform == 'openbsd'
-
-    def is_sunos5(self):
-        return self._platform == 'sunos5'
 
     def is_bitrig(self):
         return self._platform == 'bitrig'


### PR DESCRIPTION
"SunOS" and "Solaris" are the same thing these days, so make them go
down the same code paths. In particular, the browse feature was omitted
on solaris but not sunos5, causing trouble for some folks (see #838).
