### PR TITLE
Make sure configure.py and ninja.cc always agree on if -t browse is incl...

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -175,6 +175,10 @@ if (platform.is_linux() or platform.is_openbsd() or platform.is_bitrig()) and \
         not options.force_pselect:
     cflags.append('-DUSE_PPOLL')
 
+have_browse = not platform.is_windows() and not platform.is_solaris()
+if have_browse:
+    cflags.append('-DNINJA_HAVE_BROWSE')
+
 def shell_escape(str):
     """Escape str such that it's interpreted as a single argument by
     the shell."""
@@ -233,7 +237,7 @@ n.newline()
 
 objs = []
 
-if not platform.is_windows() and not platform.is_solaris():
+if have_browse:
     n.comment('browse_py.h is used to inline browse.py.')
     n.rule('inline',
            command='src/inline.sh $varname < $in > $out',

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -365,7 +365,7 @@ int NinjaMain::ToolQuery(int argc, char* argv[]) {
   return 0;
 }
 
-#if !defined(_WIN32) && !defined(NINJA_BOOTSTRAP)
+#if defined(NINJA_HAVE_BROWSE)
 int NinjaMain::ToolBrowse(int argc, char* argv[]) {
   if (argc < 1) {
     Error("expected a target to browse");
@@ -698,7 +698,7 @@ int NinjaMain::ToolUrtle(int argc, char** argv) {
 /// Returns a Tool, or NULL if Ninja should exit.
 const Tool* ChooseTool(const string& tool_name) {
   static const Tool kTools[] = {
-#if !defined(_WIN32) && !defined(NINJA_BOOTSTRAP)
+#if defined(NINJA_HAVE_BROWSE)
     { "browse", "browse dependency graph in a web browser",
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolBrowse },
 #endif


### PR DESCRIPTION
...uded.

No behavior change on most platforms. On solaris, -t browse was compiled in
in ninja.cc but browse.cc wasn't compiled in, which probably means that building
on Solaris didn't work. It might be better now.

This also makes browse.cc automatically not included in bootstrap builds;
previously this was done manually through the NINJA_BOOTSTRAP check.
