### PR TITLE
Build minidump code during bootstrap with msvs.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -105,8 +105,7 @@ if platform.is_msvc():
 else:
     args = shlex.split(os.environ.get('CXX', 'g++'))
     cflags.extend(['-Wno-deprecated',
-                   '-DNINJA_PYTHON="' + sys.executable + '"',
-                   '-DNINJA_BOOTSTRAP'])
+                   '-DNINJA_PYTHON="' + sys.executable + '"'])
     if platform.is_windows():
         cflags.append('-D_WIN32_WINNT=0x0501')
     if options.x64:

--- a/src/minidump-win32.cc
+++ b/src/minidump-win32.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NINJA_BOOTSTRAP
+#if defined(_MSC_VER)
 
 #include <windows.h>
 #include <DbgHelp.h>
@@ -85,4 +85,4 @@ void CreateWin32MiniDump(_EXCEPTION_POINTERS* pep) {
   Warning("minidump created: %s", temp_file);
 }
 
-#endif  // NINJA_BOOTSTRAP
+#endif  // _MSC_VER

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1111,7 +1111,7 @@ int real_main(int argc, char** argv) {
 }  // anonymous namespace
 
 int main(int argc, char** argv) {
-#if !defined(NINJA_BOOTSTRAP) && defined(_MSC_VER)
+#if defined(_MSC_VER)
   // Set a handler to catch crashes not caught by the __try..__except
   // block (e.g. an exception in a stack-unwind-block).
   set_terminate(TerminateHandler);


### PR DESCRIPTION
Nobody remembers why it wasn't built, and bootstrapping
still works with msvs and mingw after this change. Removing
this allows removing the NINJA_BOOTSTRAP define, which makes
things a tiny bit simpler.

No behavior change.
