### PR TITLE
Stop linking pthread.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -490,7 +490,6 @@ if options.bootstrap:
 
 n.comment('Tests all build into ninja_test executable.')
 
-test_libs = libs
 objs = []
 
 for name in ['build_log_test',
@@ -514,7 +513,7 @@ if platform.is_windows():
         objs += cxx(name)
 
 ninja_test = n.build(binary('ninja_test'), 'link', objs, implicit=ninja_lib,
-                     variables=[('libs', test_libs)])
+                     variables=[('libs', libs)])
 n.newline()
 all_targets += ninja_test
 


### PR DESCRIPTION
It was only needed by gtest, which is no longer used.
(Intesting note: I checked when the -lpthread flag was added, and it's
been around since the first revision of build.ninja, which used to be
checked in before configure.py existed. Back then, it looks like '@' was
used to dereference built-in variables, and build outputs were also
prefixed by '@'!).
