### PR TITLE
Ninja mode.el refactor

### DIFF
--- a/misc/ninja-mode.el
+++ b/misc/ninja-mode.el
@@ -1,4 +1,4 @@
-;;; ninja-mode.el --- Major mode for editing .ninja files
+;;; ninja-mode.el --- Major mode for editing .ninja files -*- lexical-binding: t -*-
 
 ;; Package-Requires: ((emacs "24"))
 


### PR DESCRIPTION
An attempt to make `ninja-mode.el` slightly less bad.

The changes are mostly about making `ninja-mode.el` a good Emacs citizen, with no major changes. Most of it is style cleanups, except

```
0a0ee58     Set up a proper syntax table for ninja-mode.
1bd6301     Correctly recognize comments. 
```

which make `syntax-ppss` and everything relying on it behave sanely.

Should I squash the hell out of the commits?
