### PR TITLE
Revert #223, fixes #874.

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -241,12 +241,11 @@ bool NinjaMain::RebuildManifest(const char* input_file, string* err) {
 
   if (builder.AlreadyUpToDate())
     return false;  // Not an error, but we didn't rebuild.
-  if (!builder.Build(err))
-    return false;
 
-  // The manifest was only rebuilt if it is now dirty (it may have been cleaned
-  // by a restat).
-  return node->dirty();
+  // Even if the manifest was cleaned by a restat rule, claim that it was
+  // rebuilt.  Not doing so can lead to crashes, see
+  // https://github.com/martine/ninja/issues/874
+  return builder.Build(err);
 }
 
 Node* NinjaMain::CollectTarget(const char* cpath, string* err) {


### PR DESCRIPTION
No test since there's still no good way to test code in ninja.cc.  Going
forward, either move NinjaMain to its own file with tests, or create a
system that makes it possible to run integration tests on the ninja
binary.  Instead, add a comment that explains why the restat
optimization isn't done.
