### PR TITLE
Remove 'Recompacting...' messages.

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -102,7 +102,7 @@ BuildLog::LogEntry::LogEntry(const string& output, uint64_t command_hash,
 {}
 
 BuildLog::BuildLog()
-  : log_file_(NULL), needs_recompaction_(false), quiet_(false) {}
+  : log_file_(NULL), needs_recompaction_(false) {}
 
 BuildLog::~BuildLog() {
   Close();
@@ -354,8 +354,6 @@ bool BuildLog::WriteEntry(FILE* f, const LogEntry& entry) {
 bool BuildLog::Recompact(const string& path, const BuildLogUser& user,
                          string* err) {
   METRIC_RECORD(".ninja_log recompact");
-  if (!quiet_)
-    printf("Recompacting log...\n");
 
   Close();
   string temp_path = path + ".recompact";

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -80,7 +80,6 @@ struct BuildLog {
 
   /// Rewrite the known log entries, throwing away old data.
   bool Recompact(const string& path, const BuildLogUser& user, string* err);
-  void set_quiet(bool quiet) { quiet_ = quiet; }
 
   typedef ExternalStringHashMap<LogEntry*>::Type Entries;
   const Entries& entries() const { return entries_; }
@@ -89,7 +88,6 @@ struct BuildLog {
   Entries entries_;
   FILE* log_file_;
   bool needs_recompaction_;
-  bool quiet_;
 };
 
 #endif // NINJA_BUILD_LOG_H_

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -290,7 +290,6 @@ TEST_F(BuildLogRecompactTest, Recompact) {
   ASSERT_TRUE(log2.LookupByOutput("out"));
   ASSERT_TRUE(log2.LookupByOutput("out2"));
   // ...and force a recompaction.
-  log2.set_quiet(true);
   EXPECT_TRUE(log2.OpenForWrite(kTestFilename, *this, &err));
   log2.Close();
 

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -307,8 +307,6 @@ DepsLog::Deps* DepsLog::GetDeps(Node* node) {
 
 bool DepsLog::Recompact(const string& path, string* err) {
   METRIC_RECORD(".ninja_deps recompact");
-  if (!quiet_)
-    printf("Recompacting deps...\n");
 
   Close();
   string temp_path = path + ".recompact";

--- a/src/deps_log.h
+++ b/src/deps_log.h
@@ -64,7 +64,7 @@ struct State;
 /// wins, allowing updates to just be appended to the file.  A separate
 /// repacking step can run occasionally to remove dead records.
 struct DepsLog {
-  DepsLog() : needs_recompaction_(false), quiet_(false), file_(NULL) {}
+  DepsLog() : needs_recompaction_(false), file_(NULL) {}
   ~DepsLog();
 
   // Writing (build-time) interface.
@@ -87,7 +87,6 @@ struct DepsLog {
 
   /// Rewrite the known log entries, throwing away old data.
   bool Recompact(const string& path, string* err);
-  void set_quiet(bool quiet) { quiet_ = quiet; }
 
   /// Returns if the deps entry for a node is still reachable from the manifest.
   ///
@@ -109,7 +108,6 @@ struct DepsLog {
   bool RecordId(Node* node);
 
   bool needs_recompaction_;
-  bool quiet_;
   FILE* file_;
 
   /// Maps id -> Node.

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -252,7 +252,6 @@ TEST_F(DepsLogTest, Recompact) {
     ASSERT_EQ("foo.h", deps->nodes[0]->path());
     ASSERT_EQ("baz.h", deps->nodes[1]->path());
 
-    log.set_quiet(true);
     ASSERT_TRUE(log.Recompact(kTestFilename, &err));
 
     // The in-memory deps graph should still be valid after recompaction.
@@ -302,7 +301,6 @@ TEST_F(DepsLogTest, Recompact) {
     ASSERT_EQ("foo.h", deps->nodes[0]->path());
     ASSERT_EQ("baz.h", deps->nodes[1]->path());
 
-    log.set_quiet(true);
     ASSERT_TRUE(log.Recompact(kTestFilename, &err));
 
     // The previous entries should have been removed.


### PR DESCRIPTION
Recompacting the build log used to be slow, so it made sense to print this
message.  We then made recompaction much faster, but didn't remove this
message back then.

The deps log only has it because the build log had it.

Since both steps are effectively instant in practice, remove these log messages.

---

If someone dislikes this change for whatever reason, please shout. Else, I'll merge this in a week or two.
