### PR TITLE
zsh-completion: remove use of 'head' with negative offset

### DIFF
--- a/misc/zsh-completion
+++ b/misc/zsh-completion
@@ -32,7 +32,7 @@ __get_tools() {
 }
 
 __get_modes() {
-  ninja -d list 2>/dev/null | while read -r a b; do echo $a; done | tail -n +2 | head -n -1
+  ninja -d list 2>/dev/null | while read -r a b; do echo $a; done | tail -n +2 | sed '$d'
 }
 
 __modes() {


### PR DESCRIPTION
Some systems - like OSX - don't come with a version of head that
supports a negative value for the -n flag. Such systems get a message
such as this when tab-completing ninja's -d flag:

```
ninja -dhead: illegal line count -- -1
```

Using sed instead should be more universally supported.
