### PR TITLE
Use a monotonic clock for measuring time.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -481,6 +481,9 @@ if platform.is_msvc():
 else:
     libs.append('-lninja')
 
+if platform.is_linux():
+    libs.append('-lrt')
+
 all_targets = []
 
 n.comment('Main executable is library plus main() function.')


### PR DESCRIPTION
gettimeofday() isn't accurate for measuring time because it can jump backwards/forwards.

I link to librt on Linux, I think it's only necessary on Linux. The FreeBSD man page says it's available in libc.

Tested on Linux and OS X.