### PR TITLE
Zero width format

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -207,6 +207,9 @@ Several placeholders are available:
 specified by `-j` or its default)
 `%e`:: Elapsed time in seconds.  _(Available since Ninja 1.2.)_
 `%%`:: A plain `%` character.
+`%0`:: Marks the start and end of a zero-width region (useful to exclude the
+width of color control codes from the elision width computation). _(Available
+since Ninja 1.6.)_
 
 The default progress status is `"[%f/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status

--- a/src/build.cc
+++ b/src/build.cc
@@ -245,6 +245,11 @@ string BuildStatus::FormatProgressStatus(
         break;
       }
 
+        // Zero-width marker (ignore).
+      case '0':
+        out += "%0";
+        break;
+
       default:
         Fatal("unknown placeholder '%%%c' in $NINJA_STATUS", *s);
         return "";

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -92,7 +92,7 @@ void LinePrinter::Print(string to_print, LineType type) {
 
     have_blank_line_ = false;
   } else {
-    printf("%s\n", to_print.c_str());
+    printf("%s\n", RemoveZeroWidthMarkers(to_print).c_str());
   }
 }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -597,7 +597,7 @@ double GetLoadAverage() {
 }
 #endif // _WIN32
 
-static string RemoveZeroWidthMarkers(const string& str) {
+string RemoveZeroWidthMarkers(const string& str) {
   string result;
   size_t last_open = 0;
   size_t open = 0;

--- a/src/util.cc
+++ b/src/util.cc
@@ -600,7 +600,7 @@ double GetLoadAverage() {
 string ElideMiddle(const string& str, size_t width) {
   const int kMargin = 3;  // Space for "...".
   string result = str;
-  if (result.size() + kMargin > width) {
+  if (result.size() > width) {
     size_t elide_size = (width - kMargin) / 2;
     result = result.substr(0, elide_size)
       + "..."

--- a/src/util.h
+++ b/src/util.h
@@ -81,6 +81,9 @@ int GetProcessorCount();
 /// on error.
 double GetLoadAverage();
 
+/// Remove zero-width markers.
+string RemoveZeroWidthMarkers(const string& str);
+
 /// Elide the given string @a str with '...' in the middle if the length
 /// exceeds @a width.
 string ElideMiddle(const string& str, size_t width);

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -399,3 +399,13 @@ TEST(ElideMiddle, ElideInTheMiddle) {
   string elided = ElideMiddle(input, 10);
   EXPECT_EQ("012...789", elided);
 }
+
+TEST(ElideMiddle, NothingToElideMiddleWithZeroWidth) {
+  string input = "Nothing %0zerowidth%0 string.";
+  EXPECT_EQ("Nothing zerowidth string.", ElideMiddle(input, 80));
+}
+
+TEST(ElideMiddle, ElideMiddleWithZeroWidth) {
+  string input = "0%0zerowidth%01234567890123456789";
+  EXPECT_EQ("0zerowidth12...789", ElideMiddle(input, 10));
+}


### PR DESCRIPTION
I decided to not do `%0{` and `%}` because the logic for control sequences more than just a single character is a messier. I can also change it over to `%{` and `%}` if separate open/close sequences are preferable. It is not (currently) an error to have mismatched open/close sequences, but it is also not a zero-width section and `%0` will be literal in that case.

---

Fixes #713.
