### PR TITLE
Added quiet mode

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -205,6 +205,7 @@ void Usage(const BuildConfig& config) {
 "  -l N     do not start new jobs if the load average is greater than N\n"
 "  -n       dry run (don't run commands but act like they succeeded)\n"
 "  -v       show all command lines while building\n"
+"  -q       hide all command lines while building\n"
 "\n"
 "  -d MODE  enable debugging (use -d list to list modes)\n"
 "  -t TOOL  run a subtool (use -t list to list subtools)\n"
@@ -1001,7 +1002,7 @@ int ReadFlags(int* argc, char*** argv,
 
   int opt;
   while (!options->tool &&
-         (opt = getopt_long(*argc, *argv, "d:f:j:k:l:nt:vw:C:h", kLongOptions,
+         (opt = getopt_long(*argc, *argv, "d:f:j:k:l:nt:vqw:C:h", kLongOptions,
                             NULL)) != -1) {
     switch (opt) {
       case 'd':
@@ -1049,6 +1050,9 @@ int ReadFlags(int* argc, char*** argv,
         break;
       case 'v':
         config->verbosity = BuildConfig::VERBOSE;
+        break;
+      case 'q':
+        config->verbosity = BuildConfig::QUIET;
         break;
       case 'w':
         if (!WarningEnable(optarg, options))


### PR DESCRIPTION
Very simple fix, was requested in https://github.com/martine/ninja/issues/480 and https://github.com/martine/ninja/issues/420.
This fix is useful when we run ninja from cmake from windows cmd, in this combination terminal print is very slow and ninja is able to finish work before cmd is able to print output to user.
