### PR TITLE
Don't set /Wx for MSVC

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -285,7 +285,6 @@ if platform.is_msvc():
               '/nologo',  # Don't print startup banner.
               '/Zi',  # Create pdb with debug info.
               '/W4',  # Highest warning level.
-              '/WX',  # Warnings as errors.
               '/wd4530', '/wd4100', '/wd4706',
               '/wd4512', '/wd4800', '/wd4702', '/wd4819',
               # Disable warnings about passing "this" during initialization.


### PR DESCRIPTION
Make the code future proof: If a new compiler / Windows SDK pulls in a new warnings, we
don't automatically want to make the build fail.

A good explanation can be found here: https://blog.flameeyes.eu/2009/02/future-proof-your-code-dont-use-werror#gsc.tab=0

This option was causing https://github.com/martine/ninja/issues/995