### PR TITLE
Print status when edge finishes on dumb terminals

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -96,7 +96,8 @@ void BuildStatus::BuildEdgeStarted(Edge* edge) {
   running_edges_.insert(make_pair(edge, start_time));
   ++started_edges_;
 
-  PrintStatus(edge);
+  if (edge->use_console() || printer_.is_smart_terminal())
+    PrintStatus(edge);
 
   if (edge->use_console())
     printer_.SetConsoleLocked(true);
@@ -121,7 +122,7 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
   if (config_.verbosity == BuildConfig::QUIET)
     return;
 
-  if (!edge->use_console() && printer_.is_smart_terminal())
+  if (!edge->use_console())
     PrintStatus(edge);
 
   // Print the command that is spewing before printing its output.


### PR DESCRIPTION
On smart terminals ninja prints the status line both before
and after running a command, reusing the same line if possible.
On a dumb terminal that doesn't support reusing the line, it
only prints the status before starting the command, but prints
the output of the command when the command finishes, by which
point other commands may have started and printed their status
line.  This makes it impossible to determine what command
produced a line of output.

Modify BuildEdgeStarted to only print the status line if the
command is going to lock the console, or if ninja is running
on a smart terminal.  Modify BuildEdgeFinished to always
print the status line unless the command locked the console,
in which case the status was already printed and no other
command can have printed any lines.

The end result will be dumb terminal output that much more
closely matches smart terminal output.  One disadvantage is
that dumb terminals won't show anything when starting a
command, making it harder to tell what commands are currently
running, but I expect most interactive uses of ninja will use
a smart terminal.