### PR TITLE
Support for AIX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ TAGS
 /build
 /build.ninja
 /ninja
+/ninja.bootstrap
 /build_log_perftest
 /canon_perftest
 /depfile_parser_perftest

--- a/configure.py
+++ b/configure.py
@@ -505,6 +505,9 @@ if platform.is_msvc():
 else:
     libs.append('-lninja')
 
+if platform.is_aix():
+    libs.append('-lperfstat')
+
 all_targets = []
 
 n.comment('Main executable is library plus main() function.')

--- a/configure.py
+++ b/configure.py
@@ -494,6 +494,8 @@ if platform.is_windows():
     objs += cc('getopt')
 else:
     objs += cxx('subprocess-posix')
+if platform.is_aix():
+    objs += cc('getopt')
 if platform.is_msvc():
     ninja_lib = n.build(built('ninja.lib'), 'ar', objs)
 else:

--- a/configure.py
+++ b/configure.py
@@ -58,11 +58,13 @@ class Platform(object):
             self._platform = 'bitrig'
         elif self._platform.startswith('netbsd'):
             self._platform = 'netbsd'
+        elif self._platform.startswith('aix'):
+            self._platform = 'aix'
 
     @staticmethod
     def known_platforms():
       return ['linux', 'darwin', 'freebsd', 'openbsd', 'solaris', 'sunos5',
-              'mingw', 'msvc', 'gnukfreebsd', 'bitrig', 'netbsd']
+              'mingw', 'msvc', 'gnukfreebsd', 'bitrig', 'netbsd', 'aix']
 
     def platform(self):
         return self._platform
@@ -89,6 +91,9 @@ class Platform(object):
     def is_solaris(self):
         return self._platform == 'solaris'
 
+    def is_aix(self):
+        return self._platform == 'aix'
+
     def uses_usr_local(self):
         return self._platform in ('freebsd', 'openbsd', 'bitrig')
 
@@ -96,7 +101,9 @@ class Platform(object):
         return self._platform in ('linux', 'openbsd', 'bitrig')
 
     def supports_ninja_browse(self):
-        return not self.is_windows() and not self.is_solaris()
+        return (not self.is_windows()
+                and not self.is_solaris()
+                and not self.is_aix())
 
 
 class Bootstrap:
@@ -344,6 +351,8 @@ if platform.is_mingw():
     cflags.remove('-fvisibility=hidden');
     ldflags.append('-static')
 elif platform.is_solaris():
+    cflags.remove('-fvisibility=hidden')
+elif platform.is_aix():
     cflags.remove('-fvisibility=hidden')
 elif platform.is_msvc():
     pass

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// On AIX, inttypes.h gets indirectly included by build_log.h.
+// It's easiest just to ask for the printf format macros right away.
+#ifndef _WIN32
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#endif
+
 #include "build_log.h"
 
 #include <errno.h>
@@ -19,9 +27,6 @@
 #include <string.h>
 
 #ifndef _WIN32
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
 #include <inttypes.h>
 #include <unistd.h>
 #endif

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -385,11 +385,13 @@ getopt_internal (int argc, char **argv, char *shortopts,
     return optopt;
 }
 
+#ifndef _AIX
 int
 getopt (int argc, char **argv, char *optstring)
 {
   return getopt_internal (argc, argv, optstring, NULL, NULL, 0);
 }
+#endif
 
 int
 getopt_long (int argc, char **argv, const char *shortopts,

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -39,7 +39,9 @@ extern "C"
   extern int optopt;
 
   /* function prototypes */
+#ifndef _AIX
   int getopt (int argc, char **argv, char *optstring);
+#endif
   int getopt_long (int argc, char **argv, const char *shortopts,
                    const GETOPT_LONG_OPTION_T * longopts, int *longind);
   int getopt_long_only (int argc, char **argv, const char *shortopts,

--- a/src/inline.sh
+++ b/src/inline.sh
@@ -20,6 +20,6 @@
 
 varname="$1"
 echo "const char $varname[] ="
-od -t x1 -A n -v | sed -e 's| ||g; s|..|\\x&|g; s|^|"|; s|$|"|'
+od -t x1 -A n -v | sed -e 's|[ \t]||g; s|..|\\x&|g; s|^|"|; s|$|"|'
 echo ";"
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -22,6 +22,9 @@
 #include "getopt.h"
 #include <direct.h>
 #include <windows.h>
+#elif defined(_AIX)
+#include "getopt.h"
+#include <unistd.h>
 #else
 #include <getopt.h>
 #include <unistd.h>

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -17,6 +17,9 @@
 
 #ifdef _WIN32
 #include "getopt.h"
+#elif defined(_AIX)
+#include "getopt.h"
+#include <unistd.h>
 #else
 #include <getopt.h>
 #endif

--- a/src/util.cc
+++ b/src/util.cc
@@ -45,6 +45,8 @@
 #elif defined(__SVR4) && defined(__sun)
 #include <unistd.h>
 #include <sys/loadavg.h>
+#elif defined(_AIX)
+#include <libperfstat.h>
 #elif defined(linux) || defined(__GLIBC__)
 #include <sys/sysinfo.h>
 #endif
@@ -572,6 +574,16 @@ double GetLoadAverage() {
   }
 
   return posix_compatible_load;
+}
+#elif defined(_AIX)
+double GetLoadAverage() {
+  perfstat_cpu_total_t cpu_stats;
+  if (perfstat_cpu_total(NULL, &cpu_stats, sizeof(cpu_stats), 1) < 0) {
+    return -0.0f;
+  }
+
+  // Calculation taken from comment in libperfstats.h
+  return double(cpu_stats.loadavg[0]) / double(1 << SBITS);
 }
 #else
 double GetLoadAverage() {


### PR DESCRIPTION
These changes add support for the AIX platform.

In our AIX 7 environment, the `SubprocessTest.InterruptChild` test does not pass due to the `/bin/sh` shell being a really old version of `ksh`. I'll address the issue of using a different shell in a separate pull request.