### PR TITLE
Improve const correctness

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -91,7 +91,7 @@ void BuildStatus::PlanHasTotalEdges(int total) {
   total_edges_ = total;
 }
 
-void BuildStatus::BuildEdgeStarted(Edge* edge) {
+void BuildStatus::BuildEdgeStarted(const Edge* edge) {
   int start_time = (int)(GetTimeMillis() - start_time_millis_);
   running_edges_.insert(make_pair(edge, start_time));
   ++started_edges_;
@@ -102,7 +102,7 @@ void BuildStatus::BuildEdgeStarted(Edge* edge) {
     printer_.SetConsoleLocked(true);
 }
 
-void BuildStatus::BuildEdgeFinished(Edge* edge,
+void BuildStatus::BuildEdgeFinished(const Edge* edge,
                                     bool success,
                                     const string& output,
                                     int* start_time,
@@ -238,7 +238,7 @@ string BuildStatus::FormatProgressStatus(
   return out;
 }
 
-void BuildStatus::PrintStatus(Edge* edge) {
+void BuildStatus::PrintStatus(const Edge* edge) {
   if (config_.verbosity == BuildConfig::QUIET)
     return;
 
@@ -261,11 +261,11 @@ void BuildStatus::PrintStatus(Edge* edge) {
 Plan::Plan() : command_edges_(0), wanted_edges_(0) {}
 
 bool Plan::AddTarget(Node* node, string* err) {
-  vector<Node*> stack;
+  vector<const Node*> stack;
   return AddSubTarget(node, &stack, err);
 }
 
-bool Plan::AddSubTarget(Node* node, vector<Node*>* stack, string* err) {
+bool Plan::AddSubTarget(Node* node, vector<const Node*>* stack, string* err) {
   Edge* edge = node->in_edge();
   if (!edge) {  // Leaf node.
     if (node->dirty()) {
@@ -316,16 +316,16 @@ bool Plan::AddSubTarget(Node* node, vector<Node*>* stack, string* err) {
   return true;
 }
 
-bool Plan::CheckDependencyCycle(Node* node, const vector<Node*>& stack,
+bool Plan::CheckDependencyCycle(const Node* node, const vector<const Node*>& stack,
                                 string* err) {
-  vector<Node*>::const_iterator start = stack.begin();
+  vector<const Node*>::const_iterator start = stack.begin();
   while (start != stack.end() && (*start)->in_edge() != node->in_edge())
     ++start;
   if (start == stack.end())
     return false;
 
   // Build error string for the cycle.
-  vector<Node*> cycle(start, stack.end());
+  vector<const Node*> cycle(start, stack.end());
   cycle.push_back(node);
 
   if (cycle.front() != cycle.back()) {
@@ -340,7 +340,7 @@ bool Plan::CheckDependencyCycle(Node* node, const vector<Node*>& stack,
   }
 
   *err = "dependency cycle: ";
-  for (vector<Node*>::const_iterator i = cycle.begin(); i != cycle.end(); ++i) {
+  for (vector<const Node*>::const_iterator i = cycle.begin(); i != cycle.end(); ++i) {
     if (i != cycle.begin())
       err->append(" -> ");
     err->append((*i)->path());
@@ -395,7 +395,7 @@ void Plan::EdgeFinished(Edge* edge) {
   }
 }
 
-void Plan::NodeFinished(Node* node) {
+void Plan::NodeFinished(const Node* node) {
   // See if we we want any edges from this node.
   for (vector<Edge*>::const_iterator oe = node->out_edges().begin();
        oe != node->out_edges().end(); ++oe) {

--- a/src/build.h
+++ b/src/build.h
@@ -68,10 +68,10 @@ struct Plan {
   int command_edge_count() const { return command_edges_; }
 
 private:
-  bool AddSubTarget(Node* node, vector<Node*>* stack, string* err);
-  bool CheckDependencyCycle(Node* node, const vector<Node*>& stack,
+  bool AddSubTarget(Node* node, vector<const Node*>* stack, string* err);
+  bool CheckDependencyCycle(const Node* node, const vector<const Node*>& stack,
                             string* err);
-  void NodeFinished(Node* node);
+  void NodeFinished(const Node* node);
 
   /// Submits a ready edge as a candidate for execution.
   /// The edge may be delayed from running, for example if it's a member of a
@@ -193,8 +193,8 @@ struct Builder {
 struct BuildStatus {
   explicit BuildStatus(const BuildConfig& config);
   void PlanHasTotalEdges(int total);
-  void BuildEdgeStarted(Edge* edge);
-  void BuildEdgeFinished(Edge* edge, bool success, const string& output,
+  void BuildEdgeStarted(const Edge* edge);
+  void BuildEdgeFinished(const Edge* edge, bool success, const string& output,
                          int* start_time, int* end_time);
   void BuildFinished();
 
@@ -205,7 +205,7 @@ struct BuildStatus {
   string FormatProgressStatus(const char* progress_status_format) const;
 
  private:
-  void PrintStatus(Edge* edge);
+  void PrintStatus(const Edge* edge);
 
   const BuildConfig& config_;
 
@@ -215,7 +215,7 @@ struct BuildStatus {
   int started_edges_, finished_edges_, total_edges_;
 
   /// Map of running edge to time the edge started running.
-  typedef map<Edge*, int> RunningEdgeMap;
+  typedef map<const Edge*, int> RunningEdgeMap;
   RunningEdgeMap running_edges_;
 
   /// Prints progress output.

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -139,11 +139,11 @@ bool BuildLog::OpenForWrite(const string& path, const BuildLogUser& user,
   return true;
 }
 
-bool BuildLog::RecordCommand(Edge* edge, int start_time, int end_time,
+bool BuildLog::RecordCommand(const Edge* edge, int start_time, int end_time,
                              TimeStamp restat_mtime) {
   string command = edge->EvaluateCommand(true);
   uint64_t command_hash = LogEntry::HashCommand(command);
-  for (vector<Node*>::iterator out = edge->outputs_.begin();
+  for (vector<Node*>::const_iterator out = edge->outputs_.begin();
        out != edge->outputs_.end(); ++out) {
     const string& path = (*out)->path();
     Entries::iterator i = entries_.find(path);

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -44,7 +44,7 @@ struct BuildLog {
   ~BuildLog();
 
   bool OpenForWrite(const string& path, const BuildLogUser& user, string* err);
-  bool RecordCommand(Edge* edge, int start_time, int end_time,
+  bool RecordCommand(const Edge* edge, int start_time, int end_time,
                      TimeStamp restat_mtime = 0);
   void Close();
 

--- a/src/clean.cc
+++ b/src/clean.cc
@@ -22,7 +22,7 @@
 #include "state.h"
 #include "util.h"
 
-Cleaner::Cleaner(State* state, const BuildConfig& config)
+Cleaner::Cleaner(const State* state, const BuildConfig& config)
   : state_(state),
     config_(config),
     removed_(),
@@ -32,7 +32,7 @@ Cleaner::Cleaner(State* state, const BuildConfig& config)
     status_(0) {
 }
 
-Cleaner::Cleaner(State* state,
+Cleaner::Cleaner(const State* state,
                  const BuildConfig& config,
                  DiskInterface* disk_interface)
   : state_(state),
@@ -83,7 +83,7 @@ bool Cleaner::IsAlreadyRemoved(const string& path) {
   return (i != removed_.end());
 }
 
-void Cleaner::RemoveEdgeFiles(Edge* edge) {
+void Cleaner::RemoveEdgeFiles(const Edge* edge) {
   string depfile = edge->GetUnescapedDepfile();
   if (!depfile.empty())
     Remove(depfile);
@@ -112,7 +112,7 @@ void Cleaner::PrintFooter() {
 int Cleaner::CleanAll(bool generator) {
   Reset();
   PrintHeader();
-  for (vector<Edge*>::iterator e = state_->edges_.begin();
+  for (vector<Edge*>::const_iterator e = state_->edges_.begin();
        e != state_->edges_.end(); ++e) {
     // Do not try to remove phony targets
     if ((*e)->is_phony())
@@ -120,7 +120,7 @@ int Cleaner::CleanAll(bool generator) {
     // Do not remove generator's files unless generator specified.
     if (!generator && (*e)->GetBindingBool("generator"))
       continue;
-    for (vector<Node*>::iterator out_node = (*e)->outputs_.begin();
+    for (vector<Node*>::const_iterator out_node = (*e)->outputs_.begin();
          out_node != (*e)->outputs_.end(); ++out_node) {
       Remove((*out_node)->path());
     }
@@ -131,7 +131,7 @@ int Cleaner::CleanAll(bool generator) {
   return status_;
 }
 
-void Cleaner::DoCleanTarget(Node* target) {
+void Cleaner::DoCleanTarget(const Node* target) {
   if (Edge* e = target->in_edge()) {
     // Do not try to remove phony targets
     if (!e->is_phony()) {
@@ -152,7 +152,7 @@ void Cleaner::DoCleanTarget(Node* target) {
   cleaned_.insert(target);
 }
 
-int Cleaner::CleanTarget(Node* target) {
+int Cleaner::CleanTarget(const Node* target) {
   assert(target);
 
   Reset();
@@ -198,10 +198,10 @@ int Cleaner::CleanTargets(int target_count, char* targets[]) {
 void Cleaner::DoCleanRule(const Rule* rule) {
   assert(rule);
 
-  for (vector<Edge*>::iterator e = state_->edges_.begin();
+  for (vector<Edge*>::const_iterator e = state_->edges_.begin();
        e != state_->edges_.end(); ++e) {
     if ((*e)->rule().name() == rule->name()) {
-      for (vector<Node*>::iterator out_node = (*e)->outputs_.begin();
+      for (vector<Node*>::const_iterator out_node = (*e)->outputs_.begin();
            out_node != (*e)->outputs_.end(); ++out_node) {
         Remove((*out_node)->path());
         RemoveEdgeFiles(*e);

--- a/src/clean.h
+++ b/src/clean.h
@@ -29,17 +29,17 @@ struct DiskInterface;
 
 struct Cleaner {
   /// Build a cleaner object with a real disk interface.
-  Cleaner(State* state, const BuildConfig& config);
+  Cleaner(const State* state, const BuildConfig& config);
 
   /// Build a cleaner object with the given @a disk_interface
   /// (Useful for testing).
-  Cleaner(State* state,
+  Cleaner(const State* state,
           const BuildConfig& config,
           DiskInterface* disk_interface);
 
   /// Clean the given @a target and all the file built for it.
   /// @return non-zero if an error occurs.
-  int CleanTarget(Node* target);
+  int CleanTarget(const Node* target);
   /// Clean the given target @a target.
   /// @return non-zero if an error occurs.
   int CleanTarget(const char* target);
@@ -86,19 +86,19 @@ struct Cleaner {
   /// @return whether the given @a path has already been removed.
   bool IsAlreadyRemoved(const string& path);
   /// Remove the depfile and rspfile for an Edge.
-  void RemoveEdgeFiles(Edge* edge);
+  void RemoveEdgeFiles(const Edge* edge);
 
   /// Helper recursive method for CleanTarget().
-  void DoCleanTarget(Node* target);
+  void DoCleanTarget(const Node* target);
   void PrintHeader();
   void PrintFooter();
   void DoCleanRule(const Rule* rule);
   void Reset();
 
-  State* state_;
+  const State* state_;
   const BuildConfig& config_;
   set<string> removed_;
-  set<Node*> cleaned_;
+  set<const Node*> cleaned_;
   int cleaned_files_count_;
   DiskInterface* disk_interface_;
   int status_;

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -34,15 +34,15 @@ void BindingEnv::AddRule(const Rule* rule) {
   rules_[rule->name()] = rule;
 }
 
-const Rule* BindingEnv::LookupRuleCurrentScope(const string& rule_name) {
-  map<string, const Rule*>::iterator i = rules_.find(rule_name);
+const Rule* BindingEnv::LookupRuleCurrentScope(const string& rule_name) const {
+  map<string, const Rule*>::const_iterator i = rules_.find(rule_name);
   if (i == rules_.end())
     return NULL;
   return i->second;
 }
 
-const Rule* BindingEnv::LookupRule(const string& rule_name) {
-  map<string, const Rule*>::iterator i = rules_.find(rule_name);
+const Rule* BindingEnv::LookupRule(const string& rule_name) const {
+  map<string, const Rule*>::const_iterator i = rules_.find(rule_name);
   if (i != rules_.end())
     return i->second;
   if (parent_)

--- a/src/eval_env.h
+++ b/src/eval_env.h
@@ -82,8 +82,8 @@ struct BindingEnv : public Env {
   virtual string LookupVariable(const string& var);
 
   void AddRule(const Rule* rule);
-  const Rule* LookupRule(const string& rule_name);
-  const Rule* LookupRuleCurrentScope(const string& rule_name);
+  const Rule* LookupRule(const string& rule_name) const;
+  const Rule* LookupRuleCurrentScope(const string& rule_name) const;
   const map<string, const Rule*>& GetRules() const;
 
   void AddBinding(const string& key, const string& val);

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -216,19 +216,19 @@ bool Edge::AllInputsReady() const {
 struct EdgeEnv : public Env {
   enum EscapeKind { kShellEscape, kDoNotEscape };
 
-  EdgeEnv(Edge* edge, EscapeKind escape)
+  EdgeEnv(const Edge* edge, EscapeKind escape)
       : edge_(edge), escape_in_out_(escape), recursive_(false) {}
   virtual string LookupVariable(const string& var);
 
   /// Given a span of Nodes, construct a list of paths suitable for a command
   /// line.
-  string MakePathList(vector<Node*>::iterator begin,
-                      vector<Node*>::iterator end,
+  string MakePathList(vector<Node*>::const_iterator begin,
+                      vector<Node*>::const_iterator end,
                       char sep);
 
  private:
   vector<string> lookups_;
-  Edge* edge_;
+  const Edge* edge_;
   EscapeKind escape_in_out_;
   bool recursive_;
 };
@@ -268,11 +268,11 @@ string EdgeEnv::LookupVariable(const string& var) {
   return edge_->env_->LookupWithFallback(var, eval, this);
 }
 
-string EdgeEnv::MakePathList(vector<Node*>::iterator begin,
-                             vector<Node*>::iterator end,
+string EdgeEnv::MakePathList(vector<Node*>::const_iterator begin,
+                             vector<Node*>::const_iterator end,
                              char sep) {
   string result;
-  for (vector<Node*>::iterator i = begin; i != end; ++i) {
+  for (vector<Node*>::const_iterator i = begin; i != end; ++i) {
     if (!result.empty())
       result.push_back(sep);
     const string& path = (*i)->PathDecanonicalized();
@@ -289,7 +289,7 @@ string EdgeEnv::MakePathList(vector<Node*>::iterator begin,
   return result;
 }
 
-string Edge::EvaluateCommand(bool incl_rsp_file) {
+string Edge::EvaluateCommand(bool incl_rsp_file) const {
   string command = GetBinding("command");
   if (incl_rsp_file) {
     string rspfile_content = GetBinding("rspfile_content");
@@ -299,21 +299,21 @@ string Edge::EvaluateCommand(bool incl_rsp_file) {
   return command;
 }
 
-string Edge::GetBinding(const string& key) {
+string Edge::GetBinding(const string& key) const {
   EdgeEnv env(this, EdgeEnv::kShellEscape);
   return env.LookupVariable(key);
 }
 
-bool Edge::GetBindingBool(const string& key) {
+bool Edge::GetBindingBool(const string& key) const {
   return !GetBinding(key).empty();
 }
 
-string Edge::GetUnescapedDepfile() {
+string Edge::GetUnescapedDepfile() const {
   EdgeEnv env(this, EdgeEnv::kDoNotEscape);
   return env.LookupVariable("depfile");
 }
 
-string Edge::GetUnescapedRspfile() {
+string Edge::GetUnescapedRspfile() const {
   EdgeEnv env(this, EdgeEnv::kDoNotEscape);
   return env.LookupVariable("rspfile");
 }

--- a/src/graph.h
+++ b/src/graph.h
@@ -137,16 +137,16 @@ struct Edge {
   /// Expand all variables in a command and return it as a string.
   /// If incl_rsp_file is enabled, the string will also contain the
   /// full contents of a response file (if applicable)
-  string EvaluateCommand(bool incl_rsp_file = false);
+  string EvaluateCommand(bool incl_rsp_file = false) const;
 
   /// Returns the shell-escaped value of |key|.
-  string GetBinding(const string& key);
-  bool GetBindingBool(const string& key);
+  string GetBinding(const string& key) const;
+  bool GetBindingBool(const string& key) const;
 
   /// Like GetBinding("depfile"), but without shell escaping.
-  string GetUnescapedDepfile();
+  string GetUnescapedDepfile() const;
   /// Like GetBinding("rspfile"), but without shell escaping.
-  string GetUnescapedRspfile();
+  string GetUnescapedRspfile() const;
 
   void Dump(const char* prefix="") const;
 
@@ -173,11 +173,11 @@ struct Edge {
   // #2 and #3 when we need to access the various subsets.
   int implicit_deps_;
   int order_only_deps_;
-  bool is_implicit(size_t index) {
+  bool is_implicit(size_t index) const {
     return index >= inputs_.size() - order_only_deps_ - implicit_deps_ &&
         !is_order_only(index);
   }
-  bool is_order_only(size_t index) {
+  bool is_order_only(size_t index) const {
     return index >= inputs_.size() - order_only_deps_;
   }
 

--- a/src/graphviz.cc
+++ b/src/graphviz.cc
@@ -19,7 +19,7 @@
 
 #include "graph.h"
 
-void GraphViz::AddTarget(Node* node) {
+void GraphViz::AddTarget(const Node* node) {
   if (visited_nodes_.find(node) != visited_nodes_.end())
     return;
 
@@ -28,7 +28,7 @@ void GraphViz::AddTarget(Node* node) {
   printf("\"%p\" [label=\"%s\"]\n", node, pathstr.c_str());
   visited_nodes_.insert(node);
 
-  Edge* edge = node->in_edge();
+  const Edge* edge = node->in_edge();
 
   if (!edge) {
     // Leaf node.
@@ -49,11 +49,11 @@ void GraphViz::AddTarget(Node* node) {
   } else {
     printf("\"%p\" [label=\"%s\", shape=ellipse]\n",
            edge, edge->rule_->name().c_str());
-    for (vector<Node*>::iterator out = edge->outputs_.begin();
+    for (vector<Node*>::const_iterator out = edge->outputs_.begin();
          out != edge->outputs_.end(); ++out) {
       printf("\"%p\" -> \"%p\"\n", edge, *out);
     }
-    for (vector<Node*>::iterator in = edge->inputs_.begin();
+    for (vector<Node*>::const_iterator in = edge->inputs_.begin();
          in != edge->inputs_.end(); ++in) {
       const char* order_only = "";
       if (edge->is_order_only(in - edge->inputs_.begin()))
@@ -62,7 +62,7 @@ void GraphViz::AddTarget(Node* node) {
     }
   }
 
-  for (vector<Node*>::iterator in = edge->inputs_.begin();
+  for (vector<Node*>::const_iterator in = edge->inputs_.begin();
        in != edge->inputs_.end(); ++in) {
     AddTarget(*in);
   }

--- a/src/graphviz.h
+++ b/src/graphviz.h
@@ -23,11 +23,11 @@ struct Edge;
 /// Runs the process of creating GraphViz .dot file output.
 struct GraphViz {
   void Start();
-  void AddTarget(Node* node);
+  void AddTarget(const Node* node);
   void Finish();
 
-  std::set<Node*> visited_nodes_;
-  std::set<Edge*> visited_edges_;
+  std::set<const Node*> visited_nodes_;
+  std::set<const Edge*> visited_edges_;
 };
 
 #endif  // NINJA_GRAPHVIZ_H_


### PR DESCRIPTION
I'm toying around with the idea of making a fork of Ninja that does (distributed) caching, exploiting the fact that Ninja knows about the full dependency graph so it should be possible to cache executables and libraries as well as object files.

As part of that, I'm trying to understand the Ninja code base. One thing that makes the code a little bit hard to follow for me is how mutable `Node*`s and `Edge*`s are passed around everywhere, and that these objects contain a mixture of the immutable state that is parsed from the manifest file, dirty flags, dependency log ids and so on.

This PR is an attempt to make the code slightly easier to follow by explicitly marking some of the places that do nothing but read from the build graph.
