### PR TITLE
Status table

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -351,7 +351,7 @@ else:
     except:
         pass
     if platform.is_mingw():
-        cflags += ['-D_WIN32_WINNT=0x0501']
+        cflags += ['-D_WIN32_WINNT=0x0501', '-D_WIN32']
     ldflags = ['-L$builddir']
     if platform.uses_usr_local():
         cflags.append('-I/usr/local/include')
@@ -509,7 +509,7 @@ if platform.is_windows():
         objs += cxx(name)
     if platform.is_msvc():
         objs += cxx('minidump-win32')
-    objs += cc('getopt')
+        objs += cc('getopt')
 else:
     objs += cxx('subprocess-posix')
 if platform.is_aix():

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -191,8 +191,10 @@ you don't need to pass `-j`.)
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 
-Ninja supports one environment variable to control its behavior:
-`NINJA_STATUS`, the progress status printed before the rule being run.
+Ninja supports two environment variables to control its behavior:
+
+- `NINJA_STATUS`, the progress status line printed before the rule being run, and
+- `NINJA_STATUS_TABLE`, the progress status table printed while rules are running.
 
 Several placeholders are available:
 
@@ -211,9 +213,12 @@ specified by `-j` or its default)
 `%L`:: Estimated time left in minutes and seconds (`0:00.0`).  _(Available since Ninja 1.7.)_
 `%%`:: A plain `%` character.
 
-The default progress status is `"[%f/%t] "` (note the trailing space
+The default progress status line is `"[%f/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status
 could be `"[%u/%r/%f] "`.
+
+The progress table status is turned off by default, i.e. `""`, an empty string.
+Another example of possible progress table status is `"[%s/%t] %E elapsed, %L left"`.
 
 Extra tools
 ~~~~~~~~~~~

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -207,6 +207,8 @@ Several placeholders are available:
 specified by `-j` or its default)
 `%e`:: Elapsed time in seconds (`0.000`).  _(Available since Ninja 1.2.)_
 `%E`:: Elapsed time in minutes and seconds (`0:00.0`).  _(Available since Ninja 1.7.)_
+`%l`:: Estimated time left in seconds (`0.000`).  _(Available since Ninja 1.7.)_
+`%L`:: Estimated time left in minutes and seconds (`0:00.0`).  _(Available since Ninja 1.7.)_
 `%%`:: A plain `%` character.
 
 The default progress status is `"[%f/%t] "` (note the trailing space

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -217,8 +217,7 @@ The default progress status line is `"[%f/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status
 could be `"[%u/%r/%f] "`.
 
-The progress table status is turned off by default, i.e. `""`, an empty string.
-Another example of possible progress table status is `"[%s/%t] %E elapsed, %L left"`.
+The default progress table status is `"[%s/%t] %E elapsed, %L left"`.
 
 Extra tools
 ~~~~~~~~~~~

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -193,8 +193,10 @@ Environment variables
 
 Ninja supports two environment variables to control its behavior:
 
-- `NINJA_STATUS`, the progress status line printed before the rule being run, and
-- `NINJA_STATUS_TABLE`, the progress status table printed while rules are running.
+- `NINJA_STATUS`, the progress status line printed before the rule being run,
+- `NINJA_STATUS_TABLE`, the progress status table printed while rules are running, and
+- `NINJA_STATUS_SLEEP`, the minimum time, in milliseconds, between progress
+  status updates on a dumb terminal.
 
 Several placeholders are available:
 

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -205,7 +205,8 @@ Several placeholders are available:
 `%o`:: Overall rate of finished edges per second
 `%c`:: Current rate of finished edges per second (average over builds
 specified by `-j` or its default)
-`%e`:: Elapsed time in seconds.  _(Available since Ninja 1.2.)_
+`%e`:: Elapsed time in seconds (`0.000`).  _(Available since Ninja 1.2.)_
+`%E`:: Elapsed time in minutes and seconds (`0:00.0`).  _(Available since Ninja 1.7.)_
 `%%`:: A plain `%` character.
 
 The default progress status is `"[%f/%t] "` (note the trailing space

--- a/src/build.cc
+++ b/src/build.cc
@@ -87,8 +87,8 @@ BuildStatus::BuildStatus(const BuildConfig& config)
       progress_line_format_(NULL), progress_table_format_(NULL),
       overall_rate_(), current_rate_(config.parallelism) {
 
-  // Don't do anything fancy in verbose mode.
-  if (config_.verbosity != BuildConfig::NORMAL)
+  // Don't do anything fancy in verbose mode nor dry run.
+  if (config_.verbosity != BuildConfig::NORMAL || config_.dry_run)
     printer_.set_smart_terminal(false);
 
   progress_line_format_ = getenv("NINJA_STATUS");

--- a/src/build.cc
+++ b/src/build.cc
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <functional>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <fcntl.h>
 #include <io.h>
 #endif
@@ -174,14 +174,14 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
     else
       final_output = output;
 
-#ifdef _WIN32
+#ifdef _MSC_VER
     // Fix extra CR being added on Windows, writing out CR CR LF (#773)
     _setmode(_fileno(stdout), _O_BINARY);  // Begin Windows extra CR fix
 #endif
 
     printer_.PrintOnNewLine(final_output);
 
-#ifdef _WIN32
+#ifdef _MSC_VER
     _setmode(_fileno(stdout), _O_TEXT);  // End Windows extra CR fix
 #endif
   }

--- a/src/build.cc
+++ b/src/build.cc
@@ -287,6 +287,29 @@ string BuildStatus::FormatProgressStatus(
         break;
       }
 
+        // Time left 0.000
+      case 'l': {
+        double elapsed = overall_rate_.Elapsed();
+        double estimated_left = (total_edges_ - started_edges_) * elapsed / max(started_edges_, 1);
+        snprintf(buf, sizeof(buf), "%.3f", estimated_left);
+        out += buf;
+        break;
+      }
+
+        // Time left 0:00 or 0.0 if less than a minute
+      case 'L': {
+        double elapsed = overall_rate_.Elapsed();
+        double estimated_left = (total_edges_ - started_edges_) * elapsed / max(started_edges_, 1);
+        int estimated_left_minutes = (int)estimated_left / 60;
+        double estimated_left_seconds = estimated_left - 60 * estimated_left_minutes;
+        if (estimated_left_minutes > 0)
+          snprintf(buf, sizeof(buf), "%d:%02.0f", estimated_left_minutes, estimated_left_seconds);
+        else
+          snprintf(buf, sizeof(buf), "%4.1f", estimated_left_seconds);
+        out += buf;
+        break;
+      }
+
       default:
         Fatal("unknown placeholder '%%%c' in $NINJA_STATUS", *s);
         return "";

--- a/src/build.cc
+++ b/src/build.cc
@@ -261,7 +261,7 @@ string BuildStatus::FormatProgressStatus(
 
         // Percentage
       case 'p':
-        percent = (100 * finished_edges_) / total_edges_;
+        percent = (100 * finished_edges_) / max(total_edges_, 1);
         snprintf(buf, sizeof(buf), "%3i%%", percent);
         out += buf;
         break;

--- a/src/build.cc
+++ b/src/build.cc
@@ -93,7 +93,7 @@ BuildStatus::BuildStatus(const BuildConfig& config)
     progress_line_format_ = "[%f/%t] ";
   progress_table_format_ = getenv("NINJA_STATUS_TABLE");
   if (!progress_table_format_)
-    progress_table_format_ = ""; // Disabled
+    progress_table_format_ = "[%s/%t] %E elapsed, %L left";
 }
 
 void BuildStatus::PlanHasTotalEdges(int total) {

--- a/src/build.cc
+++ b/src/build.cc
@@ -266,9 +266,23 @@ string BuildStatus::FormatProgressStatus(
         out += buf;
         break;
 
+        // Elapsed 0.000
       case 'e': {
         double elapsed = overall_rate_.Elapsed();
         snprintf(buf, sizeof(buf), "%.3f", elapsed);
+        out += buf;
+        break;
+      }
+
+        // Elapsed, 0:00 or 0.0 if less than a minute
+      case 'E': {
+        double elapsed = overall_rate_.Elapsed();
+        int elapsed_minutes = (int)elapsed / 60;
+        double elapsed_seconds = elapsed - 60 * elapsed_minutes;
+        if (elapsed_minutes > 0)
+          snprintf(buf, sizeof(buf), "%d:%02.0f", elapsed_minutes, elapsed_seconds);
+        else
+          snprintf(buf, sizeof(buf), "%4.1f", elapsed_seconds);
         out += buf;
         break;
       }

--- a/src/build.cc
+++ b/src/build.cc
@@ -347,6 +347,8 @@ void BuildStatus::UpdateStatus() {
 }
 
 void BuildStatus::PrintStatus(Edge* edge, EdgeStatus status) {
+  METRIC_RECORD("print status")
+
   if (config_.verbosity == BuildConfig::QUIET)
     return;
 

--- a/src/build.cc
+++ b/src/build.cc
@@ -368,7 +368,20 @@ void BuildStatus::PrintStatus(Edge* edge, EdgeStatus status) {
 
     // Print all active edges
     vector<string> to_print_lines;
-    to_print_lines.push_back(FormatProgressStatus(progress_table_format_, status));
+
+    char first_line_status[128];
+    overall_rate_.UpdateRate(finished_edges_);
+    double elapsed = overall_rate_.Elapsed();
+    int elapsed_minutes = (int)elapsed / 60;
+    double elapsed_seconds = elapsed - 60 * elapsed_minutes;
+    double estimated_left = (total_edges_ - started_edges_) * elapsed / max(started_edges_, 1);
+    int estimated_left_minutes = (int)estimated_left / 60;
+    double estimated_left_seconds = estimated_left - 60 * estimated_left_minutes;
+    snprintf(first_line_status, sizeof(first_line_status), "%d:%02.0f elapsed, %d%%, %d:%02.0f left",
+        elapsed_minutes, elapsed_seconds,
+        (100 * finished_edges_) / total_edges_,
+        estimated_left_minutes, estimated_left_seconds);
+    to_print_lines.push_back(FormatProgressStatus(progress_line_format_, status) + first_line_status);
 
     int64_t now = GetTimeMillis();
     int now_time = (int)(now - start_time_millis_);

--- a/src/build.cc
+++ b/src/build.cc
@@ -215,6 +215,8 @@ void BuildStatus::BuildStarted() {
 void BuildStatus::BuildFinished() {
   printer_.SetConsoleLocked(false);
   printer_.PrintTemporaryElide();
+  if (config_.verbosity != BuildConfig::QUIET && printer_.is_smart_terminal())
+    printer_.Print(FormatProgressStatus(progress_line_format_, kEdgeFinished) + "Finished\n");
 }
 
 string BuildStatus::FormatProgressStatus(

--- a/src/build.cc
+++ b/src/build.cc
@@ -50,7 +50,7 @@ struct DryRunCommandRunner : public CommandRunner {
   // Overridden from CommandRunner:
   virtual bool CanRunMore();
   virtual bool StartCommand(Edge* edge);
-  virtual bool WaitForCommand(Result* result);
+  virtual WaitForCommandStatus WaitForCommand(Result* result, int timeout_millis);
 
  private:
   queue<Edge*> finished_;
@@ -65,14 +65,14 @@ bool DryRunCommandRunner::StartCommand(Edge* edge) {
   return true;
 }
 
-bool DryRunCommandRunner::WaitForCommand(Result* result) {
+CommandRunner::WaitForCommandStatus DryRunCommandRunner::WaitForCommand(Result* result, int timeout_millis) {
    if (finished_.empty())
-     return false;
+     return WaitFailure;
 
    result->status = ExitSuccess;
    result->edge = finished_.front();
    finished_.pop();
-   return true;
+   return CommandFinished;
 }
 
 }  // namespace
@@ -607,7 +607,7 @@ struct RealCommandRunner : public CommandRunner {
   virtual ~RealCommandRunner() {}
   virtual bool CanRunMore();
   virtual bool StartCommand(Edge* edge);
-  virtual bool WaitForCommand(Result* result);
+  virtual WaitForCommandStatus WaitForCommand(Result* result, int timeout_millis);
   virtual vector<Edge*> GetActiveEdges();
   virtual void Abort();
 
@@ -646,12 +646,14 @@ bool RealCommandRunner::StartCommand(Edge* edge) {
   return true;
 }
 
-bool RealCommandRunner::WaitForCommand(Result* result) {
+CommandRunner::WaitForCommandStatus RealCommandRunner::WaitForCommand(Result* result, int timeout_millis) {
   Subprocess* subproc;
-  while ((subproc = subprocs_.NextFinished()) == NULL) {
-    bool interrupted = subprocs_.DoWork();
+  if ((subproc = subprocs_.NextFinished()) == NULL) {
+    bool interrupted = subprocs_.DoWork(timeout_millis);
     if (interrupted)
-      return false;
+      return WaitFailure;
+    if ((subproc = subprocs_.NextFinished()) == NULL)
+      return WaitTimeout; // Timeout
   }
 
   result->status = subproc->Finish();
@@ -662,7 +664,7 @@ bool RealCommandRunner::WaitForCommand(Result* result) {
   subproc_to_edge_.erase(e);
 
   delete subproc;
-  return true;
+  return CommandFinished;
 }
 
 Builder::Builder(State* state, const BuildConfig& config,
@@ -784,7 +786,11 @@ bool Builder::Build(string* err) {
     // See if we can reap any finished commands.
     if (pending_commands) {
       CommandRunner::Result result;
-      if (!command_runner_->WaitForCommand(&result) ||
+      CommandRunner::WaitForCommandStatus wait_status;
+      do {
+        wait_status = command_runner_->WaitForCommand(&result, -1);
+      } while (wait_status == CommandRunner::WaitTimeout);
+      if (wait_status == CommandRunner::WaitFailure ||
           result.status == ExitInterrupted) {
         Cleanup();
         status_->BuildFinished();

--- a/src/build.h
+++ b/src/build.h
@@ -16,6 +16,7 @@
 #define NINJA_BUILD_H_
 
 #include <cstdio>
+#include <list>
 #include <map>
 #include <memory>
 #include <queue>
@@ -236,6 +237,7 @@ struct BuildStatus {
 
  private:
   void PrintStatus(Edge* edge, EdgeStatus status);
+  void PrintEdgeStatusPermanently(Edge* edge, EdgeStatus status);
 
   const BuildConfig& config_;
 
@@ -244,15 +246,20 @@ struct BuildStatus {
 
   int started_edges_, finished_edges_, total_edges_;
 
-  /// Map of running edge to time the edge started running.
-  typedef map<Edge*, int> RunningEdgeMap;
-  RunningEdgeMap running_edges_;
+  /// List of running edge and time the edge started running.
+  /// Newly started edges are appended to the back.
+  typedef list<pair<Edge*, int> > RunningEdgeList;
+  RunningEdgeList running_edges_;
 
   /// Prints progress output.
   LinePrinter printer_;
 
-  /// The custom progress status format to use.
-  const char* progress_status_format_;
+  /// The custom progress status format to used for the
+  /// single line printout.
+  const char* progress_line_format_;
+  /// The custom progress status format to used for the
+  /// table printout.
+  const char* progress_table_format_;
 
   template<size_t S>
   void SnprintfRate(double rate, char(&buf)[S], const char* format) const {

--- a/src/build.h
+++ b/src/build.h
@@ -269,6 +269,10 @@ struct BuildStatus {
   /// The custom progress status format to used for the
   /// table printout.
   const char* progress_table_format_;
+  /// The number of milliseconds to wait between each
+  /// progress print on a dumb terminal.
+  int progress_sleep_millis_;
+  int64_t last_progress_print_millis_;
 
   template<size_t S>
   void SnprintfRate(double rate, char(&buf)[S], const char* format) const {

--- a/src/build.h
+++ b/src/build.h
@@ -128,8 +128,15 @@ struct CommandRunner {
     string output;
     bool success() const { return status == ExitSuccess; }
   };
+  enum WaitForCommandStatus {
+    CommandFinished,
+    WaitFailure,
+    WaitTimeout
+  };
+
   /// Wait for a command to complete, or return false if interrupted.
-  virtual bool WaitForCommand(Result* result) = 0;
+  /// Infinite wait if timeout_millis = -1.
+  virtual WaitForCommandStatus WaitForCommand(Result* result, int timeout_millis) = 0;
 
   virtual vector<Edge*> GetActiveEdges() { return vector<Edge*>(); }
   virtual void Abort() {}

--- a/src/build.h
+++ b/src/build.h
@@ -242,6 +242,8 @@ struct BuildStatus {
   string FormatProgressStatus(const char* progress_status_format,
                               EdgeStatus status) const;
 
+  void UpdateStatus();
+
  private:
   void PrintStatus(Edge* edge, EdgeStatus status);
   void PrintEdgeStatusPermanently(Edge* edge, EdgeStatus status);

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -14,7 +14,7 @@
 
 // On AIX, inttypes.h gets indirectly included by build_log.h.
 // It's easiest just to ask for the printf format macros right away.
-#ifndef _WIN32
+#ifndef _MSC_VER
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #include <inttypes.h>
 #include <unistd.h>
 #endif

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -18,7 +18,7 @@
 #include "test.h"
 
 #include <sys/stat.h>
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <fcntl.h>
 #include <share.h>
 #else

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1775,6 +1775,8 @@ TEST_F(BuildTest, StatusFormatReplacePlaceholder) {
   EXPECT_EQ("[%/s0/t0/r0/u0/f0/p  0%]",
             status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f/p%p]",
                 BuildStatus::kEdgeStarted));
+  EXPECT_TRUE(status_.FormatProgressStatus("%e", BuildStatus::kEdgeStarted).size() > 2);
+  EXPECT_TRUE(status_.FormatProgressStatus("%E", BuildStatus::kEdgeStarted).size() > 2);
 }
 
 TEST_F(BuildTest, FailedDepsParse) {

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1772,8 +1772,8 @@ TEST_F(BuildTest, StatusFormatElapsed) {
 }
 
 TEST_F(BuildTest, StatusFormatReplacePlaceholder) {
-  EXPECT_EQ("[%/s0/t0/r0/u0/f0]",
-            status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]",
+  EXPECT_EQ("[%/s0/t0/r0/u0/f0/p  0%]",
+            status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f/p%p]",
                 BuildStatus::kEdgeStarted));
 }
 

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1772,8 +1772,8 @@ TEST_F(BuildTest, StatusFormatElapsed) {
 }
 
 TEST_F(BuildTest, StatusFormatReplacePlaceholder) {
-  EXPECT_EQ("[%/s0/t0/r0/u0/f0/p  0%]",
-            status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f/p%p]",
+  EXPECT_EQ("[%/s0/t0/r0/u0/f0/p  0%/l0.000/L 0.0]",
+            status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f/p%p/l%l/L%L]",
                 BuildStatus::kEdgeStarted));
   EXPECT_TRUE(status_.FormatProgressStatus("%e", BuildStatus::kEdgeStarted).size() > 2);
   EXPECT_TRUE(status_.FormatProgressStatus("%E", BuildStatus::kEdgeStarted).size() > 2);

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
-#ifndef _WIN32
+#ifndef _MSC_VER
 #include <unistd.h>
 #endif
 

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -15,7 +15,7 @@
 #include "deps_log.h"
 
 #include <sys/stat.h>
-#ifndef _WIN32
+#ifndef _MSC_VER
 #include <unistd.h>
 #endif
 

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -25,6 +25,8 @@
 #ifdef _WIN32
 #include <sstream>
 #include <windows.h>
+#endif
+#ifdef _MSC_VER
 #include <direct.h>  // _mkdir
 #endif
 
@@ -50,7 +52,7 @@ string DirName(const string& path) {
 }
 
 int MakeDir(const string& path) {
-#ifdef _WIN32
+#ifdef _MSC_VER
   return _mkdir(path.c_str());
 #else
   return mkdir(path.c_str(), 0777);

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -369,6 +369,15 @@ string Edge::EvaluateCommand(bool incl_rsp_file) {
   return command;
 }
 
+string Edge::GetDescription(bool force_full_command) {
+  string description;
+  if (!force_full_command)
+    description = GetBinding("description");
+  if (description.empty())
+    description = EvaluateCommand();
+  return description;
+}
+
 string Edge::GetBinding(const string& key) {
   EdgeEnv env(this, EdgeEnv::kShellEscape);
   return env.LookupVariable(key);

--- a/src/graph.h
+++ b/src/graph.h
@@ -146,6 +146,8 @@ struct Edge {
   /// full contents of a response file (if applicable)
   string EvaluateCommand(bool incl_rsp_file = false);
 
+  string GetDescription(bool force_full_command = false);
+
   /// Returns the shell-escaped value of |key|.
   string GetBinding(const string& key);
   bool GetBindingBool(const string& key);

--- a/src/includes_normalize-win32.cc
+++ b/src/includes_normalize-win32.cc
@@ -82,11 +82,16 @@ bool SameDrive(StringPiece a, StringPiece b, string* err)  {
   if (!InternalGetFullPathName(b, b_absolute, sizeof(b_absolute), err)) {
     return false;
   }
+#ifdef _MSC_VER
   char a_drive[_MAX_DIR];
   char b_drive[_MAX_DIR];
   _splitpath(a_absolute, a_drive, NULL, NULL, NULL);
   _splitpath(b_absolute, b_drive, NULL, NULL, NULL);
-  return _stricmp(a_drive, b_drive) == 0;
+  return strcasecmp(a_drive, b_drive) == 0;
+#else
+  // TODO: Find some Win32 API to use to compare drives.
+  return SameDriveFast(a_absolute, b_absolute);
+#endif
 }
 
 // Check path |s| is FullPath style returned by GetFullPathName.

--- a/src/includes_normalize-win32.cc
+++ b/src/includes_normalize-win32.cc
@@ -26,6 +26,21 @@
 
 namespace {
 
+bool InternalGetFullPathName(const StringPiece& file_name, char* buffer,
+                             size_t buffer_length, string *err) {
+  DWORD result_size = GetFullPathNameA(file_name.AsString().c_str(),
+                                       buffer_length, buffer, NULL);
+  if (result_size == 0) {
+    *err = "GetFullPathNameA(" + file_name.AsString() + "): " +
+        GetLastErrorString();
+    return false;
+  } else if (result_size > buffer_length) {
+    *err = "path too long";
+    return false;
+  }
+  return true;
+}
+
 bool IsPathSeparator(char c) {
   return c == '/' ||  c == '\\';
 }
@@ -54,15 +69,19 @@ bool SameDriveFast(StringPiece a, StringPiece b) {
 }
 
 // Return true if paths a and b are on the same Windows drive.
-bool SameDrive(StringPiece a, StringPiece b)  {
+bool SameDrive(StringPiece a, StringPiece b, string* err)  {
   if (SameDriveFast(a, b)) {
     return true;
   }
 
   char a_absolute[_MAX_PATH];
   char b_absolute[_MAX_PATH];
-  GetFullPathNameA(a.AsString().c_str(), sizeof(a_absolute), a_absolute, NULL);
-  GetFullPathNameA(b.AsString().c_str(), sizeof(b_absolute), b_absolute, NULL);
+  if (!InternalGetFullPathName(a, a_absolute, sizeof(a_absolute), err)) {
+    return false;
+  }
+  if (!InternalGetFullPathName(b, b_absolute, sizeof(b_absolute), err)) {
+    return false;
+  }
   char a_drive[_MAX_DIR];
   char b_drive[_MAX_DIR];
   _splitpath(a_absolute, a_drive, NULL, NULL, NULL);
@@ -106,11 +125,15 @@ bool IsFullPathName(StringPiece s) {
 }  // anonymous namespace
 
 IncludesNormalize::IncludesNormalize(const string& relative_to) {
-  relative_to_ = AbsPath(relative_to);
+  string err;
+  relative_to_ = AbsPath(relative_to, &err);
+  if (!err.empty()) {
+    Fatal("Initializing IncludesNormalize(): %s", err.c_str());
+  }
   split_relative_to_ = SplitStringPiece(relative_to_, '/');
 }
 
-string IncludesNormalize::AbsPath(StringPiece s) {
+string IncludesNormalize::AbsPath(StringPiece s, string* err) {
   if (IsFullPathName(s)) {
     string result = s.AsString();
     for (size_t i = 0; i < result.size(); ++i) {
@@ -122,7 +145,9 @@ string IncludesNormalize::AbsPath(StringPiece s) {
   }
 
   char result[_MAX_PATH];
-  GetFullPathNameA(s.AsString().c_str(), sizeof(result), result, NULL);
+  if (!InternalGetFullPathName(s, result, sizeof(result), err)) {
+    return "";
+  }
   for (char* c = result; *c; ++c)
     if (*c == '\\')
       *c = '/';
@@ -130,8 +155,10 @@ string IncludesNormalize::AbsPath(StringPiece s) {
 }
 
 string IncludesNormalize::Relativize(
-    StringPiece path, const vector<StringPiece>& start_list) {
-  string abs_path = AbsPath(path);
+    StringPiece path, const vector<StringPiece>& start_list, string* err) {
+  string abs_path = AbsPath(path, err);
+  if (!err->empty())
+    return "";
   vector<StringPiece> path_list = SplitStringPiece(abs_path, '/');
   int i;
   for (i = 0; i < static_cast<int>(min(start_list.size(), path_list.size()));
@@ -165,12 +192,18 @@ bool IncludesNormalize::Normalize(const string& input,
   if (!CanonicalizePath(copy, &len, &slash_bits, err))
     return false;
   StringPiece partially_fixed(copy, len);
-  string abs_input = AbsPath(partially_fixed);
+  string abs_input = AbsPath(partially_fixed, err);
+  if (!err->empty())
+    return false;
 
-  if (!SameDrive(abs_input, relative_to_)) {
+  if (!SameDrive(abs_input, relative_to_, err)) {
+    if (!err->empty())
+      return false;
     *result = partially_fixed.AsString();
     return true;
   }
-  *result = Relativize(abs_input, split_relative_to_);
+  *result = Relativize(abs_input, split_relative_to_, err);
+  if (!err->empty())
+    return false;
   return true;
 }

--- a/src/includes_normalize.h
+++ b/src/includes_normalize.h
@@ -25,9 +25,9 @@ struct IncludesNormalize {
   IncludesNormalize(const string& relative_to);
 
   // Internal utilities made available for testing, maybe useful otherwise.
-  static string AbsPath(StringPiece s);
+  static string AbsPath(StringPiece s, string* err);
   static string Relativize(StringPiece path,
-                           const vector<StringPiece>& start_list);
+                           const vector<StringPiece>& start_list, string* err);
 
   /// Normalize by fixing slashes style, fixing redundant .. and . and makes the
   /// path |input| relative to |this->relative_to_| and store to |result|.

--- a/src/includes_normalize.h
+++ b/src/includes_normalize.h
@@ -16,6 +16,11 @@
 #include <vector>
 using namespace std;
 
+#ifndef _MSC_VER
+#define _MAX_PATH 260
+#define _MAX_DIR  256
+#endif
+
 struct StringPiece;
 
 /// Utility functions for normalizing include paths on Windows.

--- a/src/includes_normalize_test.cc
+++ b/src/includes_normalize_test.cc
@@ -58,9 +58,12 @@ TEST(IncludesNormalize, Simple) {
 }
 
 TEST(IncludesNormalize, WithRelative) {
+  string err;
   string currentdir = GetCurDir();
   EXPECT_EQ("c", NormalizeRelativeAndCheckNoError("a/b/c", "a/b"));
-  EXPECT_EQ("a", NormalizeAndCheckNoError(IncludesNormalize::AbsPath("a")));
+  EXPECT_EQ("a",
+            NormalizeAndCheckNoError(IncludesNormalize::AbsPath("a", &err)));
+  EXPECT_TRUE(err.empty());
   EXPECT_EQ(string("../") + currentdir + string("/a"),
             NormalizeRelativeAndCheckNoError("a", "../b"));
   EXPECT_EQ(string("../") + currentdir + string("/a/b"),
@@ -137,4 +140,28 @@ TEST(IncludesNormalize, LongInvalidPath) {
   // Make sure a path that's exactly _MAX_PATH long is canonicalized.
   EXPECT_EQ(forward_slashes.substr(cwd_len + 1),
             NormalizeAndCheckNoError(kExactlyMaxPath));
+}
+
+TEST(IncludesNormalize, ShortRelativeButTooLongAbsolutePath) {
+  string result, err;
+  IncludesNormalize normalizer(".");
+  // A short path should work
+  EXPECT_TRUE(normalizer.Normalize("a", &result, &err));
+  EXPECT_TRUE(err.empty());
+
+  // Construct max size path having cwd prefix.
+  // kExactlyMaxPath = "aaaa\\aaaa...aaaa\0";
+  char kExactlyMaxPath[_MAX_PATH + 1];
+  for (int i = 0; i < _MAX_PATH; ++i) {
+    if (i < _MAX_PATH - 1 && i % 10 == 4)
+      kExactlyMaxPath[i] = '\\';
+    else
+      kExactlyMaxPath[i] = 'a';
+  }
+  kExactlyMaxPath[_MAX_PATH] = '\0';
+  EXPECT_EQ(strlen(kExactlyMaxPath), _MAX_PATH);
+
+  // Make sure a path that's exactly _MAX_PATH long fails with a proper error.
+  EXPECT_FALSE(normalizer.Normalize(kExactlyMaxPath, &result, &err));
+  EXPECT_TRUE(err.find("GetFullPathName") != string::npos);
 }

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -14,6 +14,7 @@
 
 #include "line_printer.h"
 
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
 #ifdef _MSC_VER
@@ -27,10 +28,17 @@
 
 #include "util.h"
 
-LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
+LinePrinter::LinePrinter() : dirty_height(0), console_locked_(false) {
 #ifndef _MSC_VER
   const char* term = getenv("TERM");
   smart_terminal_ = isatty(1) && term && string(term) != "dumb";
+  winsize size;
+  if ((ioctl(0, TIOCGWINSZ, &size) == 0) && size.ws_col) {
+    console_width = size.ws_col;
+    console_height = size.ws_row;
+  } else {
+    smart_terminal_ = false;  // Temporary prints are not possible more than on one line
+  }
 #else
   // Disable output buffer.  It'd be nice to use line buffering but
   // MSDN says: "For some systems, [_IOLBF] provides line
@@ -40,60 +48,199 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
   console_ = GetStdHandle(STD_OUTPUT_HANDLE);
   CONSOLE_SCREEN_BUFFER_INFO csbi;
   smart_terminal_ = GetConsoleScreenBufferInfo(console_, &csbi);
+  bottom_dirty_row = 0;
+  console_height = static_cast<size_t>(csbi.srWindow.Bottom - csbi.srWindow.Top + 1);
 #endif
 }
 
-void LinePrinter::Print(string to_print, LineType type) {
-  if (console_locked_) {
-    line_buffer_ = to_print;
-    line_type_ = type;
+void LinePrinter::PrintTemporaryElide() {
+  vector<string> to_print_lines;
+  PrintTemporaryElide(to_print_lines);
+}
+
+void LinePrinter::PrintTemporaryElide(const string& to_print) {
+  vector<string> to_print_lines;
+  if (!to_print.empty())
+    to_print_lines.push_back(to_print);
+  PrintTemporaryElide(to_print_lines);
+}
+
+void LinePrinter::PrintTemporaryElide(const vector<string>& to_print) {
+  if (console_locked_)
     return;
-  }
 
-  if (smart_terminal_) {
-    printf("\r");  // Print over previous line, if any.
-    // On Windows, calling a C library function writing to stdout also handles
-    // pausing the executable when the "Pause" key or Ctrl-S is pressed.
-  }
+  if (!smart_terminal_)
+    return;
 
-  if (smart_terminal_ && type == ELIDE) {
 #ifdef _MSC_VER
-    CONSOLE_SCREEN_BUFFER_INFO csbi;
-    GetConsoleScreenBufferInfo(console_, &csbi);
-
-    to_print = ElideMiddle(to_print, static_cast<size_t>(csbi.dwSize.X));
-    // We don't want to have the cursor spamming back and forth, so instead of
-    // printf use WriteConsoleOutput which updates the contents of the buffer,
-    // but doesn't move the cursor position.
-    COORD buf_size = { csbi.dwSize.X, 1 };
-    COORD zero_zero = { 0, 0 };
-    SMALL_RECT target = {
-      csbi.dwCursorPosition.X, csbi.dwCursorPosition.Y,
-      static_cast<SHORT>(csbi.dwCursorPosition.X + csbi.dwSize.X - 1),
-      csbi.dwCursorPosition.Y
-    };
-    vector<CHAR_INFO> char_data(csbi.dwSize.X);
-    for (size_t i = 0; i < static_cast<size_t>(csbi.dwSize.X); ++i) {
-      char_data[i].Char.AsciiChar = i < to_print.size() ? to_print[i] : ' ';
-      char_data[i].Attributes = csbi.wAttributes;
-    }
-    WriteConsoleOutput(console_, &char_data[0], buf_size, zero_zero, &target);
+  CONSOLE_SCREEN_BUFFER_INFO csbi;
+  GetConsoleScreenBufferInfo(console_, &csbi);
+  int old_console_height = console_height;
+  console_height = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
 #else
-    // Limit output to width of the terminal if provided so we don't cause
-    // line-wrapping.
-    winsize size;
-    if ((ioctl(0, TIOCGWINSZ, &size) == 0) && size.ws_col) {
-      to_print = ElideMiddle(to_print, size.ws_col);
-    }
-    printf("%s", to_print.c_str());
-    printf("\x1B[K");  // Clear to end of line.
-    fflush(stdout);
+  winsize size;
+  if ((ioctl(0, TIOCGWINSZ, &size) == 0) && size.ws_col) {
+    console_width = size.ws_col;
+    console_height = size.ws_row;
+  }
 #endif
 
-    have_blank_line_ = false;
+  // How much to print?
+  // Try to keep some lines above us so that the user notices
+  // when other output is printed in between these status lines.
+  bool print_ellipsis = false;
+  int lines_above_us = max(1, console_height / 2); // Tunable factor.
+  int lines_to_print;
+  if (console_height < lines_above_us + 1) {
+    // Print nothing or the first line only.
+    lines_above_us = 0;
+    lines_to_print = min(static_cast<int>(to_print.size()), console_height);
+  } else if (console_height < lines_above_us + static_cast<int>(to_print.size())) {
+    // Keep one line, fill the rest of the screen,
+    // but replace the last line with "..."
+    lines_to_print = console_height - 1 - lines_above_us;
+    print_ellipsis = true;
   } else {
-    printf("%s\n", to_print.c_str());
+    lines_to_print = static_cast<int>(to_print.size());
   }
+  int old_dirty_height = dirty_height;
+  dirty_height = lines_to_print + (print_ellipsis ? 1 : 0);
+
+#ifdef _MSC_VER
+  // Scroll the buffer, on Windows terminal, if overfilling.
+
+  COORD zero_zero = { 0, 0 };
+  // Fix the old bottom_dirty_row according to possible changed buffer size.
+  if (old_dirty_height == 0) {
+    // No temporary table exists, print at the cursor position.
+    bottom_dirty_row = csbi.dwCursorPosition.Y;
+  } else {
+    if (bottom_dirty_row >= csbi.dwSize.Y) {
+      // The buffer height have been smaller and the top rows have been
+      // removed to keep the latest printed stuff. Update bottom_dirty_row.
+      bottom_dirty_row = max(csbi.dwSize.Y - 1, 0);
+    }
+  }
+  // top_dirty_row is within [0; bottom_dirty_row].
+  size_t top_dirty_row = max(bottom_dirty_row - max(old_dirty_height - 1, 0), 0);
+  // Set the new dirty bottom row
+  bottom_dirty_row = top_dirty_row + max(dirty_height - 1, 0);
+
+  // If there are not enough rows left, scroll the buffer.
+  if (bottom_dirty_row >= csbi.dwSize.Y) {
+    int lines_to_move_up = bottom_dirty_row - max(csbi.dwSize.Y - 1, 0);
+    top_dirty_row -= lines_to_move_up;
+    bottom_dirty_row -= lines_to_move_up;
+
+    SMALL_RECT content_to_scroll_rect = {
+      0,
+      static_cast<SHORT>(lines_to_move_up),
+      csbi.dwSize.X - 1,
+      csbi.dwSize.Y - 1,
+    };
+    SMALL_RECT clip_rect = {
+      0,
+      0,
+      csbi.dwSize.X - 1,
+      csbi.dwSize.Y - 1
+    };
+    CHAR_INFO fill_char;
+    fill_char.Char.AsciiChar = (char)' ';
+    fill_char.Attributes = csbi.wAttributes;
+
+    ScrollConsoleScreenBuffer(console_, &content_to_scroll_rect, &clip_rect, zero_zero, &fill_char);
+  }
+
+  // If the console has become smaller, we will print less, so scroll up a bit first.
+  if (console_height < old_console_height && csbi.srWindow.Bottom > bottom_dirty_row) {
+    // Scroll up to make the first row visible.
+    SHORT lines_removed = static_cast<SHORT>(max(dirty_height, old_dirty_height) - dirty_height);
+    // Adjust csbi.srWindow directly as it may be used later as well.
+    csbi.srWindow.Top -= lines_removed;
+    csbi.srWindow.Bottom -= lines_removed;
+    SetConsoleWindowInfo(console_, TRUE, &csbi.srWindow);
+  }
+
+  // If the amount of rows printed have changed, set the cursor to the end row.
+  if (dirty_height > old_dirty_height || dirty_height == 0) {
+    // Place the cursor at the end.
+    COORD bottom_left_pos = {
+      0, // Scroll to the far left.
+      static_cast<SHORT>(bottom_dirty_row),
+    };
+    SetConsoleCursorPosition(console_, bottom_left_pos);
+  } else {
+    // Avoid scrolling when using printf() below.
+    COORD pos = {
+      csbi.srWindow.Left,
+      static_cast<SHORT>(bottom_dirty_row),
+    };
+    if (pos.Y <= csbi.srWindow.Top)
+      pos.Y = csbi.srWindow.Top;
+    if (pos.Y >= csbi.srWindow.Bottom)
+      pos.Y = csbi.srWindow.Bottom;
+    SetConsoleCursorPosition(console_, pos);
+  }
+  // On Windows, calling a C library function writing to stdout also handles
+  // pausing the executable when the "Pause" key or Ctrl-S is pressed.
+  printf("\r");
+
+  // We don't want to have the cursor spamming back and forth, so instead of
+  // printf use WriteConsoleOutput which updates the contents of the buffer,
+  // but doesn't move the cursor position.
+  COORD buf_size = { csbi.dwSize.X, static_cast<SHORT>(max(dirty_height, old_dirty_height)) };
+  if (buf_size.Y > 0) {
+    SMALL_RECT target = {
+      0,
+      static_cast<SHORT>(top_dirty_row),
+      static_cast<SHORT>(buf_size.X - 1),
+      static_cast<SHORT>(top_dirty_row + buf_size.Y - 1)
+    };
+    vector<CHAR_INFO> char_data(buf_size.Y * buf_size.X);
+    for (int y = 0; y < buf_size.Y; ++y) {
+      string to_print_line;
+      if (y < lines_to_print) {
+        to_print_line = ElideMiddle(to_print[y], static_cast<size_t>(buf_size.X));
+      } else if (y == lines_to_print && print_ellipsis) {
+        to_print_line = "...";
+      }
+      for (int x = 0; x < buf_size.X; ++x) {
+        int i = y*buf_size.X + x;
+        char_data[i].Char.AsciiChar = static_cast<size_t>(x) < to_print_line.size() ? to_print_line[x] : ' ';
+        char_data[i].Attributes = csbi.wAttributes;
+      }
+    }
+    WriteConsoleOutput(console_, char_data.data(), buf_size, zero_zero, &target);
+  }
+#else
+  printf("\r");  // Go to beginning of the line
+
+  bool first_line_up = true;
+  if (old_dirty_height > dirty_height) {
+    for (int i = old_dirty_height - 1; i >= dirty_height; --i) {
+      if (first_line_up)
+        first_line_up = false;
+      else
+        printf("\x1B[A");  // Go up a line
+      printf("\x1B[2K");  // Clear that line
+    }
+  }
+  // Lines to print will clear themselves later. Go up some more lines, without clearing them.
+  int lines_to_go_up = max(min(dirty_height, old_dirty_height) - (first_line_up ? 1 : 0), 0);
+  if (lines_to_go_up > 0)
+    printf("\x1B[%dA", lines_to_go_up);
+
+  // Limit output to width of the terminal if provided so we don't cause
+  // line-wrapping.
+  for (int i = 0; i < dirty_height; ++i) {
+    string to_print_line = (i < lines_to_print ? ElideMiddle(to_print[i], console_width) : "...");
+    printf("%s", to_print_line.c_str());
+    printf("\x1B[K");  // Clear to end of line.
+    if (i < dirty_height-1)
+      printf("\n");
+  }
+  fflush(stdout);
+#endif
 }
 
 void LinePrinter::PrintOrBuffer(const char* data, size_t size) {
@@ -106,19 +253,10 @@ void LinePrinter::PrintOrBuffer(const char* data, size_t size) {
   }
 }
 
-void LinePrinter::PrintOnNewLine(const string& to_print) {
-  if (console_locked_ && !line_buffer_.empty()) {
-    output_buffer_.append(line_buffer_);
-    output_buffer_.append(1, '\n');
-    line_buffer_.clear();
-  }
-  if (!have_blank_line_) {
-    PrintOrBuffer("\n", 1);
-  }
-  if (!to_print.empty()) {
-    PrintOrBuffer(&to_print[0], to_print.size());
-  }
-  have_blank_line_ = to_print.empty() || *to_print.rbegin() == '\n';
+void LinePrinter::Print(const string& to_print) {
+  if (dirty_height > 0)
+    PrintTemporaryElide();
+  PrintOrBuffer(to_print.data(), to_print.size());
 }
 
 void LinePrinter::SetConsoleLocked(bool locked) {
@@ -126,16 +264,12 @@ void LinePrinter::SetConsoleLocked(bool locked) {
     return;
 
   if (locked)
-    PrintOnNewLine("");
+    PrintTemporaryElide();
 
   console_locked_ = locked;
 
   if (!locked) {
-    PrintOnNewLine(output_buffer_);
-    if (!line_buffer_.empty()) {
-      Print(line_buffer_, line_type_);
-    }
+    Print(output_buffer_);
     output_buffer_.clear();
-    line_buffer_.clear();
   }
 }

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -16,7 +16,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <windows.h>
 #else
 #include <unistd.h>
@@ -28,7 +28,7 @@
 #include "util.h"
 
 LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
-#ifndef _WIN32
+#ifndef _MSC_VER
   const char* term = getenv("TERM");
   smart_terminal_ = isatty(1) && term && string(term) != "dumb";
 #else
@@ -57,7 +57,7 @@ void LinePrinter::Print(string to_print, LineType type) {
   }
 
   if (smart_terminal_ && type == ELIDE) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     CONSOLE_SCREEN_BUFFER_INFO csbi;
     GetConsoleScreenBufferInfo(console_, &csbi);
 

--- a/src/line_printer.h
+++ b/src/line_printer.h
@@ -17,6 +17,7 @@
 
 #include <stddef.h>
 #include <string>
+#include <vector>
 using namespace std;
 
 /// Prints lines of text, possibly overprinting previously printed lines
@@ -27,16 +28,14 @@ struct LinePrinter {
   bool is_smart_terminal() const { return smart_terminal_; }
   void set_smart_terminal(bool smart) { smart_terminal_ = smart; }
 
-  enum LineType {
-    FULL,
-    ELIDE
-  };
-  /// Overprints the current line. If type is ELIDE, elides to_print to fit on
-  /// one line.
-  void Print(string to_print, LineType type);
+  /// Overprints the current box. If type is ELIDE, elides to_print to fit on
+  /// one line by line.
+  void PrintTemporaryElide();
+  void PrintTemporaryElide(const string& to_print);
+  void PrintTemporaryElide(const vector<string>& to_print);
 
-  /// Prints a string on a new line, not overprinting previous output.
-  void PrintOnNewLine(const string& to_print);
+  /// Prints a string in the normal way. Will remove any temporary output.
+  void Print(const string& to_print);
 
   /// Lock or unlock the console.  Any output sent to the LinePrinter while the
   /// console is locked will not be printed until it is unlocked.
@@ -46,24 +45,23 @@ struct LinePrinter {
   /// Whether we can do fancy terminal control codes.
   bool smart_terminal_;
 
-  /// Whether the caret is at the beginning of a blank line.
-  bool have_blank_line_;
+  /// How much of the terminal is dirty?
+  int dirty_height;
 
   /// Whether console is locked.
   bool console_locked_;
-
-  /// Buffered current line while console is locked.
-  string line_buffer_;
-
-  /// Buffered line type while console is locked.
-  LineType line_type_;
 
   /// Buffered console output while console is locked.
   string output_buffer_;
 
 #ifdef _MSC_VER
   void* console_;
+  /// If dirty_height != 0, the bottom row where stuff got printed last time.
+  int bottom_dirty_row;
+#else
+  int console_width;
 #endif
+  int console_height;
 
   /// Print the given data to the console, or buffer it if it is locked.
   void PrintOrBuffer(const char *data, size_t size);

--- a/src/line_printer.h
+++ b/src/line_printer.h
@@ -61,7 +61,7 @@ struct LinePrinter {
   /// Buffered console output while console is locked.
   string output_buffer_;
 
-#ifdef _WIN32
+#ifdef _MSC_VER
   void* console_;
 #endif
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "getopt.h"
 #include <direct.h>
 #include <windows.h>

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -119,7 +119,7 @@ bool ReadFlags(int* argc, char*** argv, const char** test_filter) {
 bool testing::Test::Check(bool condition, const char* file, int line,
                           const char* error) {
   if (!condition) {
-    printer.PrintOnNewLine(
+    printer.Print(
         StringPrintf("*** Failure in %s:%d\n%s\n", file, line, error));
     failed_ = true;
   }
@@ -144,9 +144,8 @@ int main(int argc, char **argv) {
 
     ++tests_started;
     testing::Test* test = tests[i].factory();
-    printer.Print(
-        StringPrintf("[%d/%d] %s", tests_started, nactivetests, tests[i].name),
-        LinePrinter::ELIDE);
+    printer.PrintTemporaryElide(
+        StringPrintf("[%d/%d] %s", tests_started, nactivetests, tests[i].name));
     test->SetUp();
     test->Run();
     test->TearDown();
@@ -155,6 +154,7 @@ int main(int argc, char **argv) {
     delete test;
   }
 
-  printer.PrintOnNewLine(passed ? "passed\n" : "failed\n");
+  printer.Print(StringPrintf("[%d/%d]\n", tests_started, nactivetests));
+  printer.Print(passed ? "passed\n" : "failed\n");
   return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -85,7 +85,8 @@ struct SubprocessSet {
   ~SubprocessSet();
 
   Subprocess* Add(const string& command, bool use_console = false);
-  bool DoWork();
+  /// Returns true if interrupted. timeout_millis = -1 means infinity.
+  bool DoWork(int timeout_millis);
   Subprocess* NextFinished();
   void Clear();
 

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -92,9 +92,17 @@ struct SubprocessSet {
   vector<Subprocess*> running_;
   queue<Subprocess*> finished_;
 
+#ifndef _MSC_VER
+  struct sigaction old_int_act_;
+  struct sigaction old_term_act_;
+  struct sigaction old_hup_act_;
+#endif
 #ifdef _WIN32
   static BOOL WINAPI NotifyInterrupted(DWORD dwCtrlType);
   static HANDLE ioport_;
+#ifdef __CYGWIN__
+  static void HandleInterruptSignal(int signum);
+#endif  // __CYGWIN__
 #else
   static void SetInterruptedFlag(int signum);
   static void HandlePendingInterruption();
@@ -104,9 +112,6 @@ struct SubprocessSet {
 
   static bool IsInterrupted() { return interrupted_ != 0; }
 
-  struct sigaction old_int_act_;
-  struct sigaction old_term_act_;
-  struct sigaction old_hup_act_;
   sigset_t old_mask_;
 #endif
 };

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -14,6 +14,7 @@
 
 #include "subprocess.h"
 
+#include "metrics.h"
 #include "test.h"
 
 #ifndef _WIN32
@@ -45,7 +46,7 @@ TEST_F(SubprocessTest, BadCommandStderr) {
 
   while (!subproc->Done()) {
     // Pretend we discovered that stderr was ready for writing.
-    subprocs_.DoWork();
+    subprocs_.DoWork(-1);
   }
 
   EXPECT_EQ(ExitFailure, subproc->Finish());
@@ -59,7 +60,7 @@ TEST_F(SubprocessTest, NoSuchCommand) {
 
   while (!subproc->Done()) {
     // Pretend we discovered that stderr was ready for writing.
-    subprocs_.DoWork();
+    subprocs_.DoWork(-1);
   }
 
   EXPECT_EQ(ExitFailure, subproc->Finish());
@@ -77,7 +78,7 @@ TEST_F(SubprocessTest, InterruptChild) {
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
-    subprocs_.DoWork();
+    subprocs_.DoWork(-1);
   }
 
   EXPECT_EQ(ExitInterrupted, subproc->Finish());
@@ -88,7 +89,7 @@ TEST_F(SubprocessTest, InterruptParent) {
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
-    bool interrupted = subprocs_.DoWork();
+    bool interrupted = subprocs_.DoWork(-1);
     if (interrupted)
       return;
   }
@@ -101,7 +102,7 @@ TEST_F(SubprocessTest, InterruptChildWithSigTerm) {
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
-    subprocs_.DoWork();
+    subprocs_.DoWork(-1);
   }
 
   EXPECT_EQ(ExitInterrupted, subproc->Finish());
@@ -112,7 +113,7 @@ TEST_F(SubprocessTest, InterruptParentWithSigTerm) {
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
-    bool interrupted = subprocs_.DoWork();
+    bool interrupted = subprocs_.DoWork(-1);
     if (interrupted)
       return;
   }
@@ -125,7 +126,7 @@ TEST_F(SubprocessTest, InterruptChildWithSigHup) {
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
-    subprocs_.DoWork();
+    subprocs_.DoWork(-1);
   }
 
   EXPECT_EQ(ExitInterrupted, subproc->Finish());
@@ -136,7 +137,7 @@ TEST_F(SubprocessTest, InterruptParentWithSigHup) {
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
-    bool interrupted = subprocs_.DoWork();
+    bool interrupted = subprocs_.DoWork(-1);
     if (interrupted)
       return;
   }
@@ -152,7 +153,7 @@ TEST_F(SubprocessTest, Console) {
     ASSERT_NE((Subprocess*)0, subproc);
 
     while (!subproc->Done()) {
-      subprocs_.DoWork();
+      subprocs_.DoWork(-1);
     }
 
     EXPECT_EQ(ExitSuccess, subproc->Finish());
@@ -166,7 +167,7 @@ TEST_F(SubprocessTest, SetWithSingle) {
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
-    subprocs_.DoWork();
+    subprocs_.DoWork(-1);
   }
   ASSERT_EQ(ExitSuccess, subproc->Finish());
   ASSERT_NE("", subproc->GetOutput());
@@ -201,7 +202,7 @@ TEST_F(SubprocessTest, SetWithMulti) {
   while (!processes[0]->Done() || !processes[1]->Done() ||
          !processes[2]->Done()) {
     ASSERT_GT(subprocs_.running_.size(), 0u);
-    subprocs_.DoWork();
+    subprocs_.DoWork(-1);
   }
 
   ASSERT_EQ(0u, subprocs_.running_.size());
@@ -236,7 +237,7 @@ TEST_F(SubprocessTest, SetWithLots) {
     procs.push_back(subproc);
   }
   while (!subprocs_.running_.empty())
-    subprocs_.DoWork();
+    subprocs_.DoWork(-1);
   for (size_t i = 0; i < procs.size(); ++i) {
     ASSERT_EQ(ExitSuccess, procs[i]->Finish());
     ASSERT_NE("", procs[i]->GetOutput());
@@ -253,9 +254,41 @@ TEST_F(SubprocessTest, SetWithLots) {
 TEST_F(SubprocessTest, ReadStdin) {
   Subprocess* subproc = subprocs_.Add("cat -");
   while (!subproc->Done()) {
-    subprocs_.DoWork();
+    subprocs_.DoWork(-1);
   }
   ASSERT_EQ(ExitSuccess, subproc->Finish());
   ASSERT_EQ(1u, subprocs_.finished_.size());
 }
 #endif  // _WIN32
+
+TEST_F(SubprocessTest, CheckTimeout) {
+  const char* kSlowCommand =
+#ifdef _WIN32
+    "cmd /c ping 1.1.1.1 -n 1 -w 1000 & dir \\"
+#else
+    "sleep 1s"
+#endif
+  ;
+
+  Subprocess* subproc = subprocs_.Add(kSlowCommand);
+  ASSERT_NE((Subprocess *) 0, subproc);
+
+  int correct_waits = 0;
+  while (!subproc->Done()) {
+    int64_t start = GetTimeMillis();
+    subprocs_.DoWork(123);
+    int64_t end = GetTimeMillis();
+    int delta = (int)(end - start);
+    if (delta > 70 && delta < 250)
+      correct_waits++;
+  }
+  ASSERT_EQ(ExitSuccess, subproc->Finish());
+#ifdef _WIN32
+  ASSERT_NE("", subproc->GetOutput());
+#else
+  ASSERT_EQ("", subproc->GetOutput());
+#endif
+
+  ASSERT_EQ(1u, subprocs_.finished_.size());
+  ASSERT_TRUE(correct_waits > 2);
+}

--- a/src/test.cc
+++ b/src/test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <direct.h>  // Has to be before util.h is included.
 #endif
 
@@ -22,7 +22,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include <windows.h>
 #else
 #include <unistd.h>
@@ -35,7 +35,7 @@
 
 namespace {
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #ifndef _mktemp_s
 /// mingw has no mktemp.  Implement one with the same type as the one
 /// found in the Windows API.
@@ -62,10 +62,10 @@ char* mkdtemp(char* name_template) {
 
   return name_template;
 }
-#endif  // _WIN32
+#endif  // _MSC_VER
 
 string GetSystemTempDir() {
-#ifdef _WIN32
+#ifdef _MSC_VER
   char buf[1024];
   if (!GetTempPath(sizeof(buf), buf))
     return "";
@@ -223,7 +223,7 @@ void ScopedTempDir::Cleanup() {
   if (chdir(start_dir_.c_str()) < 0)
     Fatal("chdir: %s", strerror(errno));
 
-#ifdef _WIN32
+#ifdef _MSC_VER
   string command = "rmdir /s /q " + temp_dir_name_;
 #else
   string command = "rm -rf " + temp_dir_name_;

--- a/src/timestamp.h
+++ b/src/timestamp.h
@@ -15,7 +15,7 @@
 #ifndef NINJA_TIMESTAMP_H_
 #define NINJA_TIMESTAMP_H_
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "win32port.h"
 #else
 #ifndef __STDC_FORMAT_MACROS

--- a/src/util.cc
+++ b/src/util.cc
@@ -14,13 +14,13 @@
 
 #include "util.h"
 
-#ifdef __CYGWIN__
-#include <windows.h>
-#include <io.h>
-#elif defined( _WIN32)
+#ifdef _MSC_VER
 #include <windows.h>
 #include <io.h>
 #include <share.h>
+#elif defined( _WIN32)
+#include <windows.h>
+#include <io.h>
 #endif
 
 #include <assert.h>
@@ -33,7 +33,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifndef _WIN32
+#ifndef _MSC_VER
 #include <unistd.h>
 #include <sys/time.h>
 #endif
@@ -583,7 +583,7 @@ string ElideMiddle(const string& str, size_t width) {
 }
 
 bool Truncate(const string& path, size_t size, string* err) {
-#ifdef _WIN32
+#ifdef _MSC_VER
   int fh = _sopen(path.c_str(), _O_RDWR | _O_CREAT, _SH_DENYNO,
                   _S_IREAD | _S_IWRITE);
   int success = _chsize(fh, size);

--- a/src/util.h
+++ b/src/util.h
@@ -15,7 +15,7 @@
 #ifndef NINJA_UTIL_H_
 #define NINJA_UTIL_H_
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #include "win32port.h"
 #else
 #include <stdint.h>
@@ -92,11 +92,14 @@ bool Truncate(const string& path, size_t size, string* err);
 
 #ifdef _MSC_VER
 #define snprintf _snprintf
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
 #define fileno _fileno
 #define unlink _unlink
 #define chdir _chdir
 #define strtoull _strtoui64
 #define getcwd _getcwd
+#define putenv _putenv
 #define PATH_MAX _MAX_PATH
 #endif
 


### PR DESCRIPTION
This series of commits creates a new status output, inspired by https://buckbuild.com/static/buck-build-15fps.gif at https://buckbuild.com/. I've tried to make the console work well when resizing. It does not fill the whole console window, by purpose, so that the user can see the latest output above the currently running tasks.

Estimating the time left is of the simplest kind without using the `.ninja_log`.

Use NINJA_STATUS_TABLE as well as NINJA_STATUS to configure the top status line in the table.

It has not been tested for user input during pool=console. I've been running an earlier draft for a while on a quite big project (50 MB ninja file) for a few months now, on Windows. Only basic tests has been performed on Linux, building Ninja itself.

```
> ninja.exe all
[38/55] LINK ninja.exe
Generating code
Finished generating code
[50/55] 26.7 elapsed,  2.7 left
 5.8s CXX build\test.obj
 4.2s CXX build\manifest_parser_test.obj
 1.0s CXX build\ninja_test.obj
 0.8s CXX build\edit_distance_test.obj
 0.8s CXX build\state_test.obj
 0.1s CXX build\hash_collision_bench.obj
```

See also https://groups.google.com/d/msg/ninja-build/lK5YVv5Y4T4/fjqQAjoJKrsJ
