### PR TITLE
Set output mtime of phony edges to the latest inputs

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -446,6 +446,11 @@ nothing, but phony rules are handled specially in that they aren't
 printed when run, logged (see below), nor do they contribute to the
 command count printed as part of the build process.
 
+When a `phony` target is used as an input to another build rule, the
+other build rule will, semantically, consider the inputs of the
+`phony` rule as its own. Therefore, `phony` rules can be used to group
+inputs, e.g. header files.
+
 `phony` can also be used to create dummy targets for files which
 may not exist at build time.  If a phony build statement is written
 without any dependencies, the target will be considered out of date if

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -856,3 +856,40 @@ TEST_F(GraphTest, DyndepFileCircular) {
   EXPECT_EQ(1u, edge->implicit_deps_);
   EXPECT_EQ(1u, edge->order_only_deps_);
 }
+
+// Check that phony's dependencies' mtimes are propagated.
+TEST_F(GraphTest, PhonyDepsMtimes) {
+  string err;
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule touch\n"
+" command = touch $out\n"
+"build in_ph: phony in1\n"
+"build out1: touch in_ph\n"
+));
+  fs_.Create("in1", "");
+  fs_.Create("out1", "");
+  Node* out1 = GetNode("out1");
+  Node* in1  = GetNode("in1");
+
+  EXPECT_TRUE(scan_.RecomputeDirty(out1, &err));
+  EXPECT_TRUE(!out1->dirty());
+
+  // Get the mtime of out1
+  ASSERT_TRUE(in1->Stat(&fs_, &err));
+  ASSERT_TRUE(out1->Stat(&fs_, &err));
+  TimeStamp out1Mtime1 = out1->mtime();
+  TimeStamp in1Mtime1 = in1->mtime();
+
+  // Touch in1. This should cause out1 to be dirty
+  state_.Reset();
+  fs_.Tick();
+  fs_.Create("in1", "");
+
+  ASSERT_TRUE(in1->Stat(&fs_, &err));
+  EXPECT_GT(in1->mtime(), in1Mtime1);
+
+  EXPECT_TRUE(scan_.RecomputeDirty(out1, &err));
+  EXPECT_GT(in1->mtime(), in1Mtime1);
+  EXPECT_EQ(out1->mtime(), out1Mtime1);
+  EXPECT_TRUE(out1->dirty());
+}


### PR DESCRIPTION
This commit fixes issue #478.

Observed:
Real edges depending on a phony edge will not be marked as dirty or
rebuilt if the phony's (real) inputs are updated.

Expected:
An edge should always be rebuilt if its inputs or transitive inputs are
newer than the output's mtime.

Change:
Node::mtime_ was overloaded, 0 represented "does not exist". This change
disambiguates it by adding Node::exists_. Then to fix the observed
behaviour, Node::UpdatePhonyMtime was added to update the mtime if the
node does not exist.

Add tests BuildTest.PhonyUseCase# GraphTest.PhonyDepsMtimes.
Unit tests will also test for always-dirty behaviour if a phony rule has
no inputs.

---

This patch is a rebase of #634 onto the master branch of 2015-09-16.
