### PR TITLE
Fix pool->current_use_ not being decremented when edges fail

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -58,7 +58,7 @@ struct Plan {
 
   /// Mark an edge as done building.  Used internally and by
   /// tests.
-  void EdgeFinished(Edge* edge);
+  void EdgeFinished(Edge* edge, bool success=true);
 
   /// Clean the given node during the build.
   /// Return false on error.


### PR DESCRIPTION
eg With this build file...

  pool failpool
    depth = 1
  rule fail
    command = fail
    pool = failpool
  build out1: fail
  build out2: fail
  build out3: fail
  build final: phony out1 out2 out3

...and "-k 0", we should run out1..3 sequentially before failing. Previously we
would fail after just running out1.