### PR TITLE
Resurrect the 'rules' tool.

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -283,6 +283,9 @@ target, show just the target's dependencies. _Available since Ninja 1.4._
 
 `recompact`:: recompact the `.ninja_deps` file. _Available since Ninja 1.4._
 
+`rules`:: output the list of all rules (eventually with their description
+if they have one).  It can be used to know which rule name to pass to
++ninja -t targets rule _name_+ or +ninja -t compdb+.
 
 Writing your own Ninja files
 ----------------------------

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -131,3 +131,17 @@ string EvalString::Serialize() const {
   }
   return result;
 }
+
+string EvalString::Unparse() const {
+  string result;
+  for (TokenList::const_iterator i = parsed_.begin();
+       i != parsed_.end(); ++i) {
+    bool special = (i->second == SPECIAL);
+    if (special)
+      result.append("${");
+    result.append(i->first);
+    if (special)
+      result.append("}");
+  }
+  return result;
+}

--- a/src/eval_env.h
+++ b/src/eval_env.h
@@ -33,7 +33,12 @@ struct Env {
 /// A tokenized string that contains variable references.
 /// Can be evaluated relative to an Env.
 struct EvalString {
+  /// @return The evaluated string with variable expanded using value found in
+  ///         environment @a env.
   string Evaluate(Env* env) const;
+
+  /// @return The string with variables not expanded.
+  string Unparse() const;
 
   void Clear() { parsed_.clear(); }
   bool empty() const { return parsed_.empty(); }


### PR DESCRIPTION
This tool is useful for writing shell completion script for tools
expecting a rule name as argument.

The tool was dropped by 34b46f28c.

Fix #1024.
