### PR TITLE
Print finish status for interrupted edges

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -152,8 +152,8 @@ struct CommandRunner {
   /// Wait for a command to complete, or return false if interrupted.
   virtual bool WaitForCommand(Result* result) = 0;
 
-  virtual vector<Edge*> GetActiveEdges() { return vector<Edge*>(); }
   virtual void Abort() {}
+  virtual void Wait() {}
 };
 
 /// Options (e.g. verbosity, parallelism) passed to a build.
@@ -241,7 +241,7 @@ struct BuildStatus {
   explicit BuildStatus(const BuildConfig& config);
   void PlanHasTotalEdges(int total);
   void BuildEdgeStarted(Edge* edge);
-  void BuildEdgeFinished(Edge* edge, bool success, const string& output,
+  void BuildEdgeFinished(Edge* edge, ExitStatus status, const string& output,
                          int* start_time, int* end_time);
   void BuildLoadDyndeps();
   void BuildStarted();

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -212,7 +212,8 @@ SubprocessSet::SubprocessSet() {
 }
 
 SubprocessSet::~SubprocessSet() {
-  Clear();
+  Abort();
+  Wait();
 
   SetConsoleCtrlHandler(NotifyInterrupted, FALSE);
   CloseHandle(ioport_);
@@ -278,7 +279,7 @@ Subprocess* SubprocessSet::NextFinished() {
   return subproc;
 }
 
-void SubprocessSet::Clear() {
+void SubprocessSet::Abort() {
   for (vector<Subprocess*>::iterator i = running_.begin();
        i != running_.end(); ++i) {
     // Since the foreground process is in our process group, it will receive a
@@ -290,6 +291,9 @@ void SubprocessSet::Clear() {
       }
     }
   }
+}
+
+void SubprocessSet::Wait() {
   for (vector<Subprocess*>::iterator i = running_.begin();
        i != running_.end(); ++i)
     delete *i;

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -87,7 +87,8 @@ struct SubprocessSet {
   Subprocess* Add(const string& command, bool use_console = false);
   bool DoWork();
   Subprocess* NextFinished();
-  void Clear();
+  void Abort();
+  void Wait();
 
   vector<Subprocess*> running_;
   queue<Subprocess*> finished_;


### PR DESCRIPTION
Stay in the event loop when ninja receives SIGINT or SIGTERM so that
running commands that were interrupted can have their status printed
along with "interrupted by user".  Allows the end user to see what was
running at the time ninja was interrupted.
