### PR TITLE
Allow output to be modified with -O

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -75,6 +75,7 @@ BuildStatus::BuildStatus(const BuildConfig& config)
     : config_(config),
       start_time_millis_(GetTimeMillis()),
       started_edges_(0), finished_edges_(0), total_edges_(0),
+      printer_(config.printer),
       progress_status_format_(NULL),
       overall_rate_(), current_rate_(config.parallelism) {
 
@@ -121,7 +122,7 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
   if (config_.verbosity == BuildConfig::QUIET)
     return;
 
-  if (!edge->use_console() && printer_.is_smart_terminal())
+  if (!edge->use_console() && printer_.reprint())
     PrintStatus(edge);
 
   // Print the command that is spewing before printing its output.
@@ -140,9 +141,8 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
     // (Launching subprocesses in pseudo ttys doesn't work because there are
     // only a few hundred available on some systems, and ninja can launch
     // thousands of parallel compile commands.)
-    // TODO: There should be a flag to disable escape code stripping.
     string final_output;
-    if (!printer_.is_smart_terminal())
+    if (!printer_.color())
       final_output = StripAnsiEscapeCodes(output);
     else
       final_output = output;

--- a/src/build.h
+++ b/src/build.h
@@ -119,7 +119,8 @@ struct CommandRunner {
 
 /// Options (e.g. verbosity, parallelism) passed to a build.
 struct BuildConfig {
-  BuildConfig() : verbosity(NORMAL), dry_run(false), parallelism(1),
+  BuildConfig() : verbosity(NORMAL), printer(LinePrinter()),
+                  dry_run(false), parallelism(1),
                   failures_allowed(1), max_load_average(-0.0f) {}
 
   enum Verbosity {
@@ -128,6 +129,7 @@ struct BuildConfig {
     VERBOSE
   };
   Verbosity verbosity;
+  mutable LinePrinter printer;
   bool dry_run;
   int parallelism;
   int failures_allowed;
@@ -219,7 +221,7 @@ struct BuildStatus {
   RunningEdgeMap running_edges_;
 
   /// Prints progress output.
-  LinePrinter printer_;
+  LinePrinter& printer_;
 
   /// The custom progress status format to use.
   const char* progress_status_format_;

--- a/src/line_printer.h
+++ b/src/line_printer.h
@@ -24,8 +24,16 @@ using namespace std;
 struct LinePrinter {
   LinePrinter();
 
-  bool is_smart_terminal() const { return smart_terminal_; }
-  void set_smart_terminal(bool smart) { smart_terminal_ = smart; }
+  void set_smart_terminal(bool smart) { color_ = elide_ = reprint_ = smart; }
+
+  bool color() const { return color_; }
+  void set_color(bool color) { color_ = color; }
+
+  bool elide() const { return elide_; }
+  void set_elide(bool elide) { elide_ = elide; }
+
+  bool reprint() const { return reprint_; }
+  void set_reprint(bool reprint) { reprint_ = reprint; }
 
   enum LineType {
     FULL,
@@ -43,8 +51,14 @@ struct LinePrinter {
   void SetConsoleLocked(bool locked);
 
  private:
-  /// Whether we can do fancy terminal control codes.
-  bool smart_terminal_;
+  /// Whether we can do ANSI color codes.
+  bool color_;
+
+  /// Whether we can do \r to print over the same line.
+  bool reprint_;
+
+  /// Whether we get the size of the terminal to stay within.
+  bool elide_;
 
   /// Whether the caret is at the beginning of a blank line.
   bool have_blank_line_;


### PR DESCRIPTION
Split the "smart terminal" configuration into three separate settings:
color, elide, and reprint.  Allow setting these options individually or
in bulk through a new -O option.

To have build output into a dumb terminal still include ANSI color
codes, for example if you wanted to pass continuous build output through
ansi2html, use:
   ninja -O color

To force smart terminal output, use:
   ninja -O smart

To force smart terminal output, but still print full status
descriptions:
   ninja -O smart -O noelide

Addresses some of the issues in #746 while allowing for adding more
output options in the future.
