### PR TITLE
Print output file on failure

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -125,8 +125,15 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
     PrintStatus(edge);
 
   // Print the command that is spewing before printing its output.
-  if (!success)
-    printer_.PrintOnNewLine("FAILED: " + edge->EvaluateCommand() + "\n");
+  if (!success) {
+    string outputs;
+    for (vector<Node*>::const_iterator o = edge->outputs_.begin();
+         o != edge->outputs_.end(); ++o)
+      outputs += (*o)->path() + " ";
+
+    printer_.PrintOnNewLine("FAILED: " + outputs + "\n");
+    printer_.PrintOnNewLine(edge->EvaluateCommand() + "\n");
+  }
 
   if (!output.empty()) {
     // ninja sets stdout and stderr of subprocesses to a pipe, to be able to


### PR DESCRIPTION
Modify the FAILED: output to provide the output files that failed to
build, followed by the failed command on the next line.  This makes the
failure much easier to read, as you can immediately see much shorter
name of the file that failed instead of trying to parse a very long
command line.  It also makes manually re-running the failed command much
easier because you can copy the whole line without ending up with the
FAILED: prefix.