### PR TITLE
Fix wrapping file paths in Writer.comment

### DIFF
--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -21,8 +21,11 @@ class Writer(object):
     def newline(self):
         self.output.write('\n')
 
-    def comment(self, text):
-        for line in textwrap.wrap(text, self.width - 2):
+    def comment(self, text, has_path=False):
+        args = {}
+        if has_path:
+          args['break_long_words'] = args['break_on_hyphens'] = False
+        for line in textwrap.wrap(text, self.width - 2, **args):
             self.output.write('# ' + line + '\n')
 
     def variable(self, key, value, indent=0):

--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -22,10 +22,8 @@ class Writer(object):
         self.output.write('\n')
 
     def comment(self, text, has_path=False):
-        args = {}
-        if has_path:
-            args['break_long_words'] = args['break_on_hyphens'] = False
-        for line in textwrap.wrap(text, self.width - 2, **args):
+        for line in textwrap.wrap(text, self.width - 2, break_long_words=False,
+                                  break_on_hyphens=False):
             self.output.write('# ' + line + '\n')
 
     def variable(self, key, value, indent=0):

--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -24,7 +24,7 @@ class Writer(object):
     def comment(self, text, has_path=False):
         args = {}
         if has_path:
-          args['break_long_words'] = args['break_on_hyphens'] = False
+            args['break_long_words'] = args['break_on_hyphens'] = False
         for line in textwrap.wrap(text, self.width - 2, **args):
             self.output.write('# ' + line + '\n')
 

--- a/misc/ninja_syntax_test.py
+++ b/misc/ninja_syntax_test.py
@@ -46,13 +46,8 @@ class TestLineWordWrap(unittest.TestCase):
                          self.out.getvalue())
 
     def test_comment_wrap(self):
-        # We should wrap the comments
-        self.n.comment('Hello there')
-        self.assertEqual('# Hello\n# there\n', self.out.getvalue())
-
-    def test_comment_wrap_filename(self):
         # Filenames shoud not be wrapped
-        self.n.comment('Hello /usr/local/build-tools/bin', has_path=True)
+        self.n.comment('Hello /usr/local/build-tools/bin')
         self.assertEqual('# Hello\n# /usr/local/build-tools/bin\n',
                          self.out.getvalue())
 

--- a/misc/ninja_syntax_test.py
+++ b/misc/ninja_syntax_test.py
@@ -45,6 +45,17 @@ class TestLineWordWrap(unittest.TestCase):
                                       INDENT + 'y']) + '\n',
                          self.out.getvalue())
 
+    def test_comment_wrap(self):
+        # We should wrap the comments
+        self.n.comment('Hello there')
+        self.assertEqual('# Hello\n# there\n', self.out.getvalue())
+
+    def test_comment_wrap_filename(self):
+        # Filenames shoud not be wrapped
+        self.n.comment('Hello /usr/local/build-tools/bin', has_path=True)
+        self.assertEqual('# Hello\n# /usr/local/build-tools/bin\n',
+                         self.out.getvalue())
+
     def test_short_words_indented(self):
         # Test that indent is taking into acount when breaking subsequent lines.
         # The second line should not be '    to tree', as that's longer than the


### PR DESCRIPTION
Long file names, especially with hyphens will get incorrectly wrapped by
the comment method. Pass has_path=True to prevent this type of wrapping.

This is mainly so that longer path names can show up in comments on
their on line without breaking them up.

Should fix issue #1041 