### PR TITLE
Extend format status output - Allow to change also order of description in NINJA_STATUS

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -188,6 +188,9 @@ string BuildStatus::FormatProgressStatus(
   string out;
   char buf[32];
   int percent;
+  char total_edges_str[32];
+  snprintf(total_edges_str, sizeof(total_edges_str), "%d", total_edges_);
+  int total_edges_len = strlen(total_edges_str);
   for (const char* s = progress_status_format; *s != '\0'; ++s) {
     if (*s == '%') {
       ++s;
@@ -198,14 +201,13 @@ string BuildStatus::FormatProgressStatus(
 
         // Started edges.
       case 's':
-        snprintf(buf, sizeof(buf), "%d", started_edges_);
+        snprintf(buf, sizeof(buf), "%*d", total_edges_len, started_edges_);
         out += buf;
         break;
 
         // Total edges.
       case 't':
-        snprintf(buf, sizeof(buf), "%d", total_edges_);
-        out += buf;
+        out += total_edges_str;
         break;
 
         // Running edges.
@@ -214,20 +216,20 @@ string BuildStatus::FormatProgressStatus(
         // count the edge that just finished as a running edge
         if (status == kEdgeFinished)
           running_edges++;
-        snprintf(buf, sizeof(buf), "%d", running_edges);
+        snprintf(buf, sizeof(buf), "%*d", total_edges_len, running_edges);
         out += buf;
         break;
       }
 
         // Unstarted edges.
       case 'u':
-        snprintf(buf, sizeof(buf), "%d", total_edges_ - started_edges_);
+        snprintf(buf, sizeof(buf), "%*d", total_edges_len, total_edges_ - started_edges_);
         out += buf;
         break;
 
         // Finished edges.
       case 'f':
-        snprintf(buf, sizeof(buf), "%d", finished_edges_);
+        snprintf(buf, sizeof(buf), "%*d", total_edges_len, finished_edges_);
         out += buf;
         break;
 

--- a/src/build.cc
+++ b/src/build.cc
@@ -184,10 +184,11 @@ void BuildStatus::BuildFinished() {
 }
 
 string BuildStatus::FormatProgressStatus(
-    const char* progress_status_format, EdgeStatus status) const {
+    const char* progress_status_format, EdgeStatus status, const string to_print) const {
   string out;
   char buf[32];
   int percent;
+  bool has_desc = false;
   char total_edges_str[32];
   snprintf(total_edges_str, sizeof(total_edges_str), "%d", total_edges_);
   int total_edges_len = strlen(total_edges_str);
@@ -261,6 +262,12 @@ string BuildStatus::FormatProgressStatus(
         break;
       }
 
+        // Description (to_print)
+      case 'd':
+        out += to_print;
+        has_desc = true;
+        break;
+
       default:
         Fatal("unknown placeholder '%%%c' in $NINJA_STATUS", *s);
         return "";
@@ -269,6 +276,9 @@ string BuildStatus::FormatProgressStatus(
       out.push_back(*s);
     }
   }
+
+  if (!has_desc)
+    out += to_print;
 
   return out;
 }
@@ -283,7 +293,7 @@ void BuildStatus::PrintStatus(Edge* edge, EdgeStatus status) {
   if (to_print.empty() || force_full_command)
     to_print = edge->GetBinding("command");
 
-  to_print = FormatProgressStatus(progress_status_format_, status) + to_print;
+  to_print = FormatProgressStatus(progress_status_format_, status, to_print);
 
   printer_.Print(to_print,
                  force_full_command ? LinePrinter::FULL : LinePrinter::ELIDE);

--- a/src/build.h
+++ b/src/build.h
@@ -231,7 +231,7 @@ struct BuildStatus {
   /// @param progress_status_format The format of the progress status.
   /// @param status The status of the edge.
   string FormatProgressStatus(const char* progress_status_format,
-                              EdgeStatus status) const;
+                              EdgeStatus status, const string to_print) const;
 
  private:
   void PrintStatus(Edge* edge, EdgeStatus status);

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1325,7 +1325,7 @@ TEST_F(BuildWithLogTest, RestatTest) {
   EXPECT_TRUE(builder_.Build(&err));
   ASSERT_EQ("", err);
   EXPECT_EQ("[3/3]", builder_.status_->FormatProgressStatus("[%s/%t]",
-      BuildStatus::kEdgeStarted));
+      BuildStatus::kEdgeStarted, ""));
   command_runner_.commands_ran_.clear();
   state_.Reset();
 
@@ -1768,13 +1768,13 @@ TEST_F(BuildTest, StatusFormatElapsed) {
   // Before any task is done, the elapsed time must be zero.
   EXPECT_EQ("[%/e0.000]",
             status_.FormatProgressStatus("[%%/e%e]",
-                BuildStatus::kEdgeStarted));
+                BuildStatus::kEdgeStarted, ""));
 }
 
 TEST_F(BuildTest, StatusFormatReplacePlaceholder) {
   EXPECT_EQ("[%/s0/t0/r0/u0/f0]",
             status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]",
-                BuildStatus::kEdgeStarted));
+                BuildStatus::kEdgeStarted, ""));
 }
 
 TEST_F(BuildTest, FailedDepsParse) {


### PR DESCRIPTION
**Align all edge numbers to same length when formatting output**

So when updating status output on terminal, make sure that all numbers will
be always aligned at same length. Even if progress variables change number
of characters.

___

**Allow to change also order of description in NINJA_STATUS**

This commit adds new format string %d for printing description. When %d is
not specified in NINJA_STATUS, then description is automatically printed at
the end of line.

This allows to add additional strings after description, for example
changing colors on ANSI terminals via NINJA_STATUS variable.