### PR TITLE
Speed-up bash target auto-complete.

### DIFF
--- a/misc/bash-completion
+++ b/misc/bash-completion
@@ -49,9 +49,8 @@ _ninja_target() {
 		C) eval dir="$OPTARG" ;;
 	    esac
 	done;
-	targets_command="eval ninja -C \"${dir}\" -t targets all"
-	targets=$(${targets_command} 2>/dev/null | awk -F: '{print $1}')
-	COMPREPLY=($(compgen -W "$targets" -- "$cur"))
+	targets_command="eval ninja -C \"${dir}\" -t targets all 2>/dev/null | cut -d: -f1"
+	COMPREPLY=($(compgen -W '`${targets_command}`' -- "$cur"))
     fi
     return
 }


### PR DESCRIPTION
Bash auto-complete was too slow when I used it for Chromium, which had 40k targets. The following speed-ups reduce the time to auto-complete from 2038ms to 570ms.

* Let compgen do the command substitution. Similar to
  https://lists.gnu.org/archive/html/bug-bash/2012-03/msg00115.html
* Use "cut" instead of "awk" for separating fields.
