### PR TITLE
Add keys to choose shell and shellflags

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Ninja is a small build system with a focus on speed.
-http://ninja-build.org/
+https://ninja-build.org/
 
-See the manual -- http://ninja-build.org/manual.html or
+See the manual -- https://ninja-build.org/manual.html or
 doc/manual.asciidoc included in the distribution -- for background
 and more details.
 

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -787,6 +787,10 @@ keys.
   declaration. To specify multiple commands use `&&` (or similar) to
   concatenate operations.
 
+`shell`:: _(Available since Ninja 1.7.)_ the shell interpreter to run.
+  If not given, `/bin/sh` is being used. Use an absolute path.
+  This key is unused on Windows.
+
 `depfile`:: path to an optional `Makefile` that contains extra
   _implicit dependencies_ (see <<ref_dependencies,the reference on
   dependency types>>).  This is explicitly to support C/C++ header

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -791,6 +791,10 @@ keys.
   If not given, `/bin/sh` is being used. Use an absolute path.
   This key is unused on Windows.
 
+`shellflags`:: _(Available since Ninja 1.7.)_ the shell flags to use.
+  If not given, `-c` is being used. An alternative is `-ec`.
+  This key is unused on Windows.
+
 `depfile`:: path to an optional `Makefile` that contains extra
   _implicit dependencies_ (see <<ref_dependencies,the reference on
   dependency types>>).  This is explicitly to support C/C++ header

--- a/src/build.cc
+++ b/src/build.cc
@@ -515,7 +515,8 @@ bool RealCommandRunner::CanRunMore() {
 
 bool RealCommandRunner::StartCommand(Edge* edge) {
   string command = edge->EvaluateCommand();
-  Subprocess* subproc = subprocs_.Add(command, edge->use_console());
+  Subprocess* subproc = subprocs_.Add(command, edge->use_console(),
+                                      edge->shell());
   if (!subproc)
     return false;
   subproc_to_edge_.insert(make_pair(subproc, edge));

--- a/src/build.cc
+++ b/src/build.cc
@@ -516,7 +516,7 @@ bool RealCommandRunner::CanRunMore() {
 bool RealCommandRunner::StartCommand(Edge* edge) {
   string command = edge->EvaluateCommand();
   Subprocess* subproc = subprocs_.Add(command, edge->use_console(),
-                                      edge->shell());
+                                      edge->shell(), edge->shellflags());
   if (!subproc)
     return false;
   subproc_to_edge_.insert(make_pair(subproc, edge));

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -72,7 +72,8 @@ bool Rule::IsReservedBinding(const string& var) {
       var == "restat" ||
       var == "rspfile" ||
       var == "rspfile_content" ||
-      var == "shell";
+      var == "shell" ||
+      var == "shellflags";
 }
 
 const map<string, const Rule*>& BindingEnv::GetRules() const {

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -71,7 +71,8 @@ bool Rule::IsReservedBinding(const string& var) {
       var == "pool" ||
       var == "restat" ||
       var == "rspfile" ||
-      var == "rspfile_content";
+      var == "rspfile_content" ||
+      var == "shell";
 }
 
 const map<string, const Rule*>& BindingEnv::GetRules() const {

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -351,6 +351,10 @@ string Edge::shell() {
   return GetBinding("shell");
 }
 
+string Edge::shellflags() {
+  return GetBinding("shellflags");
+}
+
 // static
 string Node::PathDecanonicalized(const string& path, unsigned int slash_bits) {
   string result = path;

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -347,6 +347,10 @@ bool Edge::use_console() const {
   return pool() == &State::kConsolePool;
 }
 
+string Edge::shell() {
+  return GetBinding("shell");
+}
+
 // static
 string Node::PathDecanonicalized(const string& path, unsigned int slash_bits) {
   string result = path;

--- a/src/graph.h
+++ b/src/graph.h
@@ -184,6 +184,7 @@ struct Edge {
   bool is_phony() const;
   bool use_console() const;
   string shell();
+  string shellflags();
 };
 
 

--- a/src/graph.h
+++ b/src/graph.h
@@ -183,6 +183,7 @@ struct Edge {
 
   bool is_phony() const;
   bool use_console() const;
+  string shell();
 };
 
 

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -21,7 +21,9 @@
 
 #include "util.h"
 
-Subprocess::Subprocess(bool use_console) : child_(NULL) , overlapped_(),
+Subprocess::Subprocess(bool use_console, const string& shell) :
+                                           child_(NULL),
+                                           overlapped_(),
                                            is_reading_(false),
                                            use_console_(use_console) {
 }
@@ -196,6 +198,8 @@ const string& Subprocess::GetOutput() const {
   return buf_;
 }
 
+const string SubprocessSet::empty_;
+
 HANDLE SubprocessSet::ioport_;
 
 SubprocessSet::SubprocessSet() {
@@ -223,8 +227,8 @@ BOOL WINAPI SubprocessSet::NotifyInterrupted(DWORD dwCtrlType) {
   return FALSE;
 }
 
-Subprocess *SubprocessSet::Add(const string& command, bool use_console) {
-  Subprocess *subprocess = new Subprocess(use_console);
+Subprocess *SubprocessSet::Add(const string& command, bool use_console, const string& shell) {
+  Subprocess *subprocess = new Subprocess(use_console, shell);
   if (!subprocess->Start(this, command)) {
     delete subprocess;
     return 0;

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -21,7 +21,7 @@
 
 #include "util.h"
 
-Subprocess::Subprocess(bool use_console, const string& shell) :
+Subprocess::Subprocess(bool use_console, const string& shell, const string& shellflags) :
                                            child_(NULL),
                                            overlapped_(),
                                            is_reading_(false),
@@ -227,8 +227,8 @@ BOOL WINAPI SubprocessSet::NotifyInterrupted(DWORD dwCtrlType) {
   return FALSE;
 }
 
-Subprocess *SubprocessSet::Add(const string& command, bool use_console, const string& shell) {
-  Subprocess *subprocess = new Subprocess(use_console, shell);
+Subprocess *SubprocessSet::Add(const string& command, bool use_console, const string& shell, const string& shellflags) {
+  Subprocess *subprocess = new Subprocess(use_console, shell, shellflags);
   if (!subprocess->Start(this, command)) {
     delete subprocess;
     return 0;

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -44,7 +44,7 @@ struct Subprocess {
   const string& GetOutput() const;
 
  private:
-  Subprocess(bool use_console);
+  Subprocess(bool use_console, const string& shell);
   bool Start(struct SubprocessSet* set, const string& command);
   void OnPipeReady();
 
@@ -63,6 +63,7 @@ struct Subprocess {
 #else
   int fd_;
   pid_t pid_;
+  string shell_;
 #endif
   bool use_console_;
 
@@ -76,11 +77,13 @@ struct SubprocessSet {
   SubprocessSet();
   ~SubprocessSet();
 
-  Subprocess* Add(const string& command, bool use_console = false);
+  Subprocess* Add(const string& command, bool use_console = false,
+                  const string& shell = empty_);
   bool DoWork();
   Subprocess* NextFinished();
   void Clear();
 
+  static const string empty_;
   vector<Subprocess*> running_;
   queue<Subprocess*> finished_;
 

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -44,7 +44,7 @@ struct Subprocess {
   const string& GetOutput() const;
 
  private:
-  Subprocess(bool use_console, const string& shell);
+  Subprocess(bool use_console, const string& shell, const string& shellflags);
   bool Start(struct SubprocessSet* set, const string& command);
   void OnPipeReady();
 
@@ -64,6 +64,7 @@ struct Subprocess {
   int fd_;
   pid_t pid_;
   string shell_;
+  string shellflags_;
 #endif
   bool use_console_;
 
@@ -78,7 +79,7 @@ struct SubprocessSet {
   ~SubprocessSet();
 
   Subprocess* Add(const string& command, bool use_console = false,
-                  const string& shell = empty_);
+                  const string& shell = empty_, const string& shellflags = empty_);
   bool DoWork();
   Subprocess* NextFinished();
   void Clear();


### PR DESCRIPTION
This can be used for instance to choose /bin/dash, or to run the scripts with -ec.
There's a lot of other uses, as can be seen by make's $(SHELL) and .SHELLFLAGS.