### PR TITLE
make use of Bindings typedef

### DIFF
--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -55,7 +55,7 @@ void Rule::AddBinding(const string& key, const EvalString& val) {
 }
 
 const EvalString* Rule::GetBinding(const string& key) const {
-  map<string, EvalString>::const_iterator i = bindings_.find(key);
+  Bindings::const_iterator i = bindings_.find(key);
   if (i == bindings_.end())
     return NULL;
   return &i->second;

--- a/src/eval_env.h
+++ b/src/eval_env.h
@@ -57,7 +57,6 @@ struct Rule {
 
   const string& name() const { return name_; }
 
-  typedef map<string, EvalString> Bindings;
   void AddBinding(const string& key, const EvalString& val);
 
   static bool IsReservedBinding(const string& var);
@@ -69,7 +68,8 @@ struct Rule {
   friend struct ManifestParser;
 
   string name_;
-  map<string, EvalString> bindings_;
+  typedef map<string, EvalString> Bindings;
+  Bindings bindings_;
 };
 
 /// An Env which contains a mapping of variables to values


### PR DESCRIPTION
Looks like we declared this typedef but never used it.

It seems we just forgot to use it so this patch makes uses of it now.
Otherwise we could just delete it.