### PR TITLE
add "msvc_deps_prefix" to Rule::IsReservedBinding()

### DIFF
--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -71,7 +71,8 @@ bool Rule::IsReservedBinding(const string& var) {
       var == "pool" ||
       var == "restat" ||
       var == "rspfile" ||
-      var == "rspfile_content";
+      var == "rspfile_content" ||
+      var == "msvc_deps_prefix";
 }
 
 const map<string, const Rule*>& BindingEnv::GetRules() const {


### PR DESCRIPTION
fixes the error about an unexpected variable for a rule that
declares the msvc_deps_prefix. The manual suggests that this
should work since Ninja 1.5
(https://ninja-build.org/manual.html#ref_rule).

Closes #1043