### PR TITLE
use the default font size for manual headings

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -24,12 +24,6 @@ div.chapter {
     margin-top: 4em;
     border-top: solid 2px black;
 }
-.section .title {
-    font-size: 1.3em;
-}
-.section .section .title {
-    font-size: 1.2em;
-}
 p {
     margin-top: 0;
 }


### PR DESCRIPTION
The third-level subsection headings were almost indistinguishable
from the second-level ones.  Fix this by just using the default
styling.