### PR TITLE
Forward flags to sub processes.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -626,3 +626,31 @@ bool Truncate(const string& path, size_t size, string* err) {
   }
   return true;
 }
+
+void SplitArgv(char* flags, int* argc, char** argv, const int max_argc) {
+  assert(*argc < max_argc - 1);
+  char* start = flags;
+  {
+    char* s = flags;
+    while (true) {
+      while (*s == ' ')
+        ++s;
+      if (*s == '\0')
+        break;
+      start = s;
+      while (*s != '\0' && *s != ' ')
+        ++s;
+      if (*argc >= max_argc - 1)
+        Fatal("more than %d arguments in NINJA_FLAGS", max_argc);
+      argv[*argc] = start;
+      ++*argc;
+      if (*s == '\0')
+        break;
+      else {
+        *s = '\0';
+        ++s;
+      }
+    }
+  }
+  argv[*argc] = NULL;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -106,4 +106,10 @@ string GetLastErrorString();
 NORETURN void Win32Fatal(const char* function);
 #endif
 
+/// Split a string of flags into an array of flag strings.
+/// @warning: Does not support shell quote
+/// @warning: Modify @a flags in-place.
+/// @warning: argc must be initialized to the index to start from.
+void SplitArgv(char* flags, int* argc, char** argv, const int max_argc);
+
 #endif  // NINJA_UTIL_H_

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -399,3 +399,116 @@ TEST(ElideMiddle, ElideInTheMiddle) {
   string elided = ElideMiddle(input, 10);
   EXPECT_EQ("012...789", elided);
 }
+
+TEST(SplitArgv, Empty) {
+  int argc = 0;
+  char* argv[16];
+  SplitArgv("", &argc, argv, 16);
+  EXPECT_EQ(0, argc);
+  EXPECT_EQ(NULL, argv[0]);
+}
+
+TEST(SplitArgv, OnlyWhitespace) {
+  int argc = 0;
+  char* argv[16];
+  SplitArgv("    ", &argc, argv, 16);
+  EXPECT_EQ(0, argc);
+  EXPECT_EQ(NULL, argv[0]);
+}
+
+TEST(SplitArgv, SingleFlags) {
+  int argc = 0;
+  char* argv[16];
+  char* flags = strdup("-n");
+  SplitArgv(flags, &argc, argv, 16);
+  EXPECT_EQ(1, argc);
+  EXPECT_TRUE(strcmp("-n", argv[0]) == 0);
+  EXPECT_EQ(NULL, argv[1]);
+  free(flags);
+}
+
+TEST(SplitArgv, SingleFlagsSurroundedBySpaces) {
+  int argc = 0;
+  char* argv[16];
+  char* flags = strdup("  -n   ");
+  SplitArgv(flags, &argc, argv, 16);
+  EXPECT_EQ(1, argc);
+  EXPECT_TRUE(strcmp("-n", argv[0]) == 0);
+  EXPECT_EQ(NULL, argv[1]);
+  free(flags);
+}
+
+TEST(SplitArgv, SingleFlagsWithArgs) {
+  int argc = 0;
+  char* argv[16];
+  char* flags = strdup("-k 1000");
+  SplitArgv(flags, &argc, argv, 16);
+  EXPECT_EQ(2, argc);
+  EXPECT_TRUE(strcmp("-k", argv[0]) == 0);
+  EXPECT_TRUE(strcmp("1000", argv[1]) == 0);
+  EXPECT_EQ(NULL, argv[2]);
+  free(flags);
+}
+
+TEST(SplitArgv, SingleFlagsWithArgsStuck) {
+  int argc = 0;
+  char* argv[16];
+  char* flags = strdup("-k1000");
+  SplitArgv(flags, &argc, argv, 16);
+  EXPECT_EQ(1, argc);
+  EXPECT_TRUE(strcmp("-k1000", argv[0]) == 0);
+  EXPECT_EQ(NULL, argv[1]);
+  free(flags);
+}
+
+TEST(SplitArgv, TwoFlagsWithArgsStuck) {
+  int argc = 0;
+  char* argv[16];
+  char* flags = strdup("-j10 -k1000");
+  SplitArgv(flags, &argc, argv, 16);
+  EXPECT_EQ(2, argc);
+  EXPECT_TRUE(strcmp("-j10", argv[0]) == 0);
+  EXPECT_TRUE(strcmp("-k1000", argv[1]) == 0);
+  EXPECT_EQ(NULL, argv[2]);
+  free(flags);
+}
+
+TEST(SplitArgv, TwoFlagsWithArgsStuckSurroundedBySpaces) {
+  int argc = 0;
+  char* argv[16];
+  char* flags = strdup("  -j10 -k1000   ");
+  SplitArgv(flags, &argc, argv, 16);
+  EXPECT_EQ(2, argc);
+  EXPECT_TRUE(strcmp("-j10", argv[0]) == 0);
+  EXPECT_TRUE(strcmp("-k1000", argv[1]) == 0);
+  EXPECT_EQ(NULL, argv[2]);
+  free(flags);
+}
+
+TEST(SplitArgv, TwoFlagsWithArgs) {
+  int argc = 0;
+  char* argv[16];
+  char* flags = strdup("-j 10 -k 1000");
+  SplitArgv(flags, &argc, argv, 16);
+  EXPECT_EQ(4, argc);
+  EXPECT_TRUE(strcmp("-j", argv[0]) == 0);
+  EXPECT_TRUE(strcmp("10", argv[1]) == 0);
+  EXPECT_TRUE(strcmp("-k", argv[2]) == 0);
+  EXPECT_TRUE(strcmp("1000", argv[3]) == 0);
+  EXPECT_EQ(NULL, argv[4]);
+  free(flags);
+}
+
+TEST(SplitArgv, TwoFlagsWithArgsSurroundedBySpaces) {
+  int argc = 0;
+  char* argv[16];
+  char* flags = strdup("  -j 10 -k 1000   ");
+  SplitArgv(flags, &argc, argv, 16);
+  EXPECT_EQ(4, argc);
+  EXPECT_TRUE(strcmp("-j", argv[0]) == 0);
+  EXPECT_TRUE(strcmp("10", argv[1]) == 0);
+  EXPECT_TRUE(strcmp("-k", argv[2]) == 0);
+  EXPECT_TRUE(strcmp("1000", argv[3]) == 0);
+  EXPECT_EQ(NULL, argv[4]);
+  free(flags);
+}


### PR DESCRIPTION
When ninja invokes ninja (for instance when building a sub-project) it
is useful to have a way to control the flags used by the sub-ninja
process. If I pass '-d explain' or '-v' when starting
ninja from the command line on the top project, I expect these flags
to be forwarded to the sub-ninja process.

Note that this patch has limited parsing capabilities of the
NINJA_FLAGS environment variables but that should be enough for our
use case.

Fixes #797, #922 and #816.