### PR TITLE
Use container-based infrastructure for travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: cpp
 compiler:
   - gcc


### PR DESCRIPTION
To start up faster. I think we want build results as soon as possible.
See https://docs.travis-ci.com/user/workers/container-based-infrastructure/ for the details.