### PR TITLE
Delete a newed status object when it is not needed any more.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -552,6 +552,8 @@ Builder::Builder(State* state, const BuildConfig& config,
 
 Builder::~Builder() {
   Cleanup();
+  if (status_)
+    delete status_;
 }
 
 void Builder::Cleanup() {


### PR DESCRIPTION
`Builder` allocates a `BuildStatus` object in its constructor by `new`, but the status object is not released by `delete`. I believe it is a good practice to free the allocated object when it is not needed any more.