### PR TITLE
Delete a newed DiskInterface object if it is owned.

### DIFF
--- a/src/clean.cc
+++ b/src/clean.cc
@@ -29,6 +29,7 @@ Cleaner::Cleaner(State* state, const BuildConfig& config)
     cleaned_(),
     cleaned_files_count_(0),
     disk_interface_(new RealDiskInterface),
+    own_disk_interface_(true),
     status_(0) {
 }
 
@@ -41,7 +42,13 @@ Cleaner::Cleaner(State* state,
     cleaned_(),
     cleaned_files_count_(0),
     disk_interface_(disk_interface),
+    own_disk_interface_(false),
     status_(0) {
+}
+
+Cleaner::~Cleaner() {
+  if (own_disk_interface_ && disk_interface_)
+    delete disk_interface_;
 }
 
 int Cleaner::RemoveFile(const string& path) {

--- a/src/clean.h
+++ b/src/clean.h
@@ -36,6 +36,7 @@ struct Cleaner {
   Cleaner(State* state,
           const BuildConfig& config,
           DiskInterface* disk_interface);
+  ~Cleaner();
 
   /// Clean the given @a target and all the file built for it.
   /// @return non-zero if an error occurs.
@@ -101,6 +102,7 @@ struct Cleaner {
   set<Node*> cleaned_;
   int cleaned_files_count_;
   DiskInterface* disk_interface_;
+  bool own_disk_interface_;
   int status_;
 };
 


### PR DESCRIPTION
`Cleaner` has two type of constructors: (1) allocates a `DiskInterface` object by `new` (i.e., owns the object); (2) takes a pointer to a `DiskInterface` object (AFAIK, the class doesn't own the object).

If the first type of the constructor is called, it is the Cleaner's responsibility to free the `DiskInterface` object when the object is not needed any more.