### PR TITLE
fix for localized version of cl.exe

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -83,7 +83,7 @@ class Platform(object):
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         out, err = popen.communicate()
-        return b'/FS ' in out
+        return b'/FS' in out
 
     def is_windows(self):
         return self.is_mingw() or self.is_msvc()


### PR DESCRIPTION
msvc (2013, 2015) korean version doesn't have trail whitespace on /FS switch
call [chcp 437] before build, or change code '/FS ' to '/FS'

2013.txt : cl /nologo /? > 2013.txt  (on vs2013 x64 cross tools command prompt)
2015.txt : cl /nologo /? > 2015.txt  (on vs2015 x64 cross tools command prompt)

[2013.txt](https://github.com/ninja-build/ninja/files/103268/2013.txt)
[2015.txt](https://github.com/ninja-build/ninja/files/103269/2015.txt)
