### PR TITLE
Make dupbuild=err work in subninja

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -380,7 +380,7 @@ bool ManifestParser::ParseFileInclude(bool new_scope, string* err) {
     return false;
   string path = eval.Evaluate(env_);
 
-  ManifestParser subparser(state_, file_reader_);
+  ManifestParser subparser(state_, file_reader_, dupe_edge_should_err_);
   if (new_scope) {
     subparser.env_ = new BindingEnv(env_);
   } else {

--- a/src/manifest_parser.h
+++ b/src/manifest_parser.h
@@ -33,7 +33,7 @@ struct ManifestParser {
   };
 
   ManifestParser(State* state, FileReader* file_reader,
-                 bool dupe_edge_should_err = false);
+                 bool dupe_edge_should_err);
 
   /// Load and parse a file.
   bool Load(const string& filename, string* err, Lexer* parent = NULL);

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -24,7 +24,7 @@
 struct ParserTest : public testing::Test,
                     public ManifestParser::FileReader {
   void AssertParse(const char* input) {
-    ManifestParser parser(&state, this);
+    ManifestParser parser(&state, this, false);
     string err;
     EXPECT_TRUE(parser.ParseTest(input, &err));
     ASSERT_EQ("", err);
@@ -377,6 +377,22 @@ TEST_F(ParserTest, DuplicateEdgeWithMultipleOutputsError) {
   EXPECT_EQ("input:5: multiple rules generate out1 [-w dupbuild=err]\n", err);
 }
 
+TEST_F(ParserTest, DuplicateEdgeInIncludedFile) {
+  files_["sub.ninja"] =
+    "rule cat\n"
+    "  command = cat $in > $out\n"
+    "build out1 out2: cat in1\n"
+    "build out1: cat in2\n"
+    "build final: cat out1\n";
+  const char kInput[] =
+    "subninja sub.ninja\n";
+  ManifestParser parser(&state, this, /*dupe_edges_should_err=*/true);
+  string err;
+  EXPECT_FALSE(parser.ParseTest(kInput, &err));
+  EXPECT_EQ("sub.ninja:5: multiple rules generate out1 [-w dupbuild=err]\n",
+            err);
+}
+
 TEST_F(ParserTest, ReservedWords) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(
 "rule build\n"
@@ -388,7 +404,7 @@ TEST_F(ParserTest, ReservedWords) {
 TEST_F(ParserTest, Errors) {
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest(string("subn", 4), &err));
     EXPECT_EQ("input:1: expected '=', got eof\n"
@@ -399,7 +415,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("foobar", &err));
     EXPECT_EQ("input:1: expected '=', got eof\n"
@@ -410,7 +426,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("x 3", &err));
     EXPECT_EQ("input:1: expected '=', got identifier\n"
@@ -421,7 +437,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = 3", &err));
     EXPECT_EQ("input:1: unexpected EOF\n"
@@ -432,7 +448,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = 3\ny 2", &err));
     EXPECT_EQ("input:2: expected '=', got identifier\n"
@@ -443,7 +459,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = $", &err));
     EXPECT_EQ("input:1: bad $-escape (literal $ must be written as $$)\n"
@@ -454,7 +470,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = $\n $[\n", &err));
     EXPECT_EQ("input:2: bad $-escape (literal $ must be written as $$)\n"
@@ -465,7 +481,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = a$\n b$\n $\n", &err));
     EXPECT_EQ("input:4: unexpected EOF\n"
@@ -474,7 +490,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("build\n", &err));
     EXPECT_EQ("input:1: expected path\n"
@@ -485,7 +501,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("build x: y z\n", &err));
     EXPECT_EQ("input:1: unknown build rule 'y'\n"
@@ -496,7 +512,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("build x:: y z\n", &err));
     EXPECT_EQ("input:1: expected build command name\n"
@@ -507,7 +523,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n  command = cat ok\n"
                                   "build x: cat $\n :\n",
@@ -520,7 +536,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n",
                                   &err));
@@ -529,7 +545,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = echo\n"
@@ -543,7 +559,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = echo\n"
@@ -555,7 +571,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = ${fafsd\n"
@@ -570,7 +586,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = cat\n"
@@ -585,7 +601,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = cat\n"
@@ -599,7 +615,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule %foo\n",
                                   &err));
@@ -608,7 +624,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n"
                                   "  command = foo\n"
@@ -622,7 +638,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n"
                                   "build $.: cc bar.cc\n",
@@ -635,7 +651,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n  && bar",
                                   &err));
@@ -644,7 +660,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n"
                                   "build $: cc bar.cc\n",
@@ -657,7 +673,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("default\n",
                                   &err));
@@ -669,7 +685,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("default nonexistent\n",
                                   &err));
@@ -681,7 +697,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule r\n  command = r\n"
                                   "build b: r\n"
@@ -695,7 +711,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("default $a\n", &err));
     EXPECT_EQ("input:1: empty path\n"
@@ -706,7 +722,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule r\n"
                                   "  command = r\n"
@@ -718,7 +734,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     // the indented blank line must terminate the rule
     // this also verifies that "unexpected (token)" errors are correct
@@ -731,7 +747,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool\n", &err));
     EXPECT_EQ("input:1: expected pool name\n", err);
@@ -739,7 +755,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n", &err));
     EXPECT_EQ("input:2: expected 'depth =' line\n", err);
@@ -747,7 +763,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  depth = 4\n"
@@ -760,7 +776,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  depth = -1\n", &err));
@@ -772,7 +788,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  bar = 1\n", &err));
@@ -784,7 +800,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL);
+    ManifestParser parser(&state, NULL, false);
     string err;
     // Pool names are dereferenced at edge parsing time.
     EXPECT_FALSE(parser.ParseTest("rule run\n"
@@ -797,7 +813,7 @@ TEST_F(ParserTest, Errors) {
 
 TEST_F(ParserTest, MissingInput) {
   State state;
-  ManifestParser parser(&state, this);
+  ManifestParser parser(&state, this, false);
   string err;
   EXPECT_FALSE(parser.Load("build.ninja", &err));
   EXPECT_EQ("loading 'build.ninja': No such file or directory", err);
@@ -805,7 +821,7 @@ TEST_F(ParserTest, MissingInput) {
 
 TEST_F(ParserTest, MultipleOutputs) {
   State state;
-  ManifestParser parser(&state, NULL);
+  ManifestParser parser(&state, NULL, false);
   string err;
   EXPECT_TRUE(parser.ParseTest("rule cc\n  command = foo\n  depfile = bar\n"
                                "build a.o b.o: cc c.cc\n",
@@ -815,7 +831,7 @@ TEST_F(ParserTest, MultipleOutputs) {
 
 TEST_F(ParserTest, MultipleOutputsWithDeps) {
   State state;
-  ManifestParser parser(&state, NULL);
+  ManifestParser parser(&state, NULL, false);
   string err;
   EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n  deps = gcc\n"
                                "build a.o b.o: cc c.cc\n",
@@ -850,7 +866,7 @@ TEST_F(ParserTest, SubNinja) {
 }
 
 TEST_F(ParserTest, MissingSubNinja) {
-  ManifestParser parser(&state, this);
+  ManifestParser parser(&state, this, false);
   string err;
   EXPECT_FALSE(parser.ParseTest("subninja foo.ninja\n", &err));
   EXPECT_EQ("input:1: loading 'foo.ninja': No such file or directory\n"
@@ -863,7 +879,7 @@ TEST_F(ParserTest, DuplicateRuleInDifferentSubninjas) {
   // Test that rules are scoped to subninjas.
   files_["test.ninja"] = "rule cat\n"
                          "  command = cat\n";
-  ManifestParser parser(&state, this);
+  ManifestParser parser(&state, this, false);
   string err;
   EXPECT_TRUE(parser.ParseTest("rule cat\n"
                                 "  command = cat\n"
@@ -876,7 +892,7 @@ TEST_F(ParserTest, DuplicateRuleInDifferentSubninjasWithInclude) {
                          "  command = cat\n";
   files_["test.ninja"] = "include rules.ninja\n"
                          "build x : cat\n";
-  ManifestParser parser(&state, this);
+  ManifestParser parser(&state, this, false);
   string err;
   EXPECT_TRUE(parser.ParseTest("include rules.ninja\n"
                                 "subninja test.ninja\n"
@@ -896,7 +912,7 @@ TEST_F(ParserTest, Include) {
 
 TEST_F(ParserTest, BrokenInclude) {
   files_["include.ninja"] = "build\n";
-  ManifestParser parser(&state, this);
+  ManifestParser parser(&state, this, false);
   string err;
   EXPECT_FALSE(parser.ParseTest("include include.ninja\n", &err));
   EXPECT_EQ("include.ninja:1: expected path\n"
@@ -976,7 +992,7 @@ TEST_F(ParserTest, UTF8) {
 
 TEST_F(ParserTest, CRLF) {
   State state;
-  ManifestParser parser(&state, NULL);
+  ManifestParser parser(&state, NULL, false);
   string err;
 
   EXPECT_TRUE(parser.ParseTest("# comment with crlf\r\n", &err));

--- a/src/test.cc
+++ b/src/test.cc
@@ -95,7 +95,7 @@ Node* StateTestWithBuiltinRules::GetNode(const string& path) {
 }
 
 void AssertParse(State* state, const char* input) {
-  ManifestParser parser(state, NULL);
+  ManifestParser parser(state, NULL, false);
   string err;
   EXPECT_TRUE(parser.ParseTest(input, &err));
   ASSERT_EQ("", err);


### PR DESCRIPTION
Was only an error in top level .ninja previously.