### PR TITLE
dupe_edge_should_err from bool to enum

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -25,9 +25,9 @@
 #include "version.h"
 
 ManifestParser::ManifestParser(State* state, FileReader* file_reader,
-                               bool dupe_edge_should_err)
+                               DupeEdgeAction dupe_edge_action)
     : state_(state), file_reader_(file_reader),
-      dupe_edge_should_err_(dupe_edge_should_err), quiet_(false) {
+      dupe_edge_action_(dupe_edge_action), quiet_(false) {
   env_ = &state->bindings_;
 }
 
@@ -331,7 +331,7 @@ bool ManifestParser::ParseEdge(string* err) {
     if (!CanonicalizePath(&path, &slash_bits, &path_err))
       return lexer_.Error(path_err, err);
     if (!state_->AddOut(edge, path, slash_bits)) {
-      if (dupe_edge_should_err_) {
+      if (dupe_edge_action_ == kDupeEdgeActionError) {
         lexer_.Error("multiple rules generate " + path + " [-w dupbuild=err]",
                      err);
         return false;
@@ -380,7 +380,7 @@ bool ManifestParser::ParseFileInclude(bool new_scope, string* err) {
     return false;
   string path = eval.Evaluate(env_);
 
-  ManifestParser subparser(state_, file_reader_, dupe_edge_should_err_);
+  ManifestParser subparser(state_, file_reader_, dupe_edge_action_);
   if (new_scope) {
     subparser.env_ = new BindingEnv(env_);
   } else {

--- a/src/manifest_parser.h
+++ b/src/manifest_parser.h
@@ -25,6 +25,11 @@ struct BindingEnv;
 struct EvalString;
 struct State;
 
+enum DupeEdgeAction {
+  kDupeEdgeActionWarn,
+  kDupeEdgeActionError,
+};
+
 /// Parses .ninja files.
 struct ManifestParser {
   struct FileReader {
@@ -33,7 +38,7 @@ struct ManifestParser {
   };
 
   ManifestParser(State* state, FileReader* file_reader,
-                 bool dupe_edge_should_err);
+                 DupeEdgeAction dupe_edge_action);
 
   /// Load and parse a file.
   bool Load(const string& filename, string* err, Lexer* parent = NULL);
@@ -66,7 +71,7 @@ private:
   BindingEnv* env_;
   FileReader* file_reader_;
   Lexer lexer_;
-  bool dupe_edge_should_err_;
+  DupeEdgeAction dupe_edge_action_;
   bool quiet_;
 };
 

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -24,7 +24,7 @@
 struct ParserTest : public testing::Test,
                     public ManifestParser::FileReader {
   void AssertParse(const char* input) {
-    ManifestParser parser(&state, this, false);
+    ManifestParser parser(&state, this, kDupeEdgeActionWarn);
     string err;
     EXPECT_TRUE(parser.ParseTest(input, &err));
     ASSERT_EQ("", err);
@@ -371,7 +371,7 @@ TEST_F(ParserTest, DuplicateEdgeWithMultipleOutputsError) {
 "build out1 out2: cat in1\n"
 "build out1: cat in2\n"
 "build final: cat out1\n";
-  ManifestParser parser(&state, this, /*dupe_edges_should_err=*/true);
+  ManifestParser parser(&state, this, kDupeEdgeActionError);
   string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:5: multiple rules generate out1 [-w dupbuild=err]\n", err);
@@ -386,7 +386,7 @@ TEST_F(ParserTest, DuplicateEdgeInIncludedFile) {
     "build final: cat out1\n";
   const char kInput[] =
     "subninja sub.ninja\n";
-  ManifestParser parser(&state, this, /*dupe_edges_should_err=*/true);
+  ManifestParser parser(&state, this, kDupeEdgeActionError);
   string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("sub.ninja:5: multiple rules generate out1 [-w dupbuild=err]\n",
@@ -404,7 +404,7 @@ TEST_F(ParserTest, ReservedWords) {
 TEST_F(ParserTest, Errors) {
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest(string("subn", 4), &err));
     EXPECT_EQ("input:1: expected '=', got eof\n"
@@ -415,7 +415,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("foobar", &err));
     EXPECT_EQ("input:1: expected '=', got eof\n"
@@ -426,7 +426,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x 3", &err));
     EXPECT_EQ("input:1: expected '=', got identifier\n"
@@ -437,7 +437,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = 3", &err));
     EXPECT_EQ("input:1: unexpected EOF\n"
@@ -448,7 +448,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = 3\ny 2", &err));
     EXPECT_EQ("input:2: expected '=', got identifier\n"
@@ -459,7 +459,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = $", &err));
     EXPECT_EQ("input:1: bad $-escape (literal $ must be written as $$)\n"
@@ -470,7 +470,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = $\n $[\n", &err));
     EXPECT_EQ("input:2: bad $-escape (literal $ must be written as $$)\n"
@@ -481,7 +481,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = a$\n b$\n $\n", &err));
     EXPECT_EQ("input:4: unexpected EOF\n"
@@ -490,7 +490,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("build\n", &err));
     EXPECT_EQ("input:1: expected path\n"
@@ -501,7 +501,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("build x: y z\n", &err));
     EXPECT_EQ("input:1: unknown build rule 'y'\n"
@@ -512,7 +512,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("build x:: y z\n", &err));
     EXPECT_EQ("input:1: expected build command name\n"
@@ -523,7 +523,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n  command = cat ok\n"
                                   "build x: cat $\n :\n",
@@ -536,7 +536,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n",
                                   &err));
@@ -545,7 +545,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = echo\n"
@@ -559,7 +559,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = echo\n"
@@ -571,7 +571,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = ${fafsd\n"
@@ -586,7 +586,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = cat\n"
@@ -601,7 +601,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = cat\n"
@@ -615,7 +615,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule %foo\n",
                                   &err));
@@ -624,7 +624,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n"
                                   "  command = foo\n"
@@ -638,7 +638,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n"
                                   "build $.: cc bar.cc\n",
@@ -651,7 +651,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n  && bar",
                                   &err));
@@ -660,7 +660,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n"
                                   "build $: cc bar.cc\n",
@@ -673,7 +673,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("default\n",
                                   &err));
@@ -685,7 +685,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("default nonexistent\n",
                                   &err));
@@ -697,7 +697,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule r\n  command = r\n"
                                   "build b: r\n"
@@ -711,7 +711,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("default $a\n", &err));
     EXPECT_EQ("input:1: empty path\n"
@@ -722,7 +722,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule r\n"
                                   "  command = r\n"
@@ -734,7 +734,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     // the indented blank line must terminate the rule
     // this also verifies that "unexpected (token)" errors are correct
@@ -747,7 +747,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool\n", &err));
     EXPECT_EQ("input:1: expected pool name\n", err);
@@ -755,7 +755,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n", &err));
     EXPECT_EQ("input:2: expected 'depth =' line\n", err);
@@ -763,7 +763,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  depth = 4\n"
@@ -776,7 +776,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  depth = -1\n", &err));
@@ -788,7 +788,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  bar = 1\n", &err));
@@ -800,7 +800,7 @@ TEST_F(ParserTest, Errors) {
 
   {
     State state;
-    ManifestParser parser(&state, NULL, false);
+    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
     string err;
     // Pool names are dereferenced at edge parsing time.
     EXPECT_FALSE(parser.ParseTest("rule run\n"
@@ -813,7 +813,7 @@ TEST_F(ParserTest, Errors) {
 
 TEST_F(ParserTest, MissingInput) {
   State state;
-  ManifestParser parser(&state, this, false);
+  ManifestParser parser(&state, this, kDupeEdgeActionWarn);
   string err;
   EXPECT_FALSE(parser.Load("build.ninja", &err));
   EXPECT_EQ("loading 'build.ninja': No such file or directory", err);
@@ -821,7 +821,7 @@ TEST_F(ParserTest, MissingInput) {
 
 TEST_F(ParserTest, MultipleOutputs) {
   State state;
-  ManifestParser parser(&state, NULL, false);
+  ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
   string err;
   EXPECT_TRUE(parser.ParseTest("rule cc\n  command = foo\n  depfile = bar\n"
                                "build a.o b.o: cc c.cc\n",
@@ -831,7 +831,7 @@ TEST_F(ParserTest, MultipleOutputs) {
 
 TEST_F(ParserTest, MultipleOutputsWithDeps) {
   State state;
-  ManifestParser parser(&state, NULL, false);
+  ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
   string err;
   EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n  deps = gcc\n"
                                "build a.o b.o: cc c.cc\n",
@@ -866,7 +866,7 @@ TEST_F(ParserTest, SubNinja) {
 }
 
 TEST_F(ParserTest, MissingSubNinja) {
-  ManifestParser parser(&state, this, false);
+  ManifestParser parser(&state, this, kDupeEdgeActionWarn);
   string err;
   EXPECT_FALSE(parser.ParseTest("subninja foo.ninja\n", &err));
   EXPECT_EQ("input:1: loading 'foo.ninja': No such file or directory\n"
@@ -879,7 +879,7 @@ TEST_F(ParserTest, DuplicateRuleInDifferentSubninjas) {
   // Test that rules are scoped to subninjas.
   files_["test.ninja"] = "rule cat\n"
                          "  command = cat\n";
-  ManifestParser parser(&state, this, false);
+  ManifestParser parser(&state, this, kDupeEdgeActionWarn);
   string err;
   EXPECT_TRUE(parser.ParseTest("rule cat\n"
                                 "  command = cat\n"
@@ -892,7 +892,7 @@ TEST_F(ParserTest, DuplicateRuleInDifferentSubninjasWithInclude) {
                          "  command = cat\n";
   files_["test.ninja"] = "include rules.ninja\n"
                          "build x : cat\n";
-  ManifestParser parser(&state, this, false);
+  ManifestParser parser(&state, this, kDupeEdgeActionWarn);
   string err;
   EXPECT_TRUE(parser.ParseTest("include rules.ninja\n"
                                 "subninja test.ninja\n"
@@ -912,7 +912,7 @@ TEST_F(ParserTest, Include) {
 
 TEST_F(ParserTest, BrokenInclude) {
   files_["include.ninja"] = "build\n";
-  ManifestParser parser(&state, this, false);
+  ManifestParser parser(&state, this, kDupeEdgeActionWarn);
   string err;
   EXPECT_FALSE(parser.ParseTest("include include.ninja\n", &err));
   EXPECT_EQ("include.ninja:1: expected path\n"
@@ -992,7 +992,7 @@ TEST_F(ParserTest, UTF8) {
 
 TEST_F(ParserTest, CRLF) {
   State state;
-  ManifestParser parser(&state, NULL, false);
+  ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
   string err;
 
   EXPECT_TRUE(parser.ParseTest("# comment with crlf\r\n", &err));

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1114,7 +1114,9 @@ int real_main(int argc, char** argv) {
 
     RealFileReader file_reader;
     ManifestParser parser(&ninja.state_, &file_reader,
-                          options.dupe_edges_should_err);
+                          options.dupe_edges_should_err
+                              ? kDupeEdgeActionError
+                              : kDupeEdgeActionWarn);
     string err;
     if (!parser.Load(options.input_file, &err)) {
       Error("%s", err.c_str());

--- a/src/test.cc
+++ b/src/test.cc
@@ -95,7 +95,7 @@ Node* StateTestWithBuiltinRules::GetNode(const string& path) {
 }
 
 void AssertParse(State* state, const char* input) {
-  ManifestParser parser(state, NULL, false);
+  ManifestParser parser(state, NULL, kDupeEdgeActionWarn);
   string err;
   EXPECT_TRUE(parser.ParseTest(input, &err));
   ASSERT_EQ("", err);


### PR DESCRIPTION
Follow up to #1095.

(`enum class` seems to be disabled by build settings.)