### PR TITLE
Add -d keepdepfile to preserve depfiles

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -892,9 +892,11 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
       deps_nodes->push_back(state_->GetNode(*i, slash_bits));
     }
 
-    if (disk_interface_->RemoveFile(depfile) < 0) {
-      *err = string("deleting depfile: ") + strerror(errno) + string("\n");
-      return false;
+    if (!g_keep_depfile) {
+      if (disk_interface_->RemoveFile(depfile) < 0) {
+        *err = string("deleting depfile: ") + strerror(errno) + string("\n");
+        return false;
+      }
     }
   } else {
     Fatal("unknown deps type '%s'", deps_type.c_str());

--- a/src/debug_flags.cc
+++ b/src/debug_flags.cc
@@ -14,6 +14,8 @@
 
 bool g_explaining = false;
 
+bool g_keep_depfile = false;
+
 bool g_keep_rsp = false;
 
 bool g_experimental_statcache = true;

--- a/src/debug_flags.h
+++ b/src/debug_flags.h
@@ -24,6 +24,8 @@
 
 extern bool g_explaining;
 
+extern bool g_keep_depfile;
+
 extern bool g_keep_rsp;
 
 extern bool g_experimental_statcache;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -774,9 +774,10 @@ const Tool* ChooseTool(const string& tool_name) {
 bool DebugEnable(const string& name) {
   if (name == "list") {
     printf("debugging modes:\n"
-"  stats    print operation counts/timing info\n"
-"  explain  explain what caused a command to execute\n"
-"  keeprsp  don't delete @response files on success\n"
+"  stats        print operation counts/timing info\n"
+"  explain      explain what caused a command to execute\n"
+"  keepdepfile  don't delete depfiles after they're read by ninja\n"
+"  keeprsp      don't delete @response files on success\n"
 #ifdef _WIN32
 "  nostatcache  don't batch stat() calls per directory and cache them\n"
 #endif
@@ -788,6 +789,9 @@ bool DebugEnable(const string& name) {
   } else if (name == "explain") {
     g_explaining = true;
     return true;
+  } else if (name == "keepdepfile") {
+    g_keep_depfile = true;
+    return true;
   } else if (name == "keeprsp") {
     g_keep_rsp = true;
     return true;
@@ -796,8 +800,9 @@ bool DebugEnable(const string& name) {
     return true;
   } else {
     const char* suggestion =
-        SpellcheckString(name.c_str(), "stats", "explain", "keeprsp",
-        "nostatcache", NULL);
+        SpellcheckString(name.c_str(),
+                         "stats", "explain", "keepdepfile", "keeprsp",
+                         "nostatcache", NULL);
     if (suggestion) {
       Error("unknown debug setting '%s', did you mean '%s'?",
             name.c_str(), suggestion);


### PR DESCRIPTION
This is useful when you are developing a tool which generates
GCC-style depfiles.