### PR TITLE
perftest: fix compilation after dupe_edge_should_err change

### DIFF
--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -71,7 +71,7 @@ bool WriteTestData(string* err) {
   long_rule_command += "$in -o $out\n";
 
   State state;
-  ManifestParser parser(&state, NULL);
+  ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
   if (!parser.ParseTest("rule cxx\n  command = " + long_rule_command, err))
     return false;
 

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -61,7 +61,7 @@ int LoadManifests(bool measure_command_evaluation) {
   string err;
   RealFileReader file_reader;
   State state;
-  ManifestParser parser(&state, &file_reader);
+  ManifestParser parser(&state, &file_reader, kDupeEdgeActionWarn);
   if (!parser.Load("build.ninja", &err)) {
     fprintf(stderr, "Failed to read test data: %s\n", err.c_str());
     exit(1);


### PR DESCRIPTION
Fix some ManifestParser constructor calls missed by commit 56bab441b7
(dupe_edge_should_err from bool to enum, 2016-01-27).