### PR TITLE
disable warning about conditional expressions

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -302,6 +302,8 @@ if platform.is_msvc():
               '/WX',  # Warnings as errors.
               '/wd4530', '/wd4100', '/wd4706',
               '/wd4512', '/wd4800', '/wd4702', '/wd4819',
+              # Disable warnings about constant conditional expressions.
+              '/wd4127',
               # Disable warnings about passing "this" during initialization.
               '/wd4355',
               # Disable warnings about ignored typedef in DbgHelp.h


### PR DESCRIPTION
This fixes a compilation error with ~~VS2010~~ VS2008.