### PR TITLE
Remove StatIfNecessary call that is never necessary

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -37,6 +37,7 @@ bool DependencyScan::RecomputeDirty(Edge* edge, string* err) {
   edge->outputs_ready_ = true;
   edge->deps_missing_ = false;
 
+  // Load output mtimes so we can compare them to the most recent input below.
   // RecomputeDirty() recursively walks the graph following the input nodes
   // of |edge| and the in_edges of these nodes.  It uses the stat state of each
   // node to mark nodes as visited and doesn't traverse across nodes that have
@@ -126,8 +127,6 @@ bool DependencyScan::RecomputeOutputsDirty(Edge* edge, Node* most_recent_input,
   string command = edge->EvaluateCommand(/*incl_rsp_file=*/true);
   for (vector<Node*>::iterator o = edge->outputs_.begin();
        o != edge->outputs_.end(); ++o) {
-    if (!(*o)->StatIfNecessary(disk_interface_, err))
-      return false;
     if (RecomputeOutputDirty(edge, most_recent_input, command, *o)) {
       *outputs_dirty = true;
       return true;


### PR DESCRIPTION
The call to StatIfNecessary in DependencyScan::RecomputeOutputsDirty was
added by commit 41c6258ec1928cbcfc5642504cb9c2b3659fa897 (Share more code between CleanNode() and
RecomputeDirty(), 2013-09-02) while consolidating code paths.  However,
it was needed only when called from RecomputeDirty because prior to
refactoring the CleanNode code path did not call it.

Later commit 015c818cbe85093316115c5a510274eccdb4180b (Let DependencyScan::RecomputeDirty() work
correclty with cyclic graphs, 2014-12-07) added back to RecomputeDirty a
loop over outputs that calls StatIfNecessary.  Therefore
RecomputeOutputsDirty no longer needs to call StatIfNecessary for either
of its own callers.