### PR TITLE
enable building ninja with Oracle Solaris Studio

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -488,6 +488,7 @@ for name in ['build',
              'manifest_parser',
              'metrics',
              'state',
+             'unixcc_parser',
              'util',
              'version']:
     objs += cxx(name)
@@ -586,6 +587,7 @@ for name in ['build_log_test',
              'state_test',
              'subprocess_test',
              'test',
+             'unixcc_parser_test',
              'util_test']:
     objs += cxx(name)
 if platform.is_windows():

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -158,17 +158,13 @@ http://code.google.com/p/gyp/[gyp]:: The meta-build system used to
 generate build files for Google Chrome and related projects (v8,
 node.js).  gyp can generate Ninja files for all platforms supported by
 Chrome. See the
-http://code.google.com/p/chromium/wiki/NinjaBuild[Chromium Ninja
-documentation for more details].
+https://chromium.googlesource.com/chromium/src/+/master/docs/ninja_build.md[Chromium Ninja documentation for more details].
 
-http://www.cmake.org/[CMake]:: A widely used meta-build system that
-can generate Ninja files on Linux as of CMake version 2.8.8.  (There
-is some Mac and Windows support -- http://www.reactos.org[ReactOS]
-uses Ninja on Windows for their buildbots, but those platforms are not
-yet officially supported by CMake as the full test suite doesn't
-pass.)
+https://cmake.org/[CMake]:: A widely used meta-build system that
+can generate Ninja files on Linux as of CMake version 2.8.8.  Newer versions
+of CMake support generating Ninja files on Windows and Mac OS X too.
 
-others:: Ninja ought to fit perfectly into other meta-build software
+https://github.com/ninja-build/ninja/wiki/List-of-generators-producing-ninja-build-files[others]:: Ninja ought to fit perfectly into other meta-build software
 like http://industriousone.com/premake[premake].  If you do this work,
 please let us know!
 

--- a/src/build.cc
+++ b/src/build.cc
@@ -126,8 +126,15 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
     PrintStatus(edge);
 
   // Print the command that is spewing before printing its output.
-  if (!success)
-    printer_.PrintOnNewLine("FAILED: " + edge->EvaluateCommand() + "\n");
+  if (!success) {
+    string outputs;
+    for (vector<Node*>::const_iterator o = edge->outputs_.begin();
+         o != edge->outputs_.end(); ++o)
+      outputs += (*o)->path() + " ";
+
+    printer_.PrintOnNewLine("FAILED: " + outputs + "\n");
+    printer_.PrintOnNewLine(edge->EvaluateCommand() + "\n");
+  }
 
   if (!output.empty()) {
     // ninja sets stdout and stderr of subprocesses to a pipe, to be able to

--- a/src/build.cc
+++ b/src/build.cc
@@ -33,6 +33,7 @@
 #include "msvc_helper.h"
 #include "state.h"
 #include "subprocess.h"
+#include "unixcc_parser.h"
 #include "util.h"
 
 namespace {
@@ -912,6 +913,15 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
         *err = string("deleting depfile: ") + strerror(errno) + string("\n");
         return false;
       }
+    }
+  } else if (deps_type == "unixcc") {
+    UnixCCParser parser;
+    string output;
+    parser.Parse(result->output, &output);
+    result->output = output;
+    for (set<string>::iterator i = parser.includes_.begin();
+         i != parser.includes_.end(); ++i) {
+      deps_nodes->push_back(state_->GetNode(*i, 0));
     }
   } else {
     Fatal("unknown deps type '%s'", deps_type.c_str());

--- a/src/build.h
+++ b/src/build.h
@@ -15,7 +15,7 @@
 #ifndef NINJA_BUILD_H_
 #define NINJA_BUILD_H_
 
-#include <cstdio>
+#include <stdio.h>
 #include <map>
 #include <memory>
 #include <queue>

--- a/src/hash_map.h
+++ b/src/hash_map.h
@@ -87,6 +87,18 @@ struct StringPieceCmp : public hash_compare<StringPiece> {
   }
 };
 
+#elif defined(__SUNPRO_CC)
+#include <hash_map>
+
+namespace std {
+template<>
+struct hash<StringPiece> {
+  size_t operator()(StringPiece key) const {
+    return MurmurHash2(key.str_, key.len_);
+  }
+};
+}
+
 #else
 #include <ext/hash_map>
 

--- a/src/test.cc
+++ b/src/test.cc
@@ -26,6 +26,9 @@
 #else
 #include <unistd.h>
 #endif
+#ifdef __sun
+#include <stdlib.h>
+#endif
 
 #include "build_log.h"
 #include "graph.h"

--- a/src/unixcc_parser.cc
+++ b/src/unixcc_parser.cc
@@ -1,0 +1,62 @@
+// Copyright 2016 SAP SE All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "unixcc_parser.h"
+#include <cstring>
+
+// Characters which we consider to be valid in a filename.
+static const char filename_characters[] = 
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "0123456789"
+    "-_/.";
+
+void UnixCCParser::Parse(const string& output, string* filtered_output) {
+  const char* in = &output[0];
+  const char* end = in + output.size();
+
+  while (in < end) {
+    const char* const line_start = in;
+
+    // Advance past initial tabs.
+    while (in < end && *in == '\t')
+      ++in;
+
+    const char* const filename_start = in;
+
+    // Treat only a small set of allowed characters as part of a filename.
+    while (in < end && strchr(filename_characters, *in) != NULL)
+      ++in;
+
+    const char* const filename_end = in;
+
+    // Only allow a filename if it is non-empty and immediately followed by a
+    // newline.
+    if (filename_start + 1 < in && in < end && *in == '\n') {
+      ++in;
+      string filename(filename_start, filename_end);
+      includes_.insert(filename);
+      continue;
+    }
+
+    // Forward to the end of the current line.
+    while (in < end && *in != '\n')
+      ++in;
+
+    if (in < end)
+        ++in;
+
+    filtered_output->append(line_start, in);
+  }
+}

--- a/src/unixcc_parser.h
+++ b/src/unixcc_parser.h
@@ -1,0 +1,23 @@
+// Copyright 2016 SAP SE All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <set>
+
+using namespace std;
+
+struct UnixCCParser {
+  void Parse(const string& output, string* filtered_output);
+  set<string> includes_;
+};

--- a/src/unixcc_parser_test.cc
+++ b/src/unixcc_parser_test.cc
@@ -1,0 +1,75 @@
+// Copyright 2016 SAP SE All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "unixcc_parser.h"
+
+#include "test.h"
+
+struct UnixCCParserTest : public testing::Test {
+  void Parse(const string& input);
+
+  UnixCCParser parser_;
+  string filtered_output_;
+};
+
+void UnixCCParserTest::Parse(const string& output) {
+  parser_.Parse(output, &filtered_output_);
+}
+
+TEST_F(UnixCCParserTest, Empty) {
+  Parse("");
+  EXPECT_TRUE(filtered_output_.empty());
+  EXPECT_TRUE(parser_.includes_.empty());
+}
+
+TEST_F(UnixCCParserTest, Basic) {
+  Parse("src/unixcc_parser.h\n");
+  EXPECT_TRUE(filtered_output_.empty());
+  ASSERT_EQ(1u, parser_.includes_.size());
+  EXPECT_EQ("src/unixcc_parser.h", *parser_.includes_.begin());
+}
+
+TEST_F(UnixCCParserTest, IgnoreDiagnostics) {
+  const string output = 
+    "\"src/unixcc_parser_test.cc\", line 30: Error: err is not defined.\n"
+    "1 Error(s) detected.\n";
+
+  Parse(output);
+  EXPECT_EQ(filtered_output_, output);
+  EXPECT_TRUE(parser_.includes_.empty());
+}
+
+TEST_F(UnixCCParserTest, RealExample) {
+  const string output = 
+    "\"src/unixcc_parser.cc\", line 18: Warning: Identifier expected instead of \"}\".\n"
+    "src/unixcc_parser.h\n"
+    "\t/opt/solarisstudio12.4/lib/compilers/include/CC/stlport4/string\n"
+    "\t\t/opt/solarisstudio12.4/lib/compilers/include/CC/stlport4/stl/_prolog.h\n"
+    "\t\t\t/opt/solarisstudio12.4/lib/compilers/include/CC/stlport4/stl/_config.h\n"
+    "\t\t\t\t/opt/solarisstudio12.4/lib/compilers/include/CC/stlport4/stl_user_config.h\n"
+    /* ... */
+    "\t\t\t\t\t/opt/solarisstudio12.4/lib/compilers/include/CC/stlport4/config/stl_sunpro.h\n"
+    /* ... */
+    "/usr/include/sys/ctype.h\n"
+    "\"src/unixcc_parser.cc\", line 70: Warning: Identifier expected instead of \"}\".\n"
+    "2 Warning(s) detected.\n";
+  const string expected_filtered_output = 
+    "\"src/unixcc_parser.cc\", line 18: Warning: Identifier expected instead of \"}\".\n"
+    "\"src/unixcc_parser.cc\", line 70: Warning: Identifier expected instead of \"}\".\n"
+    "2 Warning(s) detected.\n";
+
+  Parse(output);
+  EXPECT_EQ(expected_filtered_output, filtered_output_);
+  EXPECT_EQ(parser_.includes_.size(), 7);
+}


### PR DESCRIPTION
This adds support for compiling with Solaris Studio on Solaris.  I've only tested Solaris 11.3 x86 so far.  The Solaris C++ compiler supports printing include files when given the `-H` option so I've add a small parser for that format.  It is very similar to MSVC's /showIncludes.  If requested I can move this parser into a separate PR.  Other than that only very few changes to the code were necessary:  STLPort has a hash_map implementation that needs to be used and `src/test.cc` uses `mkdtemp` without including `stdlib.h` (I suppose on other platforms it is already included through `unistd.h`).  And lastly `src/build.h` includes `cstdio` instead of `stdio.h` the former does not declare `snprintf` only `sprintf` on Solaris.  ~~I`ve also fixed the warnings issued by the compiler as they mostly seemed sensible.  I can move that into a separate PR as well.~~
