### PR TITLE
Fix ambiguous call to set_terminate on Windows platform

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1161,7 +1161,7 @@ int main(int argc, char** argv) {
 #if defined(_MSC_VER)
   // Set a handler to catch crashes not caught by the __try..__except
   // block (e.g. an exception in a stack-unwind-block).
-  set_terminate(TerminateHandler);
+  std::set_terminate(TerminateHandler);
   __try {
     // Running inside __try ... __except suppresses any Windows error
     // dialogs for errors such as bad_alloc.


### PR DESCRIPTION
On Windows set_terminate() could either be the standard C++ one or (actually the same one but in the global namespace) the CRT one declared in corecrt_terminate.h
Hence this ambiguity - this patch solves it.

Signed-off-by: g4m4 <misept.dieseneuf@gmail.com>