### PR TITLE
Revert #910.

### DIFF
--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -70,11 +70,8 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
         break;
 
       if (!use_console_) {
-        // Put the child in its own session and process group. It will be
-        // detached from the current terminal and ctrl-c won't reach it.
-        // Since this process was just forked, it is not a process group leader
-        // and setsid() will succeed.
-        if (setsid() < 0)
+        // Put the child in its own process group, so ctrl-c won't reach it.
+        if (setpgid(0, 0) < 0)
           break;
 
         // Open /dev/null over stdin.

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -16,8 +16,6 @@
 
 #include "test.h"
 
-#include <string>
-
 #ifndef _WIN32
 // SetWithLots need setrlimit.
 #include <stdio.h>
@@ -146,22 +144,11 @@ TEST_F(SubprocessTest, InterruptParentWithSigHup) {
   ASSERT_FALSE("We should have been interrupted");
 }
 
-// A shell command to check if the current process is connected to a terminal.
-// This is different from having stdin/stdout/stderr be a terminal. (For
-// instance consider the command "yes < /dev/null > /dev/null 2>&1".
-// As "ps" will confirm, "yes" could still be connected to a terminal, despite
-// not having any of the standard file descriptors be a terminal.
-static const char kIsConnectedToTerminal[] = "tty < /dev/tty > /dev/null";
-
 TEST_F(SubprocessTest, Console) {
   // Skip test if we don't have the console ourselves.
   if (isatty(0) && isatty(1) && isatty(2)) {
-    // Test that stdin, stdout and stderr are a terminal.
-    // Also check that the current process is connected to a terminal.
     Subprocess* subproc =
-        subprocs_.Add(string("test -t 0 -a -t 1 -a -t 2 && ") +
-                      string(kIsConnectedToTerminal),
-                      /*use_console=*/true);
+        subprocs_.Add("test -t 0 -a -t 1 -a -t 2", /*use_console=*/true);
     ASSERT_NE((Subprocess*)0, subproc);
 
     while (!subproc->Done()) {
@@ -170,18 +157,6 @@ TEST_F(SubprocessTest, Console) {
 
     EXPECT_EQ(ExitSuccess, subproc->Finish());
   }
-}
-
-TEST_F(SubprocessTest, NoConsole) {
-  Subprocess* subproc =
-      subprocs_.Add(kIsConnectedToTerminal, /*use_console=*/false);
-  ASSERT_NE((Subprocess*)0, subproc);
-
-  while (!subproc->Done()) {
-    subprocs_.DoWork();
-  }
-
-  EXPECT_NE(ExitSuccess, subproc->Finish());
 }
 
 #endif


### PR DESCRIPTION
The change caused some issues (it makes it impossible ot use
posix_spawn() and makes it harder to suspend children on ctrl-z).  After
discussing with jln: Since it fixes a corner case that can be fixed by
explicitly running commands that need it in a wrapper that setsid()s
them, let's try reverting it for a while.  Please shout if this is a
problem for you.

See also #1097.