### PR TITLE
Pass location of build.ninja file to browse script

### DIFF
--- a/src/browse.cc
+++ b/src/browse.cc
@@ -22,7 +22,7 @@
 #include "build/browse_py.h"
 
 void RunBrowsePython(State* state, const char* ninja_command,
-                     int argc, char* argv[]) {
+                     const char* input_file, int argc, char* argv[]) {
   // Fork off a Python process and have it run our code via its stdin.
   // (Actually the Python process becomes the parent.)
   int pipefd[2];
@@ -50,6 +50,8 @@ void RunBrowsePython(State* state, const char* ninja_command,
       command.push_back("-");
       command.push_back("--ninja-command");
       command.push_back(ninja_command);
+      command.push_back("-f");
+      command.push_back(input_file);
       for (int i = 0; i < argc; i++) {
           command.push_back(argv[i]);
       }

--- a/src/browse.h
+++ b/src/browse.h
@@ -23,6 +23,6 @@ struct State;
 /// \a argv are arguments to be passed to the Python script.
 /// This function does not return if it runs successfully.
 void RunBrowsePython(State* state, const char* ninja_command,
-                     int argc, char* argv[]);
+                     const char* input_file, int argc, char* argv[]);
 
 #endif  // NINJA_BROWSE_H_

--- a/src/browse.py
+++ b/src/browse.py
@@ -150,8 +150,8 @@ def generate_html(node):
     return '\n'.join(document)
 
 def ninja_dump(target):
-    proc = subprocess.Popen([args.ninja_command, '-t', 'query', target],
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    cmd = [args.ninja_command, '-f', args.f, '-t', 'query', target]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             universal_newlines=True)
     return proc.communicate() + (proc.returncode,)
 
@@ -194,6 +194,8 @@ parser.add_argument('--no-browser', action='store_true',
 
 parser.add_argument('--ninja-command', default='ninja',
     help='Path to ninja binary (default %(default)s)')
+parser.add_argument('-f', default='build.ninja',
+    help='Path to build.ninja file (default %(default)s)')
 parser.add_argument('initial_target', default='all', nargs='?',
     help='Initial target to show (default %(default)s)')
 


### PR DESCRIPTION
Pass the values of -f and -C arguments to the browse python script so
they can be passed back to ninja -t query.