### PR TITLE
ninja_test: Fix Visual C++ 2015 warnings/errors about name hiding.

### DIFF
--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -121,13 +121,15 @@ TEST_F(BuildLogTest, Truncate) {
 "build out: cat mid\n"
 "build mid: cat in\n");
 
-  BuildLog log1;
-  string err;
-  EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
-  ASSERT_EQ("", err);
-  log1.RecordCommand(state_.edges_[0], 15, 18);
-  log1.RecordCommand(state_.edges_[1], 20, 25);
-  log1.Close();
+  {
+    BuildLog log1;
+    string err;
+    EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
+    ASSERT_EQ("", err);
+    log1.RecordCommand(state_.edges_[0], 15, 18);
+    log1.RecordCommand(state_.edges_[1], 20, 25);
+    log1.Close();
+  }
 
   struct stat statbuf;
   ASSERT_EQ(0, stat(kTestFilename, &statbuf));

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -431,10 +431,12 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
   }
 
   // Shorten the file, corrupting the last record.
-  struct stat st;
-  ASSERT_EQ(0, stat(kTestFilename, &st));
-  string err;
-  ASSERT_TRUE(Truncate(kTestFilename, st.st_size - 2, &err));
+  {
+    struct stat st;
+    ASSERT_EQ(0, stat(kTestFilename, &st));
+    string err;
+    ASSERT_TRUE(Truncate(kTestFilename, st.st_size - 2, &err));
+  }
 
   // Load the file again, add an entry.
   {

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -390,8 +390,8 @@ TEST_F(ParserTest, ReservedWords) {
 
 TEST_F(ParserTest, Errors) {
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest(string("subn", 4), &err));
     EXPECT_EQ("input:1: expected '=', got eof\n"
@@ -401,8 +401,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("foobar", &err));
     EXPECT_EQ("input:1: expected '=', got eof\n"
@@ -412,8 +412,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x 3", &err));
     EXPECT_EQ("input:1: expected '=', got identifier\n"
@@ -423,8 +423,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = 3", &err));
     EXPECT_EQ("input:1: unexpected EOF\n"
@@ -434,8 +434,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = 3\ny 2", &err));
     EXPECT_EQ("input:2: expected '=', got identifier\n"
@@ -445,8 +445,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = $", &err));
     EXPECT_EQ("input:1: bad $-escape (literal $ must be written as $$)\n"
@@ -456,8 +456,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = $\n $[\n", &err));
     EXPECT_EQ("input:2: bad $-escape (literal $ must be written as $$)\n"
@@ -467,8 +467,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("x = a$\n b$\n $\n", &err));
     EXPECT_EQ("input:4: unexpected EOF\n"
@@ -476,8 +476,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("build\n", &err));
     EXPECT_EQ("input:1: expected path\n"
@@ -487,8 +487,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("build x: y z\n", &err));
     EXPECT_EQ("input:1: unknown build rule 'y'\n"
@@ -498,8 +498,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("build x:: y z\n", &err));
     EXPECT_EQ("input:1: expected build command name\n"
@@ -509,8 +509,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n  command = cat ok\n"
                                   "build x: cat $\n :\n",
@@ -522,8 +522,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n",
                                   &err));
@@ -531,8 +531,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = echo\n"
@@ -545,8 +545,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = echo\n"
@@ -557,8 +557,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = ${fafsd\n"
@@ -572,8 +572,8 @@ TEST_F(ParserTest, Errors) {
 
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = cat\n"
@@ -587,8 +587,8 @@ TEST_F(ParserTest, Errors) {
 
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = cat\n"
@@ -601,8 +601,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule %foo\n",
                                   &err));
@@ -610,8 +610,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n"
                                   "  command = foo\n"
@@ -624,8 +624,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n"
                                   "build $.: cc bar.cc\n",
@@ -637,8 +637,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n  && bar",
                                   &err));
@@ -646,8 +646,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n"
                                   "build $: cc bar.cc\n",
@@ -659,8 +659,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("default\n",
                                   &err));
@@ -671,8 +671,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("default nonexistent\n",
                                   &err));
@@ -683,8 +683,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule r\n  command = r\n"
                                   "build b: r\n"
@@ -697,8 +697,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("default $a\n", &err));
     EXPECT_EQ("input:1: empty path\n"
@@ -708,8 +708,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("rule r\n"
                                   "  command = r\n"
@@ -720,8 +720,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     // the indented blank line must terminate the rule
     // this also verifies that "unexpected (token)" errors are correct
@@ -733,24 +733,24 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool\n", &err));
     EXPECT_EQ("input:1: expected pool name\n", err);
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n", &err));
     EXPECT_EQ("input:2: expected 'depth =' line\n", err);
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  depth = 4\n"
@@ -762,8 +762,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  depth = -1\n", &err));
@@ -774,8 +774,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  bar = 1\n", &err));
@@ -786,8 +786,8 @@ TEST_F(ParserTest, Errors) {
   }
 
   {
-    State state;
-    ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+    State local_state;
+    ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
     string err;
     // Pool names are dereferenced at edge parsing time.
     EXPECT_FALSE(parser.ParseTest("rule run\n"
@@ -799,16 +799,16 @@ TEST_F(ParserTest, Errors) {
 }
 
 TEST_F(ParserTest, MissingInput) {
-  State state;
-  ManifestParser parser(&state, &fs_, kDupeEdgeActionWarn);
+  State local_state;
+  ManifestParser parser(&local_state, &fs_, kDupeEdgeActionWarn);
   string err;
   EXPECT_FALSE(parser.Load("build.ninja", &err));
   EXPECT_EQ("loading 'build.ninja': No such file or directory", err);
 }
 
 TEST_F(ParserTest, MultipleOutputs) {
-  State state;
-  ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+  State local_state;
+  ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
   string err;
   EXPECT_TRUE(parser.ParseTest("rule cc\n  command = foo\n  depfile = bar\n"
                                "build a.o b.o: cc c.cc\n",
@@ -817,8 +817,8 @@ TEST_F(ParserTest, MultipleOutputs) {
 }
 
 TEST_F(ParserTest, MultipleOutputsWithDeps) {
-  State state;
-  ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+  State local_state;
+  ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
   string err;
   EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n  deps = gcc\n"
                                "build a.o b.o: cc c.cc\n",
@@ -1012,8 +1012,8 @@ TEST_F(ParserTest, UTF8) {
 }
 
 TEST_F(ParserTest, CRLF) {
-  State state;
-  ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
+  State local_state;
+  ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
   string err;
 
   EXPECT_TRUE(parser.ParseTest("# comment with crlf\r\n", &err));

--- a/src/test.h
+++ b/src/test.h
@@ -93,14 +93,14 @@ extern testing::Test* g_current_test;
   if (!EXPECT_TRUE(a))  { g_current_test->AddAssertionFailure(); return; }
 #define ASSERT_FALSE(a) \
   if (!EXPECT_FALSE(a)) { g_current_test->AddAssertionFailure(); return; }
-#define ASSERT_NO_FATAL_FAILURE(a)                  \
-  {                                                 \
-    int f = g_current_test->AssertionFailures();    \
-    a;                                              \
-    if (f != g_current_test->AssertionFailures()) { \
-      g_current_test->AddAssertionFailure();        \
-      return;                                       \
-    }                                               \
+#define ASSERT_NO_FATAL_FAILURE(a)                           \
+  {                                                          \
+    int fail_count = g_current_test->AssertionFailures();    \
+    a;                                                       \
+    if (fail_count != g_current_test->AssertionFailures()) { \
+      g_current_test->AddAssertionFailure();                 \
+      return;                                                \
+    }                                                        \
   }
 
 // Support utilites for tests.


### PR DESCRIPTION
Visual C++ 2015 warns if a local variable hides visibility of another variable
in a higher scope.  Since this project declares warnings as errors, ninja_test
simply won't build on Visual C++ 2015.

The variables have been renamed and scope limited as appropriate, so that
ninja_test will build without error now on Visual C++ 2015.