### PR TITLE
Add <stdlib.h> includes for clang++/libc++ on Ubuntu

### DIFF
--- a/src/hash_collision_bench.cc
+++ b/src/hash_collision_bench.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 using namespace std;
 
+#include <stdlib.h>
 #include <time.h>
 
 int random(int low, int high) {

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -19,6 +19,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef _WIN32

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -14,6 +14,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifdef _WIN32
 #include "getopt.h"

--- a/src/test.cc
+++ b/src/test.cc
@@ -21,6 +21,7 @@
 #include <algorithm>
 
 #include <errno.h>
+#include <stdlib.h>
 #ifdef _WIN32
 #include <windows.h>
 #else


### PR DESCRIPTION
There are a number of stdlib.h uses in these files without including
stdlib.h:

 hash_collision_bench.cc: rand, RAND_MAX, srand
 manifest_parser_perftest.cc: system, exit
 ninja_test.cc: EXIT_SUCCESS, EXIT_FAILURE
 test.cc: getenv, mkdtemp, system

This works on a Ubuntu g++/libstdc++ build, as the <algorithm> header
pulls in stdlib.h, and on a OSX clang++/libc++ build the <map> and
<string> headers pull in stdlib.h. But a Ubuntu clang++/libc++ build
does not pull in stdlib.h with any of these other headers.

 $ apt-get install clang-3.6 libc++-dev
 $ CXX=clang++-3.6 CFLAGS=-stdlib=libc++ LDFLAGS=-stdlib=libc++ \
   ./configure.py
 $ ninja ninja_test hash_collision_bench manifest_parser_perftest

This was originally discovered using the host toolchain provided with
Android, but the Ubuntu version is much easier to reproduce.