### PR TITLE
Reject duplicate outputs involving an implicit output

### DIFF
--- a/src/state.cc
+++ b/src/state.cc
@@ -14,6 +14,7 @@
 
 #include "state.h"
 
+#include <algorithm>
 #include <assert.h>
 #include <stdio.h>
 
@@ -157,6 +158,17 @@ bool State::AddDefault(StringPiece path, string* err) {
   }
   defaults_.push_back(node);
   return true;
+}
+
+bool State::IsImplicitOut(StringPiece path, unsigned int slash_bits) {
+  Node* node = GetNode(path, slash_bits);
+  Edge* edge = node->in_edge();
+  if (!edge)
+    return false;
+  vector<Node*>::iterator i =
+      std::find(edge->outputs_.begin(), edge->outputs_.end(), node);
+  return (i != edge->outputs_.end() &&
+          edge->is_implicit_out(i - edge->outputs_.begin()));
 }
 
 vector<Node*> State::RootNodes(string* err) {

--- a/src/state.h
+++ b/src/state.h
@@ -101,6 +101,8 @@ struct State {
   bool AddOut(Edge* edge, StringPiece path, unsigned int slash_bits);
   bool AddDefault(StringPiece path, string* error);
 
+  bool IsImplicitOut(StringPiece path, unsigned int slash_bits);
+
   /// Reset state.  Keeps all nodes and edges, but restores them to the
   /// state where we haven't yet examined the disk for dirty state.
   void Reset();


### PR DESCRIPTION
For compatibility with older versions of Ninja we do not reject
duplicate outputs by default.  However, we can reject them when at least
one of the outputs is implicit because older versions of Ninja do not
support implicit output syntax anyway.

Fixes #1136.