### PR TITLE
Change default NINJA_STATUS to [%f/%t]

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -208,7 +208,7 @@ specified by `-j` or its default)
 `%e`:: Elapsed time in seconds.  _(Available since Ninja 1.2.)_
 `%%`:: A plain `%` character.
 
-The default progress status is `"[%s/%t] "` (note the trailing space
+The default progress status is `"[%f/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status
 could be `"[%u/%r/%f] "`.
 

--- a/src/build.cc
+++ b/src/build.cc
@@ -84,7 +84,7 @@ BuildStatus::BuildStatus(const BuildConfig& config)
 
   progress_status_format_ = getenv("NINJA_STATUS");
   if (!progress_status_format_)
-    progress_status_format_ = "[%s/%t] ";
+    progress_status_format_ = "[%f/%t] ";
 }
 
 void BuildStatus::PlanHasTotalEdges(int total) {


### PR DESCRIPTION
PR #999 changed the status line to be printed when edges finish on dumb
teerminals, but the default status message includes the number of
started edges, resulting in sequential status lines with identical
edge counts.

Change the default status to show the number of finished edges, which
will keep the count incrementing on every line.  This will slightly
change the output on smart terminals.  Previously a build that was just
starting would show a count equal to the number of concurrent jobs, and
a build waiting for the final jobs to finish would show a count equal to
the total number of edges.  Now a starting build will show 0, and build
waiting for the final jobs will show a count less than the total number
of edges by the number of remaining jobs.

Fixes: #1142