### PR TITLE
Fix NINJA_STATUS %e and %r on dumb terminals

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -97,7 +97,7 @@ void BuildStatus::BuildEdgeStarted(Edge* edge) {
   ++started_edges_;
 
   if (edge->use_console() || printer_.is_smart_terminal())
-    PrintStatus(edge);
+    PrintStatus(edge, kEdgeStarted);
 
   if (edge->use_console())
     printer_.SetConsoleLocked(true);
@@ -129,7 +129,7 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
     return;
 
   if (!edge->use_console())
-    PrintStatus(edge);
+    PrintStatus(edge, kEdgeFinished);
 
   // Print the command that is spewing before printing its output.
   if (!success) {
@@ -170,7 +170,7 @@ void BuildStatus::BuildFinished() {
 }
 
 string BuildStatus::FormatProgressStatus(
-    const char* progress_status_format) const {
+    const char* progress_status_format, EdgeStatus status) const {
   string out;
   char buf[32];
   int percent;
@@ -195,10 +195,15 @@ string BuildStatus::FormatProgressStatus(
         break;
 
         // Running edges.
-      case 'r':
-        snprintf(buf, sizeof(buf), "%d", started_edges_ - finished_edges_);
+      case 'r': {
+        int running_edges = started_edges_ - finished_edges_;
+        // count the edge that just finished as a running edge
+        if (status == kEdgeFinished)
+          running_edges++;
+        snprintf(buf, sizeof(buf), "%d", running_edges);
         out += buf;
         break;
+      }
 
         // Unstarted edges.
       case 'u':
@@ -252,7 +257,7 @@ string BuildStatus::FormatProgressStatus(
   return out;
 }
 
-void BuildStatus::PrintStatus(Edge* edge) {
+void BuildStatus::PrintStatus(Edge* edge, EdgeStatus status) {
   if (config_.verbosity == BuildConfig::QUIET)
     return;
 
@@ -262,7 +267,7 @@ void BuildStatus::PrintStatus(Edge* edge) {
   if (to_print.empty() || force_full_command)
     to_print = edge->GetBinding("command");
 
-  to_print = FormatProgressStatus(progress_status_format_) + to_print;
+  to_print = FormatProgressStatus(progress_status_format_, status) + to_print;
 
   printer_.Print(to_print,
                  force_full_command ? LinePrinter::FULL : LinePrinter::ELIDE);

--- a/src/build.cc
+++ b/src/build.cc
@@ -109,6 +109,12 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
                                     int* start_time,
                                     int* end_time) {
   int64_t now = GetTimeMillis();
+
+  if (finished_edges_  == 0) {
+    overall_rate_.Restart();
+    current_rate_.Restart();
+  }
+
   ++finished_edges_;
 
   RunningEdgeMap::iterator i = running_edges_.find(edge);
@@ -256,10 +262,6 @@ void BuildStatus::PrintStatus(Edge* edge) {
   if (to_print.empty() || force_full_command)
     to_print = edge->GetBinding("command");
 
-  if (finished_edges_ == 0) {
-    overall_rate_.Restart();
-    current_rate_.Restart();
-  }
   to_print = FormatProgressStatus(progress_status_format_) + to_print;
 
   printer_.Print(to_print,

--- a/src/build.h
+++ b/src/build.h
@@ -202,14 +202,21 @@ struct BuildStatus {
                          int* start_time, int* end_time);
   void BuildFinished();
 
+  enum EdgeStatus {
+    kEdgeStarted,
+    kEdgeFinished,
+  };
+
   /// Format the progress status string by replacing the placeholders.
   /// See the user manual for more information about the available
   /// placeholders.
   /// @param progress_status_format The format of the progress status.
-  string FormatProgressStatus(const char* progress_status_format) const;
+  /// @param finished True if the edge being printed just finished
+  string FormatProgressStatus(const char* progress_status_format,
+                              EdgeStatus kEdgeFinished) const;
 
  private:
-  void PrintStatus(Edge* edge);
+  void PrintStatus(Edge* edge, EdgeStatus status);
 
   const BuildConfig& config_;
 

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1286,7 +1286,8 @@ TEST_F(BuildWithLogTest, RestatTest) {
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
   ASSERT_EQ("", err);
-  EXPECT_EQ("[3/3]", builder_.status_->FormatProgressStatus("[%s/%t]"));
+  EXPECT_EQ("[3/3]", builder_.status_->FormatProgressStatus("[%s/%t]",
+      BuildStatus::kEdgeStarted));
   command_runner_.commands_ran_.clear();
   state_.Reset();
 
@@ -1726,7 +1727,8 @@ TEST_F(BuildTest, DepsGccWithEmptyDepfileErrorsOut) {
 
 TEST_F(BuildTest, StatusFormatReplacePlaceholder) {
   EXPECT_EQ("[%/s0/t0/r0/u0/f0]",
-            status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]"));
+            status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]",
+                BuildStatus::kEdgeStarted));
 }
 
 TEST_F(BuildTest, FailedDepsParse) {


### PR DESCRIPTION
PR #999 on dumb terminals broke NINJA_STATUS messages with %e and slightly changed the behavior of %r.

Fixes #1146
Fixes #1148 