### PR TITLE
Extract Replace() function into util.cc, add tests, fix edge case

### DIFF
--- a/src/msvc_helper-win32.cc
+++ b/src/msvc_helper-win32.cc
@@ -18,20 +18,6 @@
 
 #include "util.h"
 
-namespace {
-
-string Replace(const string& input, const string& find, const string& replace) {
-  string result = input;
-  size_t start_pos = 0;
-  while ((start_pos = result.find(find, start_pos)) != string::npos) {
-    result.replace(start_pos, find.length(), replace);
-    start_pos += replace.length();
-  }
-  return result;
-}
-
-}  // anonymous namespace
-
 string EscapeForDepfile(const string& path) {
   // Depfiles don't escape single \.
   return Replace(path, " ", "\\ ");

--- a/src/util.cc
+++ b/src/util.cc
@@ -499,6 +499,19 @@ string StripAnsiEscapeCodes(const string& in) {
   return stripped;
 }
 
+string Replace(const string& input, const string& find, const string& replace) {
+  // Must handle empty `find` string to prevent infinite loop.
+  if (find.length() == 0)
+    return input;
+  string result = input;
+  size_t start_pos = 0;
+  while ((start_pos = result.find(find, start_pos)) != string::npos) {
+    result.replace(start_pos, find.length(), replace);
+    start_pos += replace.length();
+  }
+  return result;
+}
+
 int GetProcessorCount() {
 #ifdef _WIN32
   SYSTEM_INFO info;

--- a/src/util.h
+++ b/src/util.h
@@ -73,6 +73,10 @@ const char* SpellcheckString(const char* text, ...);
 /// Removes all Ansi escape codes (http://www.termsys.demon.co.uk/vtansi.htm).
 string StripAnsiEscapeCodes(const string& in);
 
+/// Replace all occurrences of \a find with \a replace in \a input
+/// and return the result.
+string Replace(const string& input, const string& find, const string& replace);
+
 /// @return the number of processors on the machine.  Useful for an initial
 /// guess for how many jobs to run in parallel.  @return 0 on error.
 int GetProcessorCount();

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -389,6 +389,39 @@ TEST(StripAnsiEscapeCodes, StripColors) {
             stripped);
 }
 
+TEST(Replace, Replacement) {
+  EXPECT_EQ("At About Above", Replace("at about above", "a", "A"));
+  EXPECT_EQ("at XXXut XXXve", Replace("at about above", "abo", "XXX"));
+  EXPECT_EQ("LONGLONGLONG", Replace("aaa", "a", "LONG"));
+  EXPECT_EQ("sss", Replace("SHORTSHORTSHORT", "SHORT", "s"));
+}
+
+TEST(Replace, EntireReplacement) {
+  EXPECT_EQ("new", Replace("at about above", "at about above", "new"));
+  EXPECT_EQ("", Replace("at about above", "at about above", ""));
+}
+
+TEST(Replace, NotFound) {
+  EXPECT_EQ("at about above", Replace("at about above", "abu", "XXX"));
+}
+
+TEST(Replace, EmptyInput) {
+  EXPECT_EQ("", Replace("", "a", "X"));
+}
+
+TEST(Replace, EmptyFind) {
+  EXPECT_EQ("Testing this", Replace("Testing this", "", "X"));
+}
+
+TEST(Replace, EmptyReplacement) {
+  EXPECT_EQ("Teting thi", Replace("Testing this", "s", ""));
+  EXPECT_EQ("at ut ve", Replace("at about above", "abo", ""));
+}
+
+TEST(Replace, Empty) {
+  EXPECT_EQ("", Replace("", "", ""));
+}
+
 TEST(ElideMiddle, NothingToElide) {
   string input = "Nothing to elide in this short string.";
   EXPECT_EQ(input, ElideMiddle(input, 80));


### PR DESCRIPTION
Extract string search-and-replace function `Replace()` from anonymous
namespace in `msvc_helper-win32.cc` into `util.cc` in the global
namespace, so it can be used by other modules.

Add unit tests to validate the function.

Fix infinite loop if `Replace()` called with empty string as `find`
argument.
