### PR TITLE
Write subprocess output to stdout in binary mode

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -20,6 +20,11 @@
 #include <stdlib.h>
 #include <functional>
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 #if defined(__SVR4) && defined(__sun)
 #include <sys/termios.h>
 #endif
@@ -160,7 +165,17 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
       final_output = StripAnsiEscapeCodes(output);
     else
       final_output = output;
+
+#ifdef _WIN32
+    // Fix extra CR being added on Windows, writing out CR CR LF (#773)
+    _setmode(_fileno(stdout), _O_BINARY);  // Begin Windows extra CR fix
+#endif
+
     printer_.PrintOnNewLine(final_output);
+
+#ifdef _WIN32
+    _setmode(_fileno(stdout), _O_TEXT);  // End Windows extra CR fix
+#endif
   }
 }
 


### PR DESCRIPTION
Fix for #773 option 1: write subprocess output to `stdout` in binary mode.

(See also option 2 in Pull Request #1155, which normalizes the newlines before writing out.)

Set stdout to binary mode while writing subprocess output, so that the
CR in a CR LF sequence is not replaced with CR LF itself, which would
result in CR CR LF.

Based on patch posted by nico in issue #773 comment.
