### PR TITLE
Parser accepts no explicit outputs.

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -236,16 +236,13 @@ bool ManifestParser::ParseEdge(string* err) {
     EvalString out;
     if (!lexer_.ReadPath(&out, err))
       return false;
-    if (out.empty())
-      return lexer_.Error("expected path", err);
-
-    do {
+    while (!out.empty()) {
       outs.push_back(out);
 
       out.Clear();
       if (!lexer_.ReadPath(&out, err))
         return false;
-    } while (!out.empty());
+    }
   }
 
   // Add all implicit outs, counting how many as we go.
@@ -261,6 +258,9 @@ bool ManifestParser::ParseEdge(string* err) {
       ++implicit_outs;
     }
   }
+
+  if (outs.empty())
+    return lexer_.Error("expected path", err);
 
   if (!ExpectToken(Lexer::COLON, err))
     return false;

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -976,13 +976,10 @@ TEST_F(ParserTest, ImplicitOutputDupes) {
 TEST_F(ParserTest, NoExplicitOutput) {
   ManifestParser parser(&state, NULL, kDupeEdgeActionWarn);
   string err;
-  EXPECT_FALSE(parser.ParseTest(
+  EXPECT_TRUE(parser.ParseTest(
 "rule cat\n"
 "  command = cat $in > $out\n"
 "build | imp : cat bar\n", &err));
-  ASSERT_EQ("input:3: expected path\n"
-            "build | imp : cat bar\n"
-            "      ^ near here", err);
 }
 
 TEST_F(ParserTest, DefaultDefault) {


### PR DESCRIPTION
There is a class of commands that take an output directory where
they create their output files. Among them are cp(1), tar(1) to name a
few. These commands have one or more implicit outputs but no explicit
output.

With this patch, Ninja's parser accepts build edge with an
empty list of explicit outputs.

Discussed here: https://groups.google.com/forum/#!topic/ninja-build/Nt8QlmA5cQA