### PR TITLE
Add single quotes to the output file path if it has a space.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -135,8 +135,13 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
   if (!success) {
     string outputs;
     for (vector<Node*>::const_iterator o = edge->outputs_.begin();
-         o != edge->outputs_.end(); ++o)
-      outputs += (*o)->path() + " ";
+         o != edge->outputs_.end(); ++o) {
+      if((*o)->path().find(' ') != string::npos) {
+        outputs += "'" + (*o)->path() + "' ";
+      } else {
+        outputs += (*o)->path() + " ";
+      }
+    }
 
     printer_.PrintOnNewLine("FAILED: " + outputs + "\n");
     printer_.PrintOnNewLine(edge->EvaluateCommand() + "\n");


### PR DESCRIPTION
In the "FAILED: output nodes", add single quotes to the output file path if it has a space. This is to make it easier to run ninja with the output nodes and also the failure output parsable by script.

`ninja -C out/gn_build_dir/ output/node/with/a/ space` won't work, but `ninja -C out/gn_build_dir/ 'output/node/with/a/ space'` works.

Before this change:
`FAILED: gen/path/to/a space.cc gen/path/to/no_space.h `
After this change:
`FAILED: 'gen/path/to/a space.cc' gen/path/to/no_space.h `
