### PR TITLE
Record most recent input's mtime in log file for correct dirty status computation

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -47,7 +47,7 @@ namespace {
 
 const char kFileSignature[] = "# ninja log v%d\n";
 const int kOldestSupportedVersion = 4;
-const int kCurrentVersion = 5;
+const int kCurrentVersion = 6;
 
 // 64bit MurmurHash2, by Austin Appleby
 #if defined(_MSC_VER)
@@ -103,9 +103,10 @@ BuildLog::LogEntry::LogEntry(const string& output)
   : output(output) {}
 
 BuildLog::LogEntry::LogEntry(const string& output, uint64_t command_hash,
-  int start_time, int end_time, TimeStamp restat_mtime)
+  int start_time, int end_time, TimeStamp restat_mtime, TimeStamp input_mtime)
   : output(output), command_hash(command_hash),
-    start_time(start_time), end_time(end_time), mtime(restat_mtime)
+    start_time(start_time), end_time(end_time), mtime(restat_mtime),
+    input_mtime(input_mtime)
 {}
 
 BuildLog::BuildLog()
@@ -145,7 +146,7 @@ bool BuildLog::OpenForWrite(const string& path, const BuildLogUser& user,
 }
 
 bool BuildLog::RecordCommand(Edge* edge, int start_time, int end_time,
-                             TimeStamp mtime) {
+                             TimeStamp mtime, TimeStamp input_mtime) {
   string command = edge->EvaluateCommand(true);
   uint64_t command_hash = LogEntry::HashCommand(command);
   for (vector<Node*>::iterator out = edge->outputs_.begin();
@@ -163,6 +164,7 @@ bool BuildLog::RecordCommand(Edge* edge, int start_time, int end_time,
     log_entry->start_time = start_time;
     log_entry->end_time = end_time;
     log_entry->mtime = mtime;
+    log_entry->input_mtime = input_mtime;
 
     if (log_file_) {
       if (!WriteEntry(log_file_, *log_entry))
@@ -274,7 +276,7 @@ bool BuildLog::Load(const string& path, string* err) {
     *end = 0;
 
     int start_time = 0, end_time = 0;
-    TimeStamp restat_mtime = 0;
+    TimeStamp restat_mtime = 0, input_mtime = 0;
 
     start_time = atoi(start);
     start = end + 1;
@@ -292,6 +294,15 @@ bool BuildLog::Load(const string& path, string* err) {
     *end = 0;
     restat_mtime = strtoll(start, NULL, 10);
     start = end + 1;
+
+    if (log_version >= 6) {
+        end = (char*)memchr(start, kFieldSeparator, line_end - start);
+        if (!end)
+            continue;
+        *end = 0;
+        input_mtime = strtoll(start, NULL, 10);
+        start = end + 1;
+    }
 
     end = (char*)memchr(start, kFieldSeparator, line_end - start);
     if (!end)
@@ -315,6 +326,7 @@ bool BuildLog::Load(const string& path, string* err) {
     entry->start_time = start_time;
     entry->end_time = end_time;
     entry->mtime = restat_mtime;
+    entry->input_mtime = input_mtime;
     if (log_version >= 5) {
       char c = *end; *end = '\0';
       entry->command_hash = (uint64_t)strtoull(start, NULL, 16);
@@ -353,8 +365,8 @@ BuildLog::LogEntry* BuildLog::LookupByOutput(const string& path) {
 }
 
 bool BuildLog::WriteEntry(FILE* f, const LogEntry& entry) {
-  return fprintf(f, "%d\t%d\t%" PRId64 "\t%s\t%" PRIx64 "\n",
-          entry.start_time, entry.end_time, entry.mtime,
+  return fprintf(f, "%d\t%d\t%" PRId64 "\t%" PRId64 "\t%s\t%" PRIx64 "\n",
+          entry.start_time, entry.end_time, entry.mtime, entry.input_mtime,
           entry.output.c_str(), entry.command_hash) > 0;
 }
 

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -45,7 +45,7 @@ struct BuildLog {
 
   bool OpenForWrite(const string& path, const BuildLogUser& user, string* err);
   bool RecordCommand(Edge* edge, int start_time, int end_time,
-                     TimeStamp mtime = 0);
+                     TimeStamp mtime = 0, TimeStamp input_mtime = 0);
   void Close();
 
   /// Load the on-disk log.
@@ -57,6 +57,7 @@ struct BuildLog {
     int start_time;
     int end_time;
     TimeStamp mtime;
+    TimeStamp input_mtime;
 
     static uint64_t HashCommand(StringPiece command);
 
@@ -69,7 +70,7 @@ struct BuildLog {
 
     explicit LogEntry(const string& output);
     LogEntry(const string& output, uint64_t command_hash,
-             int start_time, int end_time, TimeStamp restat_mtime);
+             int start_time, int end_time, TimeStamp restat_mtime, TimeStamp input_mtime);
   };
 
   /// Lookup a previously-run command by its output path.

--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -92,7 +92,8 @@ bool WriteTestData(string* err) {
     log.RecordCommand(state.edges_[i],
                       /*start_time=*/100 * i,
                       /*end_time=*/100 * i + 1,
-                      /*mtime=*/0);
+                      /*mtime=*/0,
+                      /*input_mtime=*/0);
   }
 
   return true;

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -50,8 +50,8 @@ TEST_F(BuildLogTest, WriteRead) {
   string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
-  log1.RecordCommand(state_.edges_[0], 15, 18);
-  log1.RecordCommand(state_.edges_[1], 20, 25);
+  log1.RecordCommand(state_.edges_[0], 15, 18, 18);
+  log1.RecordCommand(state_.edges_[1], 20, 25, 25);
   log1.Close();
 
   BuildLog log2;
@@ -126,8 +126,8 @@ TEST_F(BuildLogTest, Truncate) {
     string err;
     EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
     ASSERT_EQ("", err);
-    log1.RecordCommand(state_.edges_[0], 15, 18);
-    log1.RecordCommand(state_.edges_[1], 20, 25);
+    log1.RecordCommand(state_.edges_[0], 15, 18, 18);
+    log1.RecordCommand(state_.edges_[1], 20, 25, 25);
     log1.Close();
   }
 
@@ -142,8 +142,8 @@ TEST_F(BuildLogTest, Truncate) {
     string err;
     EXPECT_TRUE(log2.OpenForWrite(kTestFilename, *this, &err));
     ASSERT_EQ("", err);
-    log2.RecordCommand(state_.edges_[0], 15, 18);
-    log2.RecordCommand(state_.edges_[1], 20, 25);
+    log2.RecordCommand(state_.edges_[0], 15, 18, 18);
+    log2.RecordCommand(state_.edges_[1], 20, 25, 25);
     log2.Close();
 
     ASSERT_TRUE(Truncate(kTestFilename, size, &err));
@@ -249,7 +249,7 @@ TEST_F(BuildLogTest, MultiTargetEdge) {
 "build out out.d: cat\n");
 
   BuildLog log;
-  log.RecordCommand(state_.edges_[0], 21, 22);
+  log.RecordCommand(state_.edges_[0], 21, 22, 22);
 
   ASSERT_EQ(2u, log.entries().size());
   BuildLog::LogEntry* e1 = log.LookupByOutput("out");
@@ -280,8 +280,8 @@ TEST_F(BuildLogRecompactTest, Recompact) {
   // Record the same edge several times, to trigger recompaction
   // the next time the log is opened.
   for (int i = 0; i < 200; ++i)
-    log1.RecordCommand(state_.edges_[0], 15, 18 + i);
-  log1.RecordCommand(state_.edges_[1], 21, 22);
+    log1.RecordCommand(state_.edges_[0], 15, 18 + i, 18 + i);
+  log1.RecordCommand(state_.edges_[1], 21, 22, 22);
   log1.Close();
 
   // Load...

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -111,10 +111,12 @@ bool DependencyScan::RecomputeDirty(Node* node, vector<Node*>* stack,
     }
   }
 
+  edge->most_recent_input_ = most_recent_input;
+
   // We may also be dirty due to output state: missing outputs, out of
   // date outputs, etc.  Visit all outputs and determine whether they're dirty.
   if (!dirty)
-    if (!RecomputeOutputsDirty(edge, most_recent_input, &dirty, err))
+    if (!RecomputeOutputsDirty(edge, &dirty, err))
       return false;
 
   // Finally, visit each output and update their dirty state if necessary.
@@ -180,12 +182,11 @@ bool DependencyScan::VerifyDAG(Node* node, vector<Node*>* stack, string* err) {
   return false;
 }
 
-bool DependencyScan::RecomputeOutputsDirty(Edge* edge, Node* most_recent_input,
-                                           bool* outputs_dirty, string* err) {
+bool DependencyScan::RecomputeOutputsDirty(Edge* edge, bool* outputs_dirty, string* err) {
   string command = edge->EvaluateCommand(/*incl_rsp_file=*/true);
   for (vector<Node*>::iterator o = edge->outputs_.begin();
        o != edge->outputs_.end(); ++o) {
-    if (RecomputeOutputDirty(edge, most_recent_input, command, *o)) {
+    if (RecomputeOutputDirty(edge, command, *o)) {
       *outputs_dirty = true;
       return true;
     }
@@ -194,7 +195,6 @@ bool DependencyScan::RecomputeOutputsDirty(Edge* edge, Node* most_recent_input,
 }
 
 bool DependencyScan::RecomputeOutputDirty(Edge* edge,
-                                          Node* most_recent_input,
                                           const string& command,
                                           Node* output) {
   if (edge->is_phony()) {
@@ -217,26 +217,30 @@ bool DependencyScan::RecomputeOutputDirty(Edge* edge,
   }
 
   // Dirty if the output is older than the input.
-  if (most_recent_input && output->mtime() < most_recent_input->mtime()) {
-    TimeStamp output_mtime = output->mtime();
+  TimeStamp input_mtime = output->mtime();
+  if (build_log()) {
+    entry = build_log()->LookupByOutput(output->path());
+    if (entry)
+      input_mtime = entry->input_mtime > 0 ? entry->input_mtime : input_mtime;
+  }
 
+  if (edge->most_recent_input_ && input_mtime < edge->most_recent_input_->mtime()) {
     // If this is a restat rule, we may have cleaned the output with a restat
     // rule in a previous run and stored the most recent input mtime in the
     // build log.  Use that mtime instead, so that the file will only be
     // considered dirty if an input was modified since the previous run.
     bool used_restat = false;
-    if (edge->GetBindingBool("restat") && build_log() &&
-        (entry = build_log()->LookupByOutput(output->path()))) {
-      output_mtime = entry->mtime;
+    if (edge->GetBindingBool("restat") && entry) {
+      input_mtime = entry->mtime;
       used_restat = true;
     }
 
-    if (output_mtime < most_recent_input->mtime()) {
+    if (input_mtime < edge->most_recent_input_->mtime()) {
       EXPLAIN("%soutput %s older than most recent input %s "
               "(%" PRId64 " vs %" PRId64 ")",
               used_restat ? "restat of " : "", output->path().c_str(),
-              most_recent_input->path().c_str(),
-              output_mtime, most_recent_input->mtime());
+              edge->most_recent_input_->path().c_str(),
+              input_mtime, edge->most_recent_input_->mtime());
       return true;
     }
   }
@@ -252,14 +256,14 @@ bool DependencyScan::RecomputeOutputDirty(Edge* edge,
         EXPLAIN("command line changed for %s", output->path().c_str());
         return true;
       }
-      if (most_recent_input && entry->mtime < most_recent_input->mtime()) {
+      if (edge->most_recent_input_ && entry->mtime < edge->most_recent_input_->mtime()) {
         // May also be dirty due to the mtime in the log being older than the
         // mtime of the most recent input.  This can occur even when the mtime
         // on disk is newer if a previous run wrote to the output file but
         // exited with an error or was interrupted.
         EXPLAIN("recorded mtime of %s older than most recent input %s (%" PRId64 " vs %" PRId64 ")",
-                output->path().c_str(), most_recent_input->path().c_str(),
-                entry->mtime, most_recent_input->mtime());
+                output->path().c_str(), edge->most_recent_input_->path().c_str(),
+                entry->mtime, edge->most_recent_input_->mtime());
         return true;
       }
     }

--- a/src/graph.h
+++ b/src/graph.h
@@ -134,8 +134,8 @@ struct Edge {
     VisitDone
   };
 
-  Edge() : rule_(NULL), pool_(NULL), env_(NULL), mark_(VisitNone),
-           outputs_ready_(false), deps_missing_(false),
+  Edge() : rule_(NULL), pool_(NULL), most_recent_input_(NULL), env_(NULL),
+           mark_(VisitNone), outputs_ready_(false), deps_missing_(false),
            implicit_deps_(0), order_only_deps_(0), implicit_outs_(0) {}
 
   /// Return true if all inputs' in-edges are ready.
@@ -161,6 +161,7 @@ struct Edge {
   Pool* pool_;
   vector<Node*> inputs_;
   vector<Node*> outputs_;
+  Node* most_recent_input_;
   BindingEnv* env_;
   VisitMark mark_;
   bool outputs_ready_;
@@ -263,8 +264,7 @@ struct DependencyScan {
 
   /// Recompute whether any output of the edge is dirty, if so sets |*dirty|.
   /// Returns false on failure.
-  bool RecomputeOutputsDirty(Edge* edge, Node* most_recent_input,
-                             bool* dirty, string* err);
+  bool RecomputeOutputsDirty(Edge* edge, bool* dirty, string* err);
 
   BuildLog* build_log() const {
     return build_log_;
@@ -283,8 +283,7 @@ struct DependencyScan {
 
   /// Recompute whether a given single output should be marked dirty.
   /// Returns true if so.
-  bool RecomputeOutputDirty(Edge* edge, Node* most_recent_input,
-                            const string& command, Node* output);
+  bool RecomputeOutputDirty(Edge* edge, const string& command, Node* output);
 
   BuildLog* build_log_;
   DiskInterface* disk_interface_;


### PR DESCRIPTION
This adds support for recording an edge's most recent input file's mtime in the build log. This fixes #1162, by giving ninja a better metric for determining whether an edge's outputs are dirty.

If an edge's output files' mtimes are compared to the most recent input's mtime, edges might be calculated as clean even if they are actually dirty. While an edge is running its rule to produce its outputs and an input to the edge is updated before the outputs are written to disk, then subsequent runs will think that the outputs are newer than the inputs, even though the inputs have actually been updated and may be different than what were used to produce those outputs. This can be disastrous if the resulting object files still link, since some of the object files might be out of date.

Instead of comparing output mtimes, ninja will add the most recent input's mtime to the build log file (calculated when the edge first calculates its dirty status) when an edge completes. On subsequent runs, ninja will use this value to compare to the edge's most recent input's mtime to determine whether the outputs are dirty, which is provably more correct and safer, since outputs are guaranteed to actually be up to date.

A test is included for recording the correct input_time in the log file, ensuring that subsequent ninja runs utilize that value correctly.