### PR TITLE
Ninja status format string from argv.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -87,7 +87,12 @@ BuildStatus::BuildStatus(const BuildConfig& config)
   if (config_.verbosity != BuildConfig::NORMAL)
     printer_.set_smart_terminal(false);
 
-  progress_status_format_ = getenv("NINJA_STATUS");
+  if (config_.status_format) {
+    // Command line arg overrides env if given.
+    progress_status_format_ = config_.status_format;
+  } else {
+    progress_status_format_ = getenv("NINJA_STATUS");
+  }
   if (!progress_status_format_)
     progress_status_format_ = "[%f/%t] ";
 }
@@ -279,7 +284,7 @@ string BuildStatus::FormatProgressStatus(
       }
 
       default:
-        Fatal("unknown placeholder '%%%c' in $NINJA_STATUS", *s);
+        Fatal("unknown placeholder '%%%c' in the status format string", *s);
         return "";
       }
     } else {

--- a/src/build.h
+++ b/src/build.h
@@ -159,7 +159,8 @@ struct CommandRunner {
 /// Options (e.g. verbosity, parallelism) passed to a build.
 struct BuildConfig {
   BuildConfig() : verbosity(NORMAL), dry_run(false), parallelism(1),
-                  failures_allowed(1), max_load_average(-0.0f) {}
+                  failures_allowed(1), max_load_average(-0.0f),
+                  status_format(NULL) {}
 
   enum Verbosity {
     NORMAL,
@@ -173,6 +174,8 @@ struct BuildConfig {
   /// The maximum load average we must not exceed. A negative value
   /// means that we do not have any limit.
   double max_load_average;
+  /// Status format string.
+  const char* status_format;
   DepfileParserOptions depfile_parser_options;
 };
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -206,8 +206,9 @@ void Usage(const BuildConfig& config) {
 "if targets are unspecified, builds the 'default' target (see manual).\n"
 "\n"
 "options:\n"
-"  --version      print ninja version (\"%s\")\n"
-"  -v, --verbose  show all command lines while building\n"
+"  --version                   print ninja version (\"%s\")\n"
+"  -v, --verbose               show all command lines while building\n"
+"  -s, --status-format=STATUS  specify the status format string\n"
 "\n"
 "  -C DIR   change to DIR before doing anything else\n"
 "  -f FILE  specify input build file [default=build.ninja]\n"
@@ -1190,6 +1191,7 @@ int ReadFlags(int* argc, char*** argv,
     { "help", no_argument, NULL, 'h' },
     { "version", no_argument, NULL, OPT_VERSION },
     { "verbose", no_argument, NULL, 'v' },
+    { "status-format", required_argument, NULL, 's' },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1238,6 +1240,10 @@ int ReadFlags(int* argc, char*** argv,
       }
       case 'n':
         config->dry_run = true;
+        break;
+      case 's':
+        // status-format value is in optarg
+        config->status_format = optarg;
         break;
       case 't':
         options->tool = ChooseTool(optarg);


### PR DESCRIPTION
Ninja supports a status format string from NINJA_STATUS env. This is a great feature to have.
Though, in an automated build environment provisioning environmental variables could be tricky.

This patch adds a support for a command line option (--status-format=<STATUS>) to set the status format string. If given, the status format string from the command line would override the one from NINJA_STATUS env.

Only a long option is supported for now. Easy to add a short form if it will be a use case for that.
