### PR TITLE
Use POSIX_SPAWN_USEVFORK if available

### DIFF
--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -73,8 +73,6 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
   // default action in the new process image, so no explicit
   // POSIX_SPAWN_SETSIGDEF parameter is needed.
 
-  // TODO: Consider using POSIX_SPAWN_USEVFORK on Linux with glibc?
-
   if (!use_console_) {
     // Put the child in its own process group, so ctrl-c won't reach it.
     flags |= POSIX_SPAWN_SETPGROUP;
@@ -93,6 +91,9 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
     // In the console case, output_pipe is still inherited by the child and
     // closed when the subprocess finishes, which then notifies ninja.
   }
+#ifdef POSIX_SPAWN_USEVFORK
+  flags |= POSIX_SPAWN_USEVFORK;
+#endif
 
   if (posix_spawnattr_setflags(&attr, flags) != 0)
     Fatal("posix_spawnattr_setflags: %s", strerror(errno));


### PR DESCRIPTION
Existing comments were alluding to it's usage and it makes building
ninja itself go a litle bit faster (i.e. taking less wall clock time).

FWIW FreeBSD even uses vfork by default c.f.
https://www.freebsd.org/cgi/man.cgi?query=posix_spawn
