### PR TITLE
FreeBSD supports ppoll(2)

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -98,7 +98,7 @@ class Platform(object):
         return self._platform in ('freebsd', 'openbsd', 'bitrig')
 
     def supports_ppoll(self):
-        return self._platform in ('linux', 'openbsd', 'bitrig')
+        return self._platform in ('freebsd', 'linux', 'openbsd', 'bitrig')
 
     def supports_ninja_browse(self):
         return (not self.is_windows()

--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -24,6 +24,13 @@
 #include <sys/wait.h>
 #include <spawn.h>
 
+#ifdef __FreeBSD__
+#  include <sys/param.h>
+#  if defined USE_PPOLL && __FreeBSD_version < 1002000
+#    undef USE_PPOLL
+#  endif
+#endif
+
 extern char** environ;
 
 #include "util.h"


### PR DESCRIPTION
This also fixes this test error `SubprocessTest.SetWithLotsninja: fatal: pipe: Too many open files` caused by 
```cpp
if (fd_ >= static_cast<int>(FD_SETSIZE))                                      
    Fatal("pipe: %s", strerror(EMFILE)); 
```
in Subprocess::Start