### PR TITLE
Be smarter about mtimes when stat()'ing symlinks.

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1679,7 +1679,7 @@ TEST_F(BuildTest, InterruptCleanup) {
   EXPECT_FALSE(builder_.Build(&err));
   EXPECT_EQ("interrupted by user", err);
   builder_.Cleanup();
-  EXPECT_GT(fs_.Stat("out1", &err), 0);
+  EXPECT_GT(fs_.Stat("out1", DiskInterface::kDontFollow, &err), 0);
   err = "";
 
   // A touched output of an interrupted command should be deleted.
@@ -1688,7 +1688,7 @@ TEST_F(BuildTest, InterruptCleanup) {
   EXPECT_FALSE(builder_.Build(&err));
   EXPECT_EQ("interrupted by user", err);
   builder_.Cleanup();
-  EXPECT_EQ(0, fs_.Stat("out2", &err));
+  EXPECT_EQ(0, fs_.Stat("out2", DiskInterface::kDontFollow, &err));
 }
 
 TEST_F(BuildTest, StatFailureAbortsBuild) {
@@ -1832,7 +1832,7 @@ TEST_F(BuildWithDepsLogTest, Straightforward) {
     EXPECT_EQ("", err);
 
     // The deps file should have been removed.
-    EXPECT_EQ(0, fs_.Stat("in1.d", &err));
+    EXPECT_EQ(0, fs_.Stat("in1.d", DiskInterface::kDontFollow, &err));
     // Recreate it for the next step.
     fs_.Create("in1.d", "out: in2");
     deps_log.Close();
@@ -1912,7 +1912,7 @@ TEST_F(BuildWithDepsLogTest, ObsoleteDeps) {
   fs_.Create("out", "");
 
   // The deps file should have been removed, so no need to timestamp it.
-  EXPECT_EQ(0, fs_.Stat("in1.d", &err));
+  EXPECT_EQ(0, fs_.Stat("in1.d", DiskInterface::kDontFollow, &err));
 
   {
     State state;

--- a/src/clean.cc
+++ b/src/clean.cc
@@ -50,7 +50,8 @@ int Cleaner::RemoveFile(const string& path) {
 
 bool Cleaner::FileExists(const string& path) {
   string err;
-  TimeStamp mtime = disk_interface_->Stat(path, &err);
+  TimeStamp mtime =
+      disk_interface_->Stat(path, DiskInterface::kDontFollow, &err);
   if (mtime == -1)
     Error("%s", err.c_str());
   return mtime > 0;  // Treat Stat() errors as "file does not exist".

--- a/src/clean_test.cc
+++ b/src/clean_test.cc
@@ -45,10 +45,10 @@ TEST_F(CleanTest, CleanAll) {
 
   // Check they are removed.
   string err;
-  EXPECT_EQ(0, fs_.Stat("in1", &err));
-  EXPECT_EQ(0, fs_.Stat("out1", &err));
-  EXPECT_EQ(0, fs_.Stat("in2", &err));
-  EXPECT_EQ(0, fs_.Stat("out2", &err));
+  EXPECT_EQ(0, fs_.Stat("in1", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("out1", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("in2", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("out2", DiskInterface::kDontFollow, &err));
   fs_.files_removed_.clear();
 
   EXPECT_EQ(0, cleaner.CleanAll());
@@ -77,10 +77,10 @@ TEST_F(CleanTest, CleanAllDryRun) {
 
   // Check they are not removed.
   string err;
-  EXPECT_LT(0, fs_.Stat("in1", &err));
-  EXPECT_LT(0, fs_.Stat("out1", &err));
-  EXPECT_LT(0, fs_.Stat("in2", &err));
-  EXPECT_LT(0, fs_.Stat("out2", &err));
+  EXPECT_LT(0, fs_.Stat("in1", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("out1", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("in2", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("out2", DiskInterface::kDontFollow, &err));
   fs_.files_removed_.clear();
 
   EXPECT_EQ(0, cleaner.CleanAll());
@@ -108,10 +108,10 @@ TEST_F(CleanTest, CleanTarget) {
 
   // Check they are removed.
   string err;
-  EXPECT_EQ(0, fs_.Stat("in1", &err));
-  EXPECT_EQ(0, fs_.Stat("out1", &err));
-  EXPECT_LT(0, fs_.Stat("in2", &err));
-  EXPECT_LT(0, fs_.Stat("out2", &err));
+  EXPECT_EQ(0, fs_.Stat("in1", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("out1", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("in2", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("out2", DiskInterface::kDontFollow, &err));
   fs_.files_removed_.clear();
 
   ASSERT_EQ(0, cleaner.CleanTarget("out1"));
@@ -140,10 +140,10 @@ TEST_F(CleanTest, CleanTargetDryRun) {
 
   // Check they are not removed.
   string err;
-  EXPECT_LT(0, fs_.Stat("in1", &err));
-  EXPECT_LT(0, fs_.Stat("out1", &err));
-  EXPECT_LT(0, fs_.Stat("in2", &err));
-  EXPECT_LT(0, fs_.Stat("out2", &err));
+  EXPECT_LT(0, fs_.Stat("in1", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("out1", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("in2", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("out2", DiskInterface::kDontFollow, &err));
   fs_.files_removed_.clear();
 
   ASSERT_EQ(0, cleaner.CleanTarget("out1"));
@@ -173,10 +173,10 @@ TEST_F(CleanTest, CleanRule) {
 
   // Check they are removed.
   string err;
-  EXPECT_EQ(0, fs_.Stat("in1", &err));
-  EXPECT_LT(0, fs_.Stat("out1", &err));
-  EXPECT_EQ(0, fs_.Stat("in2", &err));
-  EXPECT_LT(0, fs_.Stat("out2", &err));
+  EXPECT_EQ(0, fs_.Stat("in1", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("out1", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("in2", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("out2", DiskInterface::kDontFollow, &err));
   fs_.files_removed_.clear();
 
   ASSERT_EQ(0, cleaner.CleanRule("cat_e"));
@@ -207,10 +207,10 @@ TEST_F(CleanTest, CleanRuleDryRun) {
 
   // Check they are not removed.
   string err;
-  EXPECT_LT(0, fs_.Stat("in1", &err));
-  EXPECT_LT(0, fs_.Stat("out1", &err));
-  EXPECT_LT(0, fs_.Stat("in2", &err));
-  EXPECT_LT(0, fs_.Stat("out2", &err));
+  EXPECT_LT(0, fs_.Stat("in1", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("out1", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("in2", DiskInterface::kDontFollow, &err));
+  EXPECT_LT(0, fs_.Stat("out2", DiskInterface::kDontFollow, &err));
   fs_.files_removed_.clear();
 
   ASSERT_EQ(0, cleaner.CleanRule("cat_e"));
@@ -335,12 +335,12 @@ TEST_F(CleanTest, CleanRsp) {
 
   // Check they are removed.
   string err;
-  EXPECT_EQ(0, fs_.Stat("in1", &err));
-  EXPECT_EQ(0, fs_.Stat("out1", &err));
-  EXPECT_EQ(0, fs_.Stat("in2", &err));
-  EXPECT_EQ(0, fs_.Stat("out2", &err));
-  EXPECT_EQ(0, fs_.Stat("in2.rsp", &err));
-  EXPECT_EQ(0, fs_.Stat("out2.rsp", &err));
+  EXPECT_EQ(0, fs_.Stat("in1", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("out1", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("in2", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("out2", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("in2.rsp", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("out2.rsp", DiskInterface::kDontFollow, &err));
 }
 
 TEST_F(CleanTest, CleanFailure) {
@@ -366,7 +366,7 @@ TEST_F(CleanTest, CleanPhony) {
   Cleaner cleaner(&state_, config_, &fs_);
   EXPECT_EQ(0, cleaner.CleanAll());
   EXPECT_EQ(2, cleaner.cleaned_files_count());
-  EXPECT_LT(0, fs_.Stat("phony", &err));
+  EXPECT_LT(0, fs_.Stat("phony", DiskInterface::kDontFollow, &err));
 
   fs_.Create("t1", "");
   fs_.Create("t2", "");
@@ -374,7 +374,7 @@ TEST_F(CleanTest, CleanPhony) {
   // Check that CleanTarget does not remove "phony".
   EXPECT_EQ(0, cleaner.CleanTarget("phony"));
   EXPECT_EQ(2, cleaner.cleaned_files_count());
-  EXPECT_LT(0, fs_.Stat("phony", &err));
+  EXPECT_LT(0, fs_.Stat("phony", DiskInterface::kDontFollow, &err));
 }
 
 TEST_F(CleanTest, CleanDepFileAndRspFileWithSpaces) {
@@ -400,8 +400,8 @@ TEST_F(CleanTest, CleanDepFileAndRspFileWithSpaces) {
   EXPECT_EQ(4u, fs_.files_removed_.size());
 
   string err;
-  EXPECT_EQ(0, fs_.Stat("out 1", &err));
-  EXPECT_EQ(0, fs_.Stat("out 2", &err));
-  EXPECT_EQ(0, fs_.Stat("out 1.d", &err));
-  EXPECT_EQ(0, fs_.Stat("out 2.rsp", &err));
+  EXPECT_EQ(0, fs_.Stat("out 1", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("out 2", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("out 1.d", DiskInterface::kDontFollow, &err));
+  EXPECT_EQ(0, fs_.Stat("out 2.rsp", DiskInterface::kDontFollow, &err));
 }

--- a/src/graph.h
+++ b/src/graph.h
@@ -19,12 +19,12 @@
 #include <vector>
 using namespace std;
 
+#include "disk_interface.h"
 #include "eval_env.h"
 #include "timestamp.h"
 #include "util.h"
 
 struct BuildLog;
-struct DiskInterface;
 struct DepsLog;
 struct Edge;
 struct Node;
@@ -43,13 +43,17 @@ struct Node {
         id_(-1) {}
 
   /// Return false on error.
-  bool Stat(DiskInterface* disk_interface, string* err);
+  bool Stat(DiskInterface* disk_interface,
+            DiskInterface::SymlinkTreatment symlink_treatment,
+            string* err);
 
   /// Return false on error.
-  bool StatIfNecessary(DiskInterface* disk_interface, string* err) {
+  bool StatIfNecessary(DiskInterface* disk_interface,
+            DiskInterface::SymlinkTreatment symlink_treatment,
+            string* err) {
     if (status_known())
       return true;
-    return Stat(disk_interface, err);
+    return Stat(disk_interface, symlink_treatment, err);
   }
 
   /// Mark as not-yet-stat()ed and not dirty.

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -39,7 +39,8 @@
 
 bool WriteFakeManifests(const string& dir, string* err) {
   RealDiskInterface disk_interface;
-  TimeStamp mtime = disk_interface.Stat(dir + "/build.ninja", err);
+  TimeStamp mtime = disk_interface.Stat(dir + "/build.ninja",
+                                        DiskInterface::kDontFollow, err);
   if (mtime != 0)  // 0 means that the file doesn't exist yet.
     return mtime != -1;
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -158,7 +158,8 @@ struct NinjaMain : public BuildLogUser {
     // Do keep entries around for files which still exist on disk, for
     // generators that want to use this information.
     string err;
-    TimeStamp mtime = disk_interface_.Stat(s.AsString(), &err);
+    TimeStamp mtime =
+        disk_interface_.Stat(s.AsString(), DiskInterface::kDontFollow, &err);
     if (mtime == -1)
       Error("%s", err.c_str());  // Log and ignore Stat() errors.
     return mtime == 0;
@@ -488,7 +489,8 @@ int NinjaMain::ToolDeps(const Options* options, int argc, char** argv) {
     }
 
     string err;
-    TimeStamp mtime = disk_interface.Stat((*it)->path(), &err);
+    TimeStamp mtime =
+        disk_interface.Stat((*it)->path(), DiskInterface::kTakeNewest, &err);
     if (mtime == -1)
       Error("%s", err.c_str());  // Log and ignore Stat() errors;
     printf("%s: #deps %d, deps mtime %d (%s)\n",

--- a/src/test.cc
+++ b/src/test.cc
@@ -146,7 +146,10 @@ void VirtualFileSystem::Create(const string& path,
   files_created_.insert(path);
 }
 
-TimeStamp VirtualFileSystem::Stat(const string& path, string* err) const {
+TimeStamp VirtualFileSystem::Stat(
+    const string& path,
+    DiskInterface::SymlinkTreatment symlink_treatment,
+    string* err) const {
   FileMap::const_iterator i = files_.find(path);
   if (i != files_.end()) {
     *err = i->second.stat_error;

--- a/src/test.h
+++ b/src/test.h
@@ -142,7 +142,9 @@ struct VirtualFileSystem : public DiskInterface {
   }
 
   // DiskInterface
-  virtual TimeStamp Stat(const string& path, string* err) const;
+  virtual TimeStamp Stat(const string& path,
+                         DiskInterface::SymlinkTreatment symlink_treatment,
+                         string* err) const;
   virtual bool WriteFile(const string& path, const string& contents);
   virtual bool MakeDir(const string& path);
   virtual Status ReadFile(const string& path, string* contents, string* err);


### PR DESCRIPTION
Before this change, symlinks were always followed when retrieving
mtimes. This can cause ninja to think targets are stale when outputs are
symlinks.

This patch introduces the following stat() logic for symlinks:
1. When Stat()ing inputs, use the newer of the symlink or what it points to.
- By looking at both, it maintains the pre-existing behaviour, where
  you could use a symlink as an input and ninja would know to rebuild
  when the thing it points to changes.
  1. When Stat()ing outputs, always use the timestamp of the symlink.
- If it's listed as an output, then it contains the only mtime ninja
  should care about.

Fixes Bug #1186
