### PR TITLE
Add NINJA_STATUS_STARTED and _FINISHED

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -191,8 +191,11 @@ you don't need to pass `-j`.)
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 
-Ninja supports one environment variable to control its behavior:
-`NINJA_STATUS`, the progress status printed before the rule being run.
+Ninja supports three environment variables to control its behavior:
+- `NINJA_STATUS`, the progress status. This is printed when an edge starts when
+  at a console, or when the edge finishes when output is redirected.
+- `NINJA_STATUS_STARTED`, which is printed before an edge starts.
+- `NINJA_STATUS_FINISHED`, which is printed after an edge finishes.
 
 Several placeholders are available:
 
@@ -208,9 +211,13 @@ specified by `-j` or its default)
 `%e`:: Elapsed time in seconds.  _(Available since Ninja 1.2.)_
 `%%`:: A plain `%` character.
 
-The default progress status is `"[%f/%t] "` (note the trailing space
-to separate from the build rule). Another example of possible progress status
-could be `"[%u/%r/%f] "`.
+The default progress status for `NINJA_STATUS` is `"[%f/%t] "` (note the
+trailing space to separate from the build rule). Another example of possible
+progress status could be `"[%u/%r/%f] "`.
+
+`NINJA_STATUS_STARTED` and `NINJA_STATUS_FINISHED` both default to unset,
+causing them not to be used. If either of them are set, then `NINJA_STATUS` will
+not be used.
 
 Extra tools
 ~~~~~~~~~~~

--- a/src/build.h
+++ b/src/build.h
@@ -217,7 +217,7 @@ struct BuildStatus {
                               EdgeStatus kEdgeFinished) const;
 
  private:
-  void PrintStatus(Edge* edge, EdgeStatus status);
+  void PrintStatus(Edge* edge, EdgeStatus status, const char* format);
 
   const BuildConfig& config_;
 
@@ -235,6 +235,12 @@ struct BuildStatus {
 
   /// The custom progress status format to use.
   const char* progress_status_format_;
+
+  /// An optional custom progress status format to use when an edge is started.
+  const char* progress_status_format_started_;
+
+  /// An optional custom progress status format to use when an edge is finished.
+  const char* progress_status_format_finished_;
 
   template<size_t S>
   void snprinfRate(double rate, char(&buf)[S], const char* format) const {


### PR DESCRIPTION
I had a thought that this might be useful. https://github.com/ninja-build/ninja/pull/999 has vaguely bugged me on Windows since now it looks like I'm waiting for the last .cc file to compile, when it's actually of course the link.

Also, with a simple further addition to the %-formats to include a job-slot-index, I think #1020 could then be implemented as a simple (?) filter.