### PR TITLE
Tidy up rate snprintf'ing helper

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -220,14 +220,14 @@ string BuildStatus::FormatProgressStatus(
         // Overall finished edges per second.
       case 'o':
         overall_rate_.UpdateRate(finished_edges_);
-        snprinfRate(overall_rate_.rate(), buf, "%.1f");
+        SnprintfRate(overall_rate_.rate(), buf, "%.1f");
         out += buf;
         break;
 
         // Current rate, average over the last '-j' jobs.
       case 'c':
         current_rate_.UpdateRate(finished_edges_);
-        snprinfRate(current_rate_.rate(), buf, "%.1f");
+        SnprintfRate(current_rate_.rate(), buf, "%.1f");
         out += buf;
         break;
 

--- a/src/build.h
+++ b/src/build.h
@@ -212,9 +212,9 @@ struct BuildStatus {
   /// See the user manual for more information about the available
   /// placeholders.
   /// @param progress_status_format The format of the progress status.
-  /// @param finished True if the edge being printed just finished
+  /// @param status The status of the edge.
   string FormatProgressStatus(const char* progress_status_format,
-                              EdgeStatus kEdgeFinished) const;
+                              EdgeStatus status) const;
 
  private:
   void PrintStatus(Edge* edge, EdgeStatus status);
@@ -237,9 +237,11 @@ struct BuildStatus {
   const char* progress_status_format_;
 
   template<size_t S>
-  void snprinfRate(double rate, char(&buf)[S], const char* format) const {
-    if (rate == -1) snprintf(buf, S, "?");
-    else            snprintf(buf, S, format, rate);
+  void SnprintfRate(double rate, char(&buf)[S], const char* format) const {
+    if (rate == -1)
+      snprintf(buf, S, "?");
+    else
+      snprintf(buf, S, format, rate);
   }
 
   struct RateInfo {


### PR DESCRIPTION
Fix minor typo in "snprinfRate" (no 't') and the doc comment.
