### PR TITLE
Improve error message when a depfile contains a bad path

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -422,8 +422,10 @@ bool ImplicitDepLoader::LoadDepFile(Edge* edge, const string& path,
 
   unsigned int unused;
   if (!CanonicalizePath(const_cast<char*>(depfile.out_.str_),
-                        &depfile.out_.len_, &unused, err))
+                        &depfile.out_.len_, &unused, err)) {
+    *err = path + ": " + *err;
     return false;
+  }
 
   // Check that this depfile matches the edge's output, if not return false to
   // mark the edge as dirty.


### PR DESCRIPTION
Debugging "ninja: error: empty path" is not fun, so make the error
message mention the depfile name.
