### PR TITLE
Use ninja startup as time base for the ninja_log

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -73,7 +73,6 @@ bool DryRunCommandRunner::WaitForCommand(Result* result) {
 
 BuildStatus::BuildStatus(const BuildConfig& config)
     : config_(config),
-      start_time_millis_(GetTimeMillis()),
       started_edges_(0), finished_edges_(0), total_edges_(0),
       progress_status_format_(NULL),
       overall_rate_(), current_rate_(config.parallelism) {
@@ -92,7 +91,7 @@ void BuildStatus::PlanHasTotalEdges(int total) {
 }
 
 void BuildStatus::BuildEdgeStarted(Edge* edge) {
-  int start_time = (int)(GetTimeMillis() - start_time_millis_);
+  int start_time = (int)(GetTimeMillis() - config_.start_time_millis_);
   running_edges_.insert(make_pair(edge, start_time));
   ++started_edges_;
 
@@ -114,7 +113,7 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
 
   RunningEdgeMap::iterator i = running_edges_.find(edge);
   *start_time = i->second;
-  *end_time = (int)(now - start_time_millis_);
+  *end_time = (int)(now - config_.start_time_millis_);
   running_edges_.erase(i);
 
   if (edge->use_console())

--- a/src/build.h
+++ b/src/build.h
@@ -124,7 +124,8 @@ struct CommandRunner {
 /// Options (e.g. verbosity, parallelism) passed to a build.
 struct BuildConfig {
   BuildConfig() : verbosity(NORMAL), dry_run(false), parallelism(1),
-                  failures_allowed(1), max_load_average(-0.0f) {}
+                  failures_allowed(1), max_load_average(-0.0f),
+                  start_time_millis_(GetTimeMillis()) {}
 
   enum Verbosity {
     NORMAL,
@@ -138,6 +139,9 @@ struct BuildConfig {
   /// The maximum load average we must not exceed. A negative value
   /// means that we do not have any limit.
   double max_load_average;
+
+  // Time the build started.
+  int64_t start_time_millis_;
 };
 
 /// Builder wraps the build process: starting commands, updating status.
@@ -220,9 +224,6 @@ struct BuildStatus {
   void PrintStatus(Edge* edge, EdgeStatus status);
 
   const BuildConfig& config_;
-
-  /// Time the build started.
-  int64_t start_time_millis_;
 
   int started_edges_, finished_edges_, total_edges_;
 


### PR DESCRIPTION
Currently, the time base used for the ninja log is reset for every build, including if the build.ninja is regenerated and the build restarts. It also won't include the manifest read time - in most cases that's minimal, but ours is several seconds.

For our builds that required regen, this caused the log to look like:

```
  0  3     ...
  1  4     ...
  4  1697  ... out/build.ninja
  0  5     ...
  1  6     ...
  5  10    ...
```

With this patch, it looks more like:

```
  3337  3340  ...
  3338  3341  ...
  3341  5034  ... out/build.ninja
  9487  9492  ...
  9488  9493  ...
  9492  9497  ...
```

Then https://github.com/nico/ninjatracing can create proper traces that show the relation between the restarts, and can account for the initial setup overhead.