### PR TITLE
Add a new deps format for a newline-separate list of files.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -889,10 +889,11 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
       deps_nodes->push_back(state_->GetNode(*i, ~0u));
     }
   } else
-  if (deps_type == "gcc") {
+  if (deps_type == "gcc" || deps_type == "list") {
     string depfile = result->edge->GetUnescapedDepfile();
     if (depfile.empty()) {
-      *err = string("edge with deps=gcc but no depfile makes no sense");
+      *err = string(
+          "edge with deps=gcc or deps=list but no depfile makes no sense");
       return false;
     }
 
@@ -911,8 +912,12 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
       return true;
 
     DepfileParser deps;
-    if (!deps.Parse(&content, err))
-      return false;
+    if (deps_type == "gcc") {
+      if (!deps.ParseGcc(&content, err))
+        return false;
+    } else if (deps_type == "list") {
+      deps.ParseList(content);
+    }
 
     // XXX check depfile matches expected output.
     deps_nodes->reserve(deps.ins_.size());

--- a/src/depfile_parser.cc
+++ b/src/depfile_parser.cc
@@ -29,7 +29,7 @@
 // otherwise they are passed through verbatim.
 // If anyone actually has depfiles that rely on the more complicated
 // behavior we can adjust this.
-bool DepfileParser::Parse(string* content, string* err) {
+bool DepfileParser::ParseGcc(string* content, string* err) {
   // in: current parser input point.
   // end: end of input.
   // parsing_targets: whether we are parsing targets or dependencies.
@@ -239,4 +239,18 @@ yy16:
     return false;
   }
   return true;
+}
+
+void DepfileParser::ParseList(const string& content) {
+  size_t start = 0;
+  while (start < content.size()) {
+    size_t end = content.find_first_of("\r\n", start);
+    if (end == string::npos)
+      end = content.size();
+
+    int len = end - start;
+    if (len > 0)
+      ins_.push_back(StringPiece(&content[start], len));
+    start = end + 1;
+  }
 }

--- a/src/depfile_parser.h
+++ b/src/depfile_parser.h
@@ -23,12 +23,28 @@ using namespace std;
 
 /// Parser for the dependency information emitted by gcc's -M flags.
 struct DepfileParser {
-  /// Parse an input file.  Input must be NUL-terminated.
+  /// Parse an input file with GCC-formatted deps.  Input must be
+  /// NUL-terminated.
   /// Warning: may mutate the content in-place and parsed StringPieces are
   /// pointers within it.
-  bool Parse(string* content, string* err);
+  bool ParseGcc(string* content, string* err);
+
+  /// Parses the "list" format of a dep file, where the format is one-file-per
+  /// line with no other transformations applied. Can not fail.
+  /// Warning: parsed StringPieces are pointers to within the content.
+  void ParseList(const string& content);
 
   StringPiece out_;
+  vector<StringPiece> ins_;
+};
+
+/// Parser for the "list" format for depfiles (file-per-line).
+struct DepfileListParser {
+  /// Parse an input file. This format is very simple so there are no errors
+  /// that can be generated.
+  /// Warning: parsed StringPieces are pointers within the content string.
+  void Parse(const string& content);
+
   vector<StringPiece> ins_;
 };
 

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -415,7 +415,7 @@ bool ImplicitDepLoader::LoadDepFile(Edge* edge, const string& path,
 
   DepfileParser depfile;
   string depfile_err;
-  if (!depfile.Parse(&content, &depfile_err)) {
+  if (!depfile.ParseGcc(&content, &depfile_err)) {
     *err = path + ": " + depfile_err;
     return false;
   }


### PR DESCRIPTION
Simplifies integration with scripts which no longer need to write a
Makefile format. The Makefile format is confusing in the presence of
multiple outputs, and has complex escaping and quoting rules.

The new list format has no escaping rules as the format is a newline-
separated list of literal filenames.