### PR TITLE
Only run SubprocessTest.SetWithLots on FreeBSD when ppoll() exists.

### DIFF
--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -24,13 +24,6 @@
 #include <sys/wait.h>
 #include <spawn.h>
 
-#ifdef __FreeBSD__
-#  include <sys/param.h>
-#  if defined USE_PPOLL && __FreeBSD_version < 1002000
-#    undef USE_PPOLL
-#  endif
-#endif
-
 extern char** environ;
 
 #include "util.h"

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -26,6 +26,14 @@ using namespace std;
 #include <signal.h>
 #endif
 
+// ppoll() exists on FreeBSD, but only on newer versions.
+#ifdef __FreeBSD__
+#  include <sys/param.h>
+#  if defined USE_PPOLL && __FreeBSD_version < 1002000
+#    undef USE_PPOLL
+#  endif
+#endif
+
 #include "exit_status.h"
 
 /// Subprocess wraps a single async subprocess.  It is entirely

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -214,9 +214,7 @@ TEST_F(SubprocessTest, SetWithMulti) {
   }
 }
 
-// OS X's process limit is less than 1025 by default
-// (|sysctl kern.maxprocperuid| is 709 on 10.7 and 10.8 and less prior to that).
-#if !defined(__APPLE__) && !defined(_WIN32)
+#if defined(USE_PPOLL)
 TEST_F(SubprocessTest, SetWithLots) {
   // Arbitrary big number; needs to be over 1024 to confirm we're no longer
   // hostage to pselect.


### PR DESCRIPTION
Should fix #1189 after #1185.