### PR TITLE
Optimize lexing and parsing

### DIFF
--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -107,12 +107,7 @@ string EvalString::Evaluate(Env* env) const {
 }
 
 void EvalString::AddText(StringPiece text) {
-  // Add it to the end of an existing RAW token if possible.
-  if (!parsed_.empty() && parsed_.back().second == RAW) {
-    parsed_.back().first.append(text.str_, text.len_);
-  } else {
-    parsed_.push_back(make_pair(text.AsString(), RAW));
-  }
+  parsed_.push_back(make_pair(text.AsString(), RAW));
 }
 void EvalString::AddSpecial(StringPiece text) {
   parsed_.push_back(make_pair(text.AsString(), SPECIAL));

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -272,6 +272,12 @@ string EdgeEnv::MakePathList(vector<Node*>::iterator begin,
                              vector<Node*>::iterator end,
                              char sep) {
   string result;
+  size_t len = 0;
+  for (vector<Node*>::iterator i = begin; i != end; ++i) {
+    len += (*i)->path().size() + 1;
+  }
+
+  result.reserve(len);
   for (vector<Node*>::iterator i = begin; i != end; ++i) {
     if (!result.empty())
       result.push_back(sep);

--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -621,7 +621,7 @@ yy100:
   return true;
 }
 
-bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
+bool Lexer::ReadPath(EvalString* eval, string* err) {
   const char* p = ofs_;
   const char* q;
   const char* start;
@@ -668,22 +668,22 @@ bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
 	if (yych <= ' ') {
 		if (yych <= '\n') {
 			if (yych <= 0x00) goto yy110;
-			if (yych >= '\n') goto yy107;
+			if (yych >= '\n') goto yy105;
 		} else {
-			if (yych == '\r') goto yy105;
-			if (yych >= ' ') goto yy107;
+			if (yych == '\r') goto yy107;
+			if (yych >= ' ') goto yy105;
 		}
 	} else {
 		if (yych <= '9') {
 			if (yych == '$') goto yy109;
 		} else {
-			if (yych <= ':') goto yy107;
-			if (yych == '|') goto yy107;
+			if (yych <= ':') goto yy105;
+			if (yych == '|') goto yy105;
 		}
 	}
 	++p;
 	yych = *p;
-	goto yy140;
+	goto yy139;
 yy104:
 	{
       eval->AddText(StringPiece(start, p - start));
@@ -691,23 +691,17 @@ yy104:
     }
 yy105:
 	++p;
+yy106:
+	{
+      p = start;
+      break;
+    }
+yy107:
+	++p;
 	if ((yych = *p) == '\n') goto yy137;
 	{
       last_token_ = start;
       return Error(DescribeLastError(), err);
-    }
-yy107:
-	++p;
-	{
-      if (path) {
-        p = start;
-        break;
-      } else {
-        if (*start == '\n')
-          break;
-        eval->AddText(StringPiece(start, 1));
-        continue;
-      }
     }
 yy109:
 	yych = *++p;
@@ -841,18 +835,14 @@ yy134:
       continue;
     }
 yy137:
-	++p;
-	{
-      if (path)
-        p = start;
-      break;
-    }
-yy139:
+	yych = *++p;
+	goto yy106;
+yy138:
 	++p;
 	yych = *p;
-yy140:
+yy139:
 	if (yybm[0+yych] & 128) {
-		goto yy139;
+		goto yy138;
 	}
 	goto yy104;
 }
@@ -860,8 +850,233 @@ yy140:
   }
   last_token_ = start;
   ofs_ = p;
-  if (path)
-    EatWhitespace();
+  EatWhitespace();
+  return true;
+}
+
+bool Lexer::ReadVarValue(EvalString* eval, string* err) {
+  const char* p = ofs_;
+  const char* q;
+  const char* start;
+  for (;;) {
+    start = p;
+    
+{
+	unsigned char yych;
+	static const unsigned char yybm[] = {
+		  0, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128,   0, 128, 128,   0, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		144, 128, 128, 128,   0, 128, 128, 128, 
+		128, 128, 128, 128, 128, 224, 160, 128, 
+		224, 224, 224, 224, 224, 224, 224, 224, 
+		224, 224, 128, 128, 128, 128, 128, 128, 
+		128, 224, 224, 224, 224, 224, 224, 224, 
+		224, 224, 224, 224, 224, 224, 224, 224, 
+		224, 224, 224, 224, 224, 224, 224, 224, 
+		224, 224, 224, 128, 128, 128, 128, 224, 
+		128, 224, 224, 224, 224, 224, 224, 224, 
+		224, 224, 224, 224, 224, 224, 224, 224, 
+		224, 224, 224, 224, 224, 224, 224, 224, 
+		224, 224, 224, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+		128, 128, 128, 128, 128, 128, 128, 128, 
+	};
+	yych = *p;
+	if (yych <= '\f') {
+		if (yych <= 0x00) goto yy150;
+		if (yych == '\n') goto yy144;
+	} else {
+		if (yych <= '\r') goto yy146;
+		if (yych == '$') goto yy148;
+	}
+	++p;
+	yych = *p;
+	goto yy179;
+yy143:
+	{
+      eval->AddText(StringPiece(start, p - start));
+      continue;
+    }
+yy144:
+	++p;
+yy145:
+	{
+      break;
+    }
+yy146:
+	++p;
+	if ((yych = *p) == '\n') goto yy177;
+	{
+      eval->AddText(StringPiece(start, 1));
+      continue;
+    }
+yy148:
+	++p;
+	if ((yych = *p) <= '-') {
+		if (yych <= 0x1F) {
+			if (yych <= '\n') {
+				if (yych <= '\t') goto yy152;
+				goto yy164;
+			} else {
+				if (yych == '\r') goto yy154;
+				goto yy152;
+			}
+		} else {
+			if (yych <= '#') {
+				if (yych <= ' ') goto yy155;
+				goto yy152;
+			} else {
+				if (yych <= '$') goto yy157;
+				if (yych <= ',') goto yy152;
+				goto yy159;
+			}
+		}
+	} else {
+		if (yych <= 'Z') {
+			if (yych <= '9') {
+				if (yych <= '/') goto yy152;
+				goto yy159;
+			} else {
+				if (yych <= ':') goto yy161;
+				if (yych <= '@') goto yy152;
+				goto yy159;
+			}
+		} else {
+			if (yych <= '`') {
+				if (yych == '_') goto yy159;
+				goto yy152;
+			} else {
+				if (yych <= 'z') goto yy159;
+				if (yych <= '{') goto yy163;
+				goto yy152;
+			}
+		}
+	}
+	{
+      last_token_ = start;
+      return Error(DescribeLastError(), err);
+    }
+yy150:
+	++p;
+	{
+      last_token_ = start;
+      return Error("unexpected EOF", err);
+    }
+yy152:
+	++p;
+yy153:
+	{
+      last_token_ = start;
+      return Error("bad $-escape (literal $ must be written as $$)", err);
+    }
+yy154:
+	yych = *++p;
+	if (yych == '\n') goto yy174;
+	goto yy153;
+yy155:
+	++p;
+	{
+      eval->AddText(StringPiece(" ", 1));
+      continue;
+    }
+yy157:
+	++p;
+	{
+      eval->AddText(StringPiece("$", 1));
+      continue;
+    }
+yy159:
+	++p;
+	yych = *p;
+	goto yy173;
+yy160:
+	{
+      eval->AddSpecial(StringPiece(start + 1, p - start - 1));
+      continue;
+    }
+yy161:
+	++p;
+	{
+      eval->AddText(StringPiece(":", 1));
+      continue;
+    }
+yy163:
+	yych = *(q = ++p);
+	if (yybm[0+yych] & 32) {
+		goto yy167;
+	}
+	goto yy153;
+yy164:
+	++p;
+	yych = *p;
+	if (yybm[0+yych] & 16) {
+		goto yy164;
+	}
+	{
+      continue;
+    }
+yy167:
+	++p;
+	yych = *p;
+	if (yybm[0+yych] & 32) {
+		goto yy167;
+	}
+	if (yych == '}') goto yy170;
+	p = q;
+	goto yy153;
+yy170:
+	++p;
+	{
+      eval->AddSpecial(StringPiece(start + 2, p - start - 3));
+      continue;
+    }
+yy172:
+	++p;
+	yych = *p;
+yy173:
+	if (yybm[0+yych] & 64) {
+		goto yy172;
+	}
+	goto yy160;
+yy174:
+	++p;
+	yych = *p;
+	if (yych == ' ') goto yy174;
+	{
+      continue;
+    }
+yy177:
+	yych = *++p;
+	goto yy145;
+yy178:
+	++p;
+	yych = *p;
+yy179:
+	if (yybm[0+yych] & 128) {
+		goto yy178;
+	}
+	goto yy143;
+}
+
+  }
+  last_token_ = start;
+  ofs_ = p;
   // Non-path strings end in newlines, so there's no whitespace to eat.
   return true;
 }

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -76,15 +76,11 @@ struct Lexer {
   /// Read a path (complete with $escapes).
   /// Returns false only on error, returned path may be empty if a delimiter
   /// (space, newline) is hit.
-  bool ReadPath(EvalString* path, string* err) {
-    return ReadEvalString(path, true, err);
-  }
+  bool ReadPath(EvalString* path, string* err);
 
   /// Read the value side of a var = value line (complete with $escapes).
   /// Returns false only on error.
-  bool ReadVarValue(EvalString* value, string* err) {
-    return ReadEvalString(value, false, err);
-  }
+  bool ReadVarValue(EvalString* value, string* err);
 
   /// Construct an error message with context.
   bool Error(const string& message, string* err);

--- a/src/lexer.in.cc
+++ b/src/lexer.in.cc
@@ -197,7 +197,7 @@ bool Lexer::ReadIdent(string* out) {
   return true;
 }
 
-bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
+bool Lexer::ReadPath(EvalString* eval, string* err) {
   const char* p = ofs_;
   const char* q;
   const char* start;
@@ -208,21 +208,9 @@ bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
       eval->AddText(StringPiece(start, p - start));
       continue;
     }
-    "\r\n" {
-      if (path)
-        p = start;
+    "\r\n"|[ :|\n] {
+      p = start;
       break;
-    }
-    [ :|\n] {
-      if (path) {
-        p = start;
-        break;
-      } else {
-        if (*start == '\n')
-          break;
-        eval->AddText(StringPiece(start, 1));
-        continue;
-      }
     }
     "$$" {
       eval->AddText(StringPiece("$", 1));
@@ -266,8 +254,70 @@ bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
   }
   last_token_ = start;
   ofs_ = p;
-  if (path)
-    EatWhitespace();
+  EatWhitespace();
+  return true;
+}
+
+bool Lexer::ReadVarValue(EvalString* eval, string* err) {
+  const char* p = ofs_;
+  const char* q;
+  const char* start;
+  for (;;) {
+    start = p;
+    /*!re2c
+    [^$\r\n\000]+ {
+      eval->AddText(StringPiece(start, p - start));
+      continue;
+    }
+    "\r\n" | "\n" {
+      break;
+    }
+    "\r" {
+      eval->AddText(StringPiece(start, 1));
+      continue;
+    }
+    "$$" {
+      eval->AddText(StringPiece("$", 1));
+      continue;
+    }
+    "$ " {
+      eval->AddText(StringPiece(" ", 1));
+      continue;
+    }
+    "$\r\n"[ ]* {
+      continue;
+    }
+    "$\n"[ ]* {
+      continue;
+    }
+    "${"varname"}" {
+      eval->AddSpecial(StringPiece(start + 2, p - start - 3));
+      continue;
+    }
+    "$"simple_varname {
+      eval->AddSpecial(StringPiece(start + 1, p - start - 1));
+      continue;
+    }
+    "$:" {
+      eval->AddText(StringPiece(":", 1));
+      continue;
+    }
+    "$". {
+      last_token_ = start;
+      return Error("bad $-escape (literal $ must be written as $$)", err);
+    }
+    nul {
+      last_token_ = start;
+      return Error("unexpected EOF", err);
+    }
+    [^] {
+      last_token_ = start;
+      return Error(DescribeLastError(), err);
+    }
+    */
+  }
+  last_token_ = start;
+  ofs_ = p;
   // Non-path strings end in newlines, so there's no whitespace to eat.
   return true;
 }

--- a/src/lexer_test.cc
+++ b/src/lexer_test.cc
@@ -33,7 +33,7 @@ TEST(Lexer, ReadEvalStringEscapes) {
   string err;
   EXPECT_TRUE(lexer.ReadVarValue(&eval, &err));
   EXPECT_EQ("", err);
-  EXPECT_EQ("[ $ab c: cde]",
+  EXPECT_EQ("[ ][$][ab c][:][ ][cde]",
             eval.Serialize());
 }
 

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -195,7 +195,7 @@ TEST_F(ParserTest, Continuation) {
   ASSERT_EQ(2u, state.bindings_.GetRules().size());
   const Rule* rule = state.bindings_.GetRules().begin()->second;
   EXPECT_EQ("link", rule->name());
-  EXPECT_EQ("[foo bar baz]", rule->GetBinding("command")->Serialize());
+  EXPECT_EQ("[foo bar ][baz]", rule->GetBinding("command")->Serialize());
 }
 
 TEST_F(ParserTest, Backslash) {


### PR DESCRIPTION
These two patches add a few small optimizations to the lexing and parsing code that were found with vallgrind --tool=callgrind and verified with perf stat:
   - Reserve string sizes before repeated appends in EdgeEnv::MakePathList
   - Separate Lexer::ReadPath and Lexer::ReadVarValue so that ReadVarValue doesn't split on whitespace
   - Use a computed lookup table in IsKnownShellSafeCharacter