### PR TITLE
Amalgamate sources into a single .cc file when bootstrapping

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -566,7 +566,7 @@ if options.bootstrap:
 
 libninja_objs = []
 for name in srcs:
-  libninja_objs += cxxbuild(name, order_only=order_only_deps.get(name))
+    libninja_objs += cxxbuild(name, order_only=order_only_deps.get(name))
 
 if platform.is_msvc():
     ninja_lib = n.build(built('ninja.lib'), 'ar', libninja_objs)

--- a/src/amalgamate.py
+++ b/src/amalgamate.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+
+import sys
+import re
+import os
+
+INCLUDE_RE = re.compile('^#include "([^"]*)"')
+
+def parse_include(line):
+  match = INCLUDE_RE.match(line)
+  return match.groups()[0] if match else None
+
+def exists(name):
+  if os.path.isfile(name):
+    return name
+  else:
+    return None
+
+class Amalgamator:
+  def __init__(self, output_file):
+    self.included = set()
+    self.output_c = open(output_file, "w")
+
+  def add_src(self, infile_name):
+    for line in open(infile_name):
+      include = parse_include(line)
+      if include is not None:
+        if include not in self.included:
+          self.included.add(include)
+          self.add_src(exists(include) or exists(os.path.join("src", include)))
+      else:
+        self.output_c.write(line)
+
+# ---- main ----
+
+output_file = sys.argv[1]
+amalgamator = Amalgamator(output_file)
+
+for filename in sys.argv[2:]:
+  amalgamator.add_src(filename.strip())

--- a/src/amalgamate.py
+++ b/src/amalgamate.py
@@ -7,29 +7,32 @@ import os
 INCLUDE_RE = re.compile('^#include "([^"]*)"')
 
 def parse_include(line):
-  match = INCLUDE_RE.match(line)
-  return match.groups()[0] if match else None
+    match = INCLUDE_RE.match(line)
+    return match.groups()[0] if match else None
 
 def exists(name):
-  if os.path.isfile(name):
-    return name
-  else:
-    return None
+    if os.path.isfile(name):
+        return name
+    else:
+        return None
+
+def trynames(name):
+    return exists(name) or exists(os.path.join("src", name))
 
 class Amalgamator:
-  def __init__(self, output_file):
-    self.included = set()
-    self.output_c = open(output_file, "w")
+    def __init__(self, output_file):
+        self.included = set()
+        self.output_c = open(output_file, "w")
 
-  def add_src(self, infile_name):
-    for line in open(infile_name):
-      include = parse_include(line)
-      if include is not None:
-        if include not in self.included:
-          self.included.add(include)
-          self.add_src(exists(include) or exists(os.path.join("src", include)))
-      else:
-        self.output_c.write(line)
+    def add_src(self, infile_name):
+        for line in open(infile_name):
+            include = parse_include(line)
+            if include is not None:
+                if include not in self.included:
+                    self.included.add(include)
+                    self.add_src(trynames(include))
+            else:
+                self.output_c.write(line)
 
 # ---- main ----
 
@@ -37,4 +40,4 @@ output_file = sys.argv[1]
 amalgamator = Amalgamator(output_file)
 
 for filename in sys.argv[2:]:
-  amalgamator.add_src(filename.strip())
+    amalgamator.add_src(filename.strip())

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -45,9 +45,9 @@
 
 namespace {
 
-const char kFileSignature[] = "# ninja log v%d\n";
+const char kLogFileSignature[] = "# ninja log v%d\n";
 const int kOldestSupportedVersion = 4;
-const int kCurrentVersion = 5;
+const int kLogCurrentVersion = 5;
 
 // 64bit MurmurHash2, by Austin Appleby
 #if defined(_MSC_VER)
@@ -135,7 +135,7 @@ bool BuildLog::OpenForWrite(const string& path, const BuildLogUser& user,
   fseek(log_file_, 0, SEEK_END);
 
   if (ftell(log_file_) == 0) {
-    if (fprintf(log_file_, kFileSignature, kCurrentVersion) < 0) {
+    if (fprintf(log_file_, kLogFileSignature, kLogCurrentVersion) < 0) {
       *err = strerror(errno);
       return false;
     }
@@ -248,7 +248,7 @@ bool BuildLog::Load(const string& path, string* err) {
   char* line_end = 0;
   while (reader.ReadLine(&line_start, &line_end)) {
     if (!log_version) {
-      sscanf(line_start, kFileSignature, &log_version);
+      sscanf(line_start, kLogFileSignature, &log_version);
 
       if (log_version < kOldestSupportedVersion) {
         *err = ("build log version invalid, perhaps due to being too old; "
@@ -335,7 +335,7 @@ bool BuildLog::Load(const string& path, string* err) {
   // - if it's getting large
   int kMinCompactionEntryCount = 100;
   int kCompactionRatio = 3;
-  if (log_version < kCurrentVersion) {
+  if (log_version < kLogCurrentVersion) {
     needs_recompaction_ = true;
   } else if (total_entry_count > kMinCompactionEntryCount &&
              total_entry_count > unique_entry_count * kCompactionRatio) {
@@ -370,7 +370,7 @@ bool BuildLog::Recompact(const string& path, const BuildLogUser& user,
     return false;
   }
 
-  if (fprintf(f, kFileSignature, kCurrentVersion) < 0) {
+  if (fprintf(f, kLogFileSignature, kLogCurrentVersion) < 0) {
     *err = strerror(errno);
     fclose(f);
     return false;

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -29,8 +29,8 @@
 
 // The version is stored as 4 bytes after the signature and also serves as a
 // byte order mark. Signature and version combined are 16 bytes long.
-const char kFileSignature[] = "# ninjadeps\n";
-const int kCurrentVersion = 3;
+const char kDepsFileSignature[] = "# ninjadeps\n";
+const int kDepsCurrentVersion = 3;
 
 // Record size is currently limited to less than the full 32 bit, due to
 // internal buffers having to have this size.
@@ -45,7 +45,7 @@ bool DepsLog::OpenForWrite(const string& path, string* err) {
     if (!Recompact(path, err))
       return false;
   }
-  
+
   file_ = fopen(path.c_str(), "ab");
   if (!file_) {
     *err = strerror(errno);
@@ -61,11 +61,12 @@ bool DepsLog::OpenForWrite(const string& path, string* err) {
   fseek(file_, 0, SEEK_END);
 
   if (ftell(file_) == 0) {
-    if (fwrite(kFileSignature, sizeof(kFileSignature) - 1, 1, file_) < 1) {
+    if (fwrite(kDepsFileSignature, sizeof(kDepsFileSignature) - 1, 1, file_) <
+        1) {
       *err = strerror(errno);
       return false;
     }
-    if (fwrite(&kCurrentVersion, 4, 1, file_) < 1) {
+    if (fwrite(&kDepsCurrentVersion, 4, 1, file_) < 1) {
       *err = strerror(errno);
       return false;
     }
@@ -180,8 +181,8 @@ bool DepsLog::Load(const string& path, State* state, string* err) {
   // But the v1 format could sometimes (rarely) end up with invalid data, so
   // don't migrate v1 to v3 to force a rebuild. (v2 only existed for a few days,
   // and there was no release with it, so pretend that it never happened.)
-  if (!valid_header || strcmp(buf, kFileSignature) != 0 ||
-      version != kCurrentVersion) {
+  if (!valid_header || strcmp(buf, kDepsFileSignature) != 0 ||
+      version != kDepsCurrentVersion) {
     if (version == 1)
       *err = "deps log version change; rebuilding";
     else


### PR DESCRIPTION
This PR needs some work still, but I wanted to get feedback before polishing/fixing it.

The ultimate goal here is to lower the barrier to entry to using Ninja. You should be able to just drop configure.py and ninja-bootstrap.cc into your project, and now your project can use Ninja without worrying about whether end-users have installed Ninja or not (or have the right version). You bootstrap in this case using simply: `./configure.py --bootstrap_from_amalgamation`.

To reduce the number of code-paths/variations, I made regular bootstrapping build from the amalgamation also. And to make things more principled/consistent, `ninja.bootstrap` is always built from `ninja-bootstrap.cc` and `ninja` is always built in the regular way, instead of spawning a ninja that will attempt to overwrite itself.

As a side benefit, this makes bootstrapping faster (since it's only compiling one file):

```
Right now:
$ time ./configure.py --bootstrap
bootstrapping ninja...
wrote build.ninja.
bootstrap complete.  rebuilding...
[27/27] LINK ninja

real    0m10.444s
user    0m20.639s
sys     0m1.579s

With my change:
$ time ./configure.py --bootstrap
bootstrapping ninja...
wrote build.ninja.
bootstrap complete.  rebuilding...
[26/26] LINK ninja

real    0m6.364s
user    0m16.623s
sys     0m1.148s
```

The `--bootstrap_from_amalgamation` flag was added for the case where you want to bootstrap directly from the amalgamation (the case I described above where you want to use Ninja in your project).