### PR TITLE
add verbosity to environment of created processes

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -537,7 +537,7 @@ bool RealCommandRunner::CanRunMore() {
 
 bool RealCommandRunner::StartCommand(Edge* edge) {
   string command = edge->EvaluateCommand();
-  Subprocess* subproc = subprocs_.Add(command, edge->use_console());
+  Subprocess* subproc = subprocs_.Add(command, config_.verbosity, edge->use_console());
   if (!subproc)
     return false;
   subproc_to_edge_.insert(make_pair(subproc, edge));

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -26,6 +26,8 @@ using namespace std;
 #include <signal.h>
 #endif
 
+#include "build.h"
+
 // ppoll() exists on FreeBSD, but only on newer versions.
 #ifdef __FreeBSD__
 #  include <sys/param.h>
@@ -53,7 +55,7 @@ struct Subprocess {
 
  private:
   Subprocess(bool use_console);
-  bool Start(struct SubprocessSet* set, const string& command);
+  bool Start(struct SubprocessSet* set, const string& command, const BuildConfig::Verbosity& verbosity);
   void OnPipeReady();
 
   string buf_;
@@ -84,7 +86,7 @@ struct SubprocessSet {
   SubprocessSet();
   ~SubprocessSet();
 
-  Subprocess* Add(const string& command, bool use_console = false);
+  Subprocess* Add(const string& command, const BuildConfig::Verbosity& verbosity, bool use_console = false);
   bool DoWork();
   Subprocess* NextFinished();
   void Clear();

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -40,7 +40,7 @@ struct SubprocessTest : public testing::Test {
 
 // Run a command that fails and emits to stderr.
 TEST_F(SubprocessTest, BadCommandStderr) {
-  Subprocess* subproc = subprocs_.Add("cmd /c ninja_no_such_command");
+  Subprocess* subproc = subprocs_.Add("cmd /c ninja_no_such_command", BuildConfig::NORMAL);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -54,7 +54,7 @@ TEST_F(SubprocessTest, BadCommandStderr) {
 
 // Run a command that does not exist
 TEST_F(SubprocessTest, NoSuchCommand) {
-  Subprocess* subproc = subprocs_.Add("ninja_no_such_command");
+  Subprocess* subproc = subprocs_.Add("ninja_no_such_command", BuildConfig::NORMAL);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -73,7 +73,7 @@ TEST_F(SubprocessTest, NoSuchCommand) {
 #ifndef _WIN32
 
 TEST_F(SubprocessTest, InterruptChild) {
-  Subprocess* subproc = subprocs_.Add("kill -INT $$");
+  Subprocess* subproc = subprocs_.Add("kill -INT $$", BuildConfig::NORMAL);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -84,7 +84,7 @@ TEST_F(SubprocessTest, InterruptChild) {
 }
 
 TEST_F(SubprocessTest, InterruptParent) {
-  Subprocess* subproc = subprocs_.Add("kill -INT $PPID ; sleep 1");
+  Subprocess* subproc = subprocs_.Add("kill -INT $PPID ; sleep 1", BuildConfig::NORMAL);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -97,7 +97,7 @@ TEST_F(SubprocessTest, InterruptParent) {
 }
 
 TEST_F(SubprocessTest, InterruptChildWithSigTerm) {
-  Subprocess* subproc = subprocs_.Add("kill -TERM $$");
+  Subprocess* subproc = subprocs_.Add("kill -TERM $$", BuildConfig::NORMAL);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -108,7 +108,7 @@ TEST_F(SubprocessTest, InterruptChildWithSigTerm) {
 }
 
 TEST_F(SubprocessTest, InterruptParentWithSigTerm) {
-  Subprocess* subproc = subprocs_.Add("kill -TERM $PPID ; sleep 1");
+  Subprocess* subproc = subprocs_.Add("kill -TERM $PPID ; sleep 1", BuildConfig::NORMAL);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -121,7 +121,7 @@ TEST_F(SubprocessTest, InterruptParentWithSigTerm) {
 }
 
 TEST_F(SubprocessTest, InterruptChildWithSigHup) {
-  Subprocess* subproc = subprocs_.Add("kill -HUP $$");
+  Subprocess* subproc = subprocs_.Add("kill -HUP $$", BuildConfig::NORMAL);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -132,7 +132,7 @@ TEST_F(SubprocessTest, InterruptChildWithSigHup) {
 }
 
 TEST_F(SubprocessTest, InterruptParentWithSigHup) {
-  Subprocess* subproc = subprocs_.Add("kill -HUP $PPID ; sleep 1");
+  Subprocess* subproc = subprocs_.Add("kill -HUP $PPID ; sleep 1", BuildConfig::NORMAL);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -148,7 +148,7 @@ TEST_F(SubprocessTest, Console) {
   // Skip test if we don't have the console ourselves.
   if (isatty(0) && isatty(1) && isatty(2)) {
     Subprocess* subproc =
-        subprocs_.Add("test -t 0 -a -t 1 -a -t 2", /*use_console=*/true);
+        subprocs_.Add("test -t 0 -a -t 1 -a -t 2", BuildConfig::NORMAL, /*use_console=*/true);
     ASSERT_NE((Subprocess*)0, subproc);
 
     while (!subproc->Done()) {
@@ -162,7 +162,7 @@ TEST_F(SubprocessTest, Console) {
 #endif
 
 TEST_F(SubprocessTest, SetWithSingle) {
-  Subprocess* subproc = subprocs_.Add(kSimpleCommand);
+  Subprocess* subproc = subprocs_.Add(kSimpleCommand, BuildConfig::NORMAL);
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -188,7 +188,7 @@ TEST_F(SubprocessTest, SetWithMulti) {
   };
 
   for (int i = 0; i < 3; ++i) {
-    processes[i] = subprocs_.Add(kCommands[i]);
+    processes[i] = subprocs_.Add(kCommands[i], BuildConfig::NORMAL);
     ASSERT_NE((Subprocess *) 0, processes[i]);
   }
 
@@ -231,7 +231,7 @@ TEST_F(SubprocessTest, SetWithLots) {
 
   vector<Subprocess*> procs;
   for (size_t i = 0; i < kNumProcs; ++i) {
-    Subprocess* subproc = subprocs_.Add("/bin/echo");
+    Subprocess* subproc = subprocs_.Add("/bin/echo", BuildConfig::NORMAL);
     ASSERT_NE((Subprocess *) 0, subproc);
     procs.push_back(subproc);
   }
@@ -251,7 +251,7 @@ TEST_F(SubprocessTest, SetWithLots) {
 // Verify that a command that attempts to read stdin correctly thinks
 // that stdin is closed.
 TEST_F(SubprocessTest, ReadStdin) {
-  Subprocess* subproc = subprocs_.Add("cat -");
+  Subprocess* subproc = subprocs_.Add("cat -", BuildConfig::NORMAL);
   while (!subproc->Done()) {
     subprocs_.DoWork();
   }


### PR DESCRIPTION
cmake automoc needs VERBOSE=1 in env to print its commands:

cmake generates rules of the form "cd QT && cmake -E cmake_autogen project Debug"
This call to cmake executes the QT moc and uic and rcc compilers which generate files. If any of those calls fail it is impossible to see the actual command lines even if ninja is run with "-v". cmake prints the commands if the environment variable VERBOSE is set - so add this to the current environment.