### PR TITLE
Handle insecure string pickle issue, fixes #1216

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -457,6 +457,8 @@ def has_re2c():
     try:
         proc = subprocess.Popen(['re2c', '-V'], stdout=subprocess.PIPE)
         return int(proc.communicate()[0], 10) >= 1103
+    except ValueError:
+        return False
     except OSError:
         return False
 if has_re2c():


### PR DESCRIPTION
I patched `./configure.py` to catch `ValueError` and silently fail. This results in `./configure.py` reporting `warning: A compatible version of re2c (>= 0.11.3) was not found; changes to src/*.in.cc will not affect your build.` Although not perfect, this fix at least lets people build Ninja from source instead of being stumped by a bug in Python 2.7. It doesn't help people that want to make changes to the code in `src/`, but at least they get this error and know that some additional work needs to be done.