### PR TITLE
[compdb] Expand response files inline based on a switch.

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -697,9 +697,6 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
   argc++;
   argv--;
 
-  bool first = true;
-  vector<char> cwd;
-
   EvaluateCommandMode eval_mode = ECM_NORMAL;
 
   optind = 1;
@@ -723,6 +720,9 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
   }
   argv += optind;
   argc -= optind;
+
+  bool first = true;
+  vector<char> cwd;
 
   do {
     cwd.resize(cwd.size() + 1024);


### PR DESCRIPTION
References to response files in a clang compile_commands.json file can
be tricky to deal with when tooling expects all the command flags to be
present in the 'command' field.

This change introduces a '-x' option to '-t compdb' that will expand
@rspfile style response file invocations inline.

E.g.

```sh
$ ninja -t compdb cc
[
  {
    "directory": "/src/foo",
    "command": "cc -foo -bar @foo.obj.rsp",
    "file": "foo.cc"
  }
]

$ ninja -t compdb -x cc
[
  {
    "directory": "/src/foo",
    "command": "cc -foo -bar foo.cc",
    "file": "foo.cc"
  }
]
```

Does this change seem reasonable?

I tested this manually. The tools are all implemented in `ninja.cc` and none of them seem to have tests. I'd need to refactor that file to expose the tooling for tests. I wanted to check with folks on whether this is a reasonable change before I went ahead and did the necessary reworking of ninja.cc to expose tools for tests.