### PR TITLE
fix GetProcessorCount() on embedded systems like NVIDIA TK1

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -505,7 +505,7 @@ int GetProcessorCount() {
   GetNativeSystemInfo(&info);
   return info.dwNumberOfProcessors;
 #else
-  return sysconf(_SC_NPROCESSORS_ONLN);
+  return sysconf(_SC_NPROCESSORS_CONF);
 #endif
 }
 


### PR DESCRIPTION
Use _SC_NPROCESSORS_CONF rather than _SC_NPROCESSORS_ONLN to
query the number of available CPUs, as on some systems, especially
embedded systems, CPUs may be marked as offline for power saving
reasons.

On an otherwise idle Nvidia TK1 system GetProcessorCount() would
always return 1 just because the other CPUs are not in use, and
then we'd only use 2 out of 4+ cores for compilation.

sched_getaffinity() + CPU_COUNT returns the same as _SC_NPROCESSORS_ONLN
in that case, so does not provide a better solution either.

/proc/cpuinfo will always list all CPUs, but parsing that seems
cumbersome and is likely also less portable.

It's conceivable that there are some cornercases where CONF
returns a higher number than CPUs actually available for use,
but arguably the marginal cost of spawning too many processes
is negligible compared to the cost of not using available cores.