### PR TITLE
Add -o flag for output options for verbosity and raw output

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -123,15 +123,24 @@ struct CommandRunner {
 
 /// Options (e.g. verbosity, parallelism) passed to a build.
 struct BuildConfig {
-  BuildConfig() : verbosity(NORMAL), dry_run(false), parallelism(1),
-                  failures_allowed(1), max_load_average(-0.0f) {}
+  BuildConfig() : verbosity(NORMAL), control_sequences(SMART), dry_run(false),
+                  parallelism(1), failures_allowed(1), max_load_average(-0.0f) {
+  }
 
   enum Verbosity {
     NORMAL,
-    QUIET,  // No output -- used when testing.
-    VERBOSE
+    QUIET,  // No output -- used for output mode "quiet".
+    VERBOSE  // Print all command lines -- used for output mode "verbose".
+  };
+  enum ControlSequences {
+    SMART,  // ninja will decide whether to strip control sequences.
+    KEEP_ALL,  // Never strip control sequences.
+    KEEP_NONE,  // Always strip control sequences.
+    KEEP_COLORS  // Always strip control sequences except for color codes.
   };
   Verbosity verbosity;
+  /// Specifies what control sequences to retain in the output.
+  ControlSequences control_sequences;
   bool dry_run;
   int parallelism;
   int failures_allowed;

--- a/src/util.cc
+++ b/src/util.cc
@@ -476,7 +476,7 @@ static bool islatinalpha(int c) {
   return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 }
 
-string StripAnsiEscapeCodes(const string& in) {
+string StripAnsiEscapeCodes(const string& in, bool preserve_color) {
   string stripped;
   stripped.reserve(in.size());
 
@@ -491,6 +491,17 @@ string StripAnsiEscapeCodes(const string& in) {
     if (i + 1 >= in.size()) break;
     if (in[i + 1] != '[') continue;  // Not a CSI.
     i += 2;
+
+    if (preserve_color) {
+      size_t start = i - 2;
+      // Check for display attributes, e.g. "ESC[4m" or "ESC[31;46m".
+      while (i < in.size() && (isdigit(in[i]) || in[i] == ';'))
+        ++i;
+      if (i < in.size() && in[i] == 'm') {
+        stripped.insert(stripped.size(), in, start, i - start + 1);
+        continue;
+      }
+    }
 
     // Skip everything up to and including the next [a-zA-Z].
     while (i < in.size() && !islatinalpha(in[i]))

--- a/src/util.h
+++ b/src/util.h
@@ -70,8 +70,9 @@ const char* SpellcheckStringV(const string& text,
 /// Like SpellcheckStringV, but takes a NULL-terminated list.
 const char* SpellcheckString(const char* text, ...);
 
-/// Removes all Ansi escape codes (http://www.termsys.demon.co.uk/vtansi.htm).
-string StripAnsiEscapeCodes(const string& in);
+/// Removes Ansi escape codes, optionally preserving color codes (see
+/// http://www.termsys.demon.co.uk/vtansi.htm).
+string StripAnsiEscapeCodes(const string& in, bool preserve_color);
 
 /// @return the number of processors on the machine.  Useful for an initial
 /// guess for how many jobs to run in parallel.  @return 0 on error.


### PR DESCRIPTION
Adds the general-purpose -o flag to address #746, with options for
verbosity (#480) and control sequence stripping (#581, #672, #916). Also
provides the ability to enable both verbose and raw output as a
workaround for #1214 without changing the existing verbose behavior.

-o verbose  show all command lines while building
-o quiet    hide command lines and outputs while building
-o raw      never strip control sequences from output
-o strip    always strip control sequences from output
-o color    strip most control sequences from output, but retain color codes

This patch does not affect Ninja's defaults of normal verbosity and
smart terminal detection for escape sequence stripping.

"-o color" is particularly useful for utilities like `head` and
`less -R` that interpret color codes from stdin and pass this colored
output to stdout. Any valid ANSI color code, of the form:

    `'ESC' '[' [ colors ] 'm'`

where `colors` is a semicolon-delimited list of optional integers:

   `[ n ] [ ';' colors ]`

is retained in its entirety when using "-o color" (any other CSI escape
sequences besides ANSI color codes are still stripped for non-smart
terminals).