### PR TITLE
Fix build in canon_perftest_fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: cpp
 compiler:
   - gcc
   - clang
-script: ./configure.py --bootstrap && ./ninja ninja_test && ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots && ./misc/ninja_syntax_test.py
+script: ./configure.py --bootstrap && ./ninja all && ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots && ./misc/ninja_syntax_test.py

--- a/src/canon_perftest.cc
+++ b/src/canon_perftest.cc
@@ -33,7 +33,7 @@ int main() {
   for (int j = 0; j < 5; ++j) {
     const int kNumRepetitions = 2000000;
     int64_t start = GetTimeMillis();
-    unsigned int slash_bits;
+    uint64_t slash_bits;
     for (int i = 0; i < kNumRepetitions; ++i) {
       CanonicalizePath(buf, &len, &slash_bits, &err);
     }


### PR DESCRIPTION
https://github.com/ninja-build/ninja/pull/1181 changed
CanonicalizePath to take a uint64_t* instead of a unsigned int*,
make the same change in canon_perftest.

Fixes "./ninja all" build.