### PR TITLE
Allow commands with implicit outputs in the depslog

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -385,7 +385,7 @@ bool ManifestParser::ParseEdge(string* err) {
 
   // Multiple outputs aren't (yet?) supported with depslog.
   string deps_type = edge->GetBinding("deps");
-  if (!deps_type.empty() && edge->outputs_.size() > 1) {
+  if (!deps_type.empty() && edge->outputs_.size() - edge->implicit_outs_ > 1) {
     return lexer_.Error("multiple outputs aren't (yet?) supported by depslog; "
                         "bring this up on the mailing list if it affects you",
                         err);

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -816,6 +816,16 @@ TEST_F(ParserTest, MultipleOutputs) {
   EXPECT_EQ("", err);
 }
 
+TEST_F(ParserTest, MultipleImplicitOutputsWithDeps) {
+  State local_state;
+  ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);
+  string err;
+  EXPECT_TRUE(parser.ParseTest("rule cc\n  command = foo\n  deps = gcc\n"
+                               "build a.o | a.gcno: cc c.cc\n",
+                               &err));
+  EXPECT_EQ("", err);
+}
+
 TEST_F(ParserTest, MultipleOutputsWithDeps) {
   State local_state;
   ManifestParser parser(&local_state, NULL, kDupeEdgeActionWarn);


### PR DESCRIPTION
Compilers such as GCC and Clang can output auxiliary files when certain
arguments are passed. In order to add these to the build graph today, we
must turn off the depslog for these commands (deps = gcc -> deps = )

One example is '--coverage', which will output the standard .o/.d files,
but also writes a .gcno file. Then we'd like to distribute a bundle of
these files for the test systems to create the full coverage
information, so they need to be in the build graph.

This is no worse than using depfiles today, since the current depfile
code only cares about the first output. And the depslog code also only
looks at the first output. For auxiliary (implicit) outputs, this is
completely fine. For commands with multiple output that don't have a
"primary" output, the current depslog code that uses the first output
may not be correct, so I'm leaving the check in for that case.