### PR TITLE
Support restat when rebuilding manifest

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -247,10 +247,19 @@ bool NinjaMain::RebuildManifest(const char* input_file, string* err) {
   if (builder.AlreadyUpToDate())
     return false;  // Not an error, but we didn't rebuild.
 
-  // Even if the manifest was cleaned by a restat rule, claim that it was
-  // rebuilt.  Not doing so can lead to crashes, see
-  // https://github.com/ninja-build/ninja/issues/874
-  return builder.Build(err);
+  if (!builder.Build(err))
+    return false;
+
+  // The manifest was only rebuilt if it is now dirty (it may have been cleaned
+  // by a restat).
+  if (!node->dirty()) {
+    // Reset the state to prevent problems like
+    // https://github.com/ninja-build/ninja/issues/874
+    state_.Reset();
+    return false;
+  }
+
+  return true;
 }
 
 Node* NinjaMain::CollectTarget(const char* cpath, string* err) {


### PR DESCRIPTION
As a fix for #874, we started reloading the entire manifest even if the
manifest was never rebuilt due to a restat rule. But this can be slow,
so call State::Reset instead, which also fixes the original crash.

Fixes #987