### PR TITLE
Separate stderr and stdout on windows

### DIFF
--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -150,7 +150,7 @@ bool Subprocess::Done() const {
   return fd_ == -1;
 }
 
-const string& Subprocess::GetOutput() const {
+string Subprocess::GetOutput() const {
   return buf_;
 }
 

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -70,6 +70,22 @@ TEST_F(SubprocessTest, NoSuchCommand) {
 #endif
 }
 
+#ifdef _WIN32
+// Run a command that outputs to stdout and stderr
+TEST_F(SubprocessTest, CommandStdOutAndStdErr) {
+  Subprocess* subproc = subprocs_.Add("cmd /c \"echo hello&& echo err 1>&2\"");
+  ASSERT_NE((Subprocess *) 0, subproc);
+
+  while (!subproc->Done()) {
+    // Pretend we discovered that stderr was ready for writing.
+    subprocs_.DoWork();
+  }
+
+  EXPECT_EQ(ExitSuccess, subproc->Finish());
+  EXPECT_EQ("hello\r\nerr \r\n", subproc->GetOutput());
+}
+#endif
+
 #ifndef _WIN32
 
 TEST_F(SubprocessTest, InterruptChild) {


### PR DESCRIPTION
Too avoid corrupt output of tools that output to stderr and
stdout on windows (as the Intel Compiler), use two pipes to catch the
output to stderr and stdout separately on windows.
In Subprocess::GetOutput simply concatenate both outputs.

This should fix the issues with the Intel Compiler reported in #1037 and #972