### PR TITLE
std:: corrections

### DIFF
--- a/src/edit_distance.cc
+++ b/src/edit_distance.cc
@@ -36,7 +36,7 @@ int EditDistance(const StringPiece& s1,
   int m = s1.len_;
   int n = s2.len_;
 
-  vector<int> row(n + 1);
+  std::vector<int> row(n + 1);
   for (int i = 1; i <= n; ++i)
     row[i] = i;
 
@@ -48,17 +48,17 @@ int EditDistance(const StringPiece& s1,
     for (int x = 1; x <= n; ++x) {
       int old_row = row[x];
       if (allow_replacements) {
-        row[x] = min(previous + (s1.str_[y - 1] == s2.str_[x - 1] ? 0 : 1),
-                     min(row[x - 1], row[x]) + 1);
+        row[x] = std::min(previous + (s1.str_[y - 1] == s2.str_[x - 1] ? 0 : 1),
+                     std::min(row[x - 1], row[x]) + 1);
       }
       else {
         if (s1.str_[y - 1] == s2.str_[x - 1])
           row[x] = previous;
         else
-          row[x] = min(row[x - 1], row[x]) + 1;
+          row[x] = std::min(row[x - 1], row[x]) + 1;
       }
       previous = old_row;
-      best_this_row = min(best_this_row, row[x]);
+      best_this_row = std::min(best_this_row, row[x]);
     }
 
     if (max_edit_distance && best_this_row > max_edit_distance)

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -16,8 +16,8 @@
 
 #include "eval_env.h"
 
-string BindingEnv::LookupVariable(const string& var) {
-  map<string, string>::iterator i = bindings_.find(var);
+std::string BindingEnv::LookupVariable(const std::string& var) {
+  std::map<std::string, std::string>::iterator i = bindings_.find(var);
   if (i != bindings_.end())
     return i->second;
   if (parent_)
@@ -25,7 +25,7 @@ string BindingEnv::LookupVariable(const string& var) {
   return "";
 }
 
-void BindingEnv::AddBinding(const string& key, const string& val) {
+void BindingEnv::AddBinding(const std::string& key, const std::string& val) {
   bindings_[key] = val;
 }
 
@@ -34,15 +34,15 @@ void BindingEnv::AddRule(const Rule* rule) {
   rules_[rule->name()] = rule;
 }
 
-const Rule* BindingEnv::LookupRuleCurrentScope(const string& rule_name) {
-  map<string, const Rule*>::iterator i = rules_.find(rule_name);
+const Rule* BindingEnv::LookupRuleCurrentScope(const std::string& rule_name) {
+  std::map<std::string, const Rule*>::iterator i = rules_.find(rule_name);
   if (i == rules_.end())
     return NULL;
   return i->second;
 }
 
-const Rule* BindingEnv::LookupRule(const string& rule_name) {
-  map<string, const Rule*>::iterator i = rules_.find(rule_name);
+const Rule* BindingEnv::LookupRule(const std::string& rule_name) {
+  std::map<std::string, const Rule*>::iterator i = rules_.find(rule_name);
   if (i != rules_.end())
     return i->second;
   if (parent_)
@@ -50,11 +50,11 @@ const Rule* BindingEnv::LookupRule(const string& rule_name) {
   return NULL;
 }
 
-void Rule::AddBinding(const string& key, const EvalString& val) {
+void Rule::AddBinding(const std::string& key, const EvalString& val) {
   bindings_[key] = val;
 }
 
-const EvalString* Rule::GetBinding(const string& key) const {
+const EvalString* Rule::GetBinding(const std::string& key) const {
   Bindings::const_iterator i = bindings_.find(key);
   if (i == bindings_.end())
     return NULL;
@@ -62,7 +62,7 @@ const EvalString* Rule::GetBinding(const string& key) const {
 }
 
 // static
-bool Rule::IsReservedBinding(const string& var) {
+bool Rule::IsReservedBinding(const std::string& var) {
   return var == "command" ||
       var == "depfile" ||
       var == "description" ||
@@ -75,14 +75,14 @@ bool Rule::IsReservedBinding(const string& var) {
       var == "msvc_deps_prefix";
 }
 
-const map<string, const Rule*>& BindingEnv::GetRules() const {
+const std::map<std::string, const Rule*>& BindingEnv::GetRules() const {
   return rules_;
 }
 
-string BindingEnv::LookupWithFallback(const string& var,
+std::string BindingEnv::LookupWithFallback(const std::string& var,
                                       const EvalString* eval,
                                       Env* env) {
-  map<string, string>::iterator i = bindings_.find(var);
+  std::map<std::string, std::string>::iterator i = bindings_.find(var);
   if (i != bindings_.end())
     return i->second;
 
@@ -95,8 +95,8 @@ string BindingEnv::LookupWithFallback(const string& var,
   return "";
 }
 
-string EvalString::Evaluate(Env* env) const {
-  string result;
+std::string EvalString::Evaluate(Env* env) const {
+  std::string result;
   for (TokenList::const_iterator i = parsed_.begin(); i != parsed_.end(); ++i) {
     if (i->second == RAW)
       result.append(i->first);
@@ -118,8 +118,8 @@ void EvalString::AddSpecial(StringPiece text) {
   parsed_.push_back(make_pair(text.AsString(), SPECIAL));
 }
 
-string EvalString::Serialize() const {
-  string result;
+std::string EvalString::Serialize() const {
+  std::string result;
   for (TokenList::const_iterator i = parsed_.begin();
        i != parsed_.end(); ++i) {
     result.append("[");

--- a/src/eval_env.h
+++ b/src/eval_env.h
@@ -18,7 +18,6 @@
 #include <map>
 #include <string>
 #include <vector>
-using namespace std;
 
 #include "string_piece.h"
 
@@ -27,13 +26,13 @@ struct Rule;
 /// An interface for a scope for variable (e.g. "$foo") lookups.
 struct Env {
   virtual ~Env() {}
-  virtual string LookupVariable(const string& var) = 0;
+  virtual std::string LookupVariable(const std::string& var) = 0;
 };
 
 /// A tokenized string that contains variable references.
 /// Can be evaluated relative to an Env.
 struct EvalString {
-  string Evaluate(Env* env) const;
+  std::string Evaluate(Env* env) const;
 
   void Clear() { parsed_.clear(); }
   bool empty() const { return parsed_.empty(); }
@@ -43,32 +42,32 @@ struct EvalString {
 
   /// Construct a human-readable representation of the parsed state,
   /// for use in tests.
-  string Serialize() const;
+  std::string Serialize() const;
 
 private:
   enum TokenType { RAW, SPECIAL };
-  typedef vector<pair<string, TokenType> > TokenList;
+  typedef std::vector<std::pair<std::string, TokenType> > TokenList;
   TokenList parsed_;
 };
 
 /// An invokable build command and associated metadata (description, etc.).
 struct Rule {
-  explicit Rule(const string& name) : name_(name) {}
+  explicit Rule(const std::string& name) : name_(name) {}
 
-  const string& name() const { return name_; }
+  const std::string& name() const { return name_; }
 
-  void AddBinding(const string& key, const EvalString& val);
+  void AddBinding(const std::string& key, const EvalString& val);
 
-  static bool IsReservedBinding(const string& var);
+  static bool IsReservedBinding(const std::string& var);
 
-  const EvalString* GetBinding(const string& key) const;
+  const EvalString* GetBinding(const std::string& key) const;
 
  private:
   // Allow the parsers to reach into this object and fill out its fields.
   friend struct ManifestParser;
 
-  string name_;
-  typedef map<string, EvalString> Bindings;
+  std::string name_;
+  typedef std::map<std::string, EvalString> Bindings;
   Bindings bindings_;
 };
 
@@ -79,26 +78,26 @@ struct BindingEnv : public Env {
   explicit BindingEnv(BindingEnv* parent) : parent_(parent) {}
 
   virtual ~BindingEnv() {}
-  virtual string LookupVariable(const string& var);
+  virtual std::string LookupVariable(const std::string& var);
 
   void AddRule(const Rule* rule);
-  const Rule* LookupRule(const string& rule_name);
-  const Rule* LookupRuleCurrentScope(const string& rule_name);
-  const map<string, const Rule*>& GetRules() const;
+  const Rule* LookupRule(const std::string& rule_name);
+  const Rule* LookupRuleCurrentScope(const std::string& rule_name);
+  const std::map<std::string, const Rule*>& GetRules() const;
 
-  void AddBinding(const string& key, const string& val);
+  void AddBinding(const std::string& key, const std::string& val);
 
   /// This is tricky.  Edges want lookup scope to go in this order:
   /// 1) value set on edge itself (edge_->env_)
   /// 2) value set on rule, with expansion in the edge's scope
   /// 3) value set on enclosing scope of edge (edge_->env_->parent_)
   /// This function takes as parameters the necessary info to do (2).
-  string LookupWithFallback(const string& var, const EvalString* eval,
-                            Env* env);
+  std::string LookupWithFallback(const std::string& var, const EvalString* eval,
+                                 Env* env);
 
 private:
-  map<string, string> bindings_;
-  map<string, const Rule*> rules_;
+  std::map<std::string, std::string> bindings_;
+  std::map<std::string, const Rule*> rules_;
   BindingEnv* parent_;
 };
 

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -55,7 +55,7 @@ struct Lexer {
 
   /// If the last token read was an ERROR token, provide more info
   /// or the empty string.
-  string DescribeLastError();
+  std::string DescribeLastError();
 
   /// Start parsing some input.
   void Start(StringPiece filename, StringPiece input);
@@ -71,30 +71,30 @@ struct Lexer {
 
   /// Read a simple identifier (a rule or variable name).
   /// Returns false if a name can't be read.
-  bool ReadIdent(string* out);
+  bool ReadIdent(std::string* out);
 
   /// Read a path (complete with $escapes).
   /// Returns false only on error, returned path may be empty if a delimiter
   /// (space, newline) is hit.
-  bool ReadPath(EvalString* path, string* err) {
+  bool ReadPath(EvalString* path, std::string* err) {
     return ReadEvalString(path, true, err);
   }
 
   /// Read the value side of a var = value line (complete with $escapes).
   /// Returns false only on error.
-  bool ReadVarValue(EvalString* value, string* err) {
+  bool ReadVarValue(EvalString* value, std::string* err) {
     return ReadEvalString(value, false, err);
   }
 
   /// Construct an error message with context.
-  bool Error(const string& message, string* err);
+  bool Error(const std::string& message, std::string* err);
 
 private:
   /// Skip past whitespace (called after each read token/ident/etc.).
   void EatWhitespace();
 
   /// Read a $-escaped string.
-  bool ReadEvalString(EvalString* eval, bool path, string* err);
+  bool ReadEvalString(EvalString* eval, bool path, std::string* err);
 
   StringPiece filename_;
   StringPiece input_;

--- a/src/string_piece.h
+++ b/src/string_piece.h
@@ -17,18 +17,16 @@
 
 #include <string>
 
-using namespace std;
-
 #include <string.h>
 
-/// StringPiece represents a slice of a string whose memory is managed
-/// externally.  It is useful for reducing the number of std::strings
+/// StringPiece represents a slice of a std::string whose memory is managed
+/// externally.  It is useful for reducing the number of std::std::strings
 /// we need to allocate.
 struct StringPiece {
   StringPiece() : str_(NULL), len_(0) {}
 
   /// The constructors intentionally allow for implicit conversions.
-  StringPiece(const string& str) : str_(str.data()), len_(str.size()) {}
+  StringPiece(const std::string& str) : str_(str.data()), len_(str.size()) {}
   StringPiece(const char* str) : str_(str), len_(strlen(str)) {}
 
   StringPiece(const char* str, size_t len) : str_(str), len_(len) {}
@@ -41,9 +39,9 @@ struct StringPiece {
   }
 
   /// Convert the slice into a full-fledged std::string, copying the
-  /// data into a new string.
-  string AsString() const {
-    return len_ ? string(str_, len_) : string();
+  /// data into a new std::string.
+  std::string AsString() const {
+    return len_ ? std::string(str_, len_) : std::string();
   }
 
   const char* str_;

--- a/src/string_piece.h
+++ b/src/string_piece.h
@@ -45,7 +45,7 @@ struct StringPiece {
   }
 
   const char* str_;
-  size_t len_;
+  std::size_t len_;
 };
 
 #endif  // NINJA_STRINGPIECE_H_

--- a/src/string_piece.h
+++ b/src/string_piece.h
@@ -29,7 +29,7 @@ struct StringPiece {
   StringPiece(const std::string& str) : str_(str.data()), len_(str.size()) {}
   StringPiece(const char* str) : str_(str), len_(strlen(str)) {}
 
-  StringPiece(const char* str, size_t len) : str_(str), len_(len) {}
+  StringPiece(const char* str, std::size_t len) : str_(str), len_(len) {}
 
   bool operator==(const StringPiece& other) const {
     return len_ == other.len_ && memcmp(str_, other.str_, len_) == 0;


### PR DESCRIPTION
I made these changes because on NetBSD the compiler asks them.
I replaced "naked" string, map etc. by std::string, std::map etc.
./configure.py --bootstrap works!