### PR TITLE
WIP: build: add a trailing newline to rspfile contents

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -745,6 +745,8 @@ bool Builder::StartEdge(Edge* edge, string* err) {
   string rspfile = edge->GetUnescapedRspfile();
   if (!rspfile.empty()) {
     string content = edge->GetBinding("rspfile_content");
+    // Add a trailing newline. Some compilers drop the last flag if this is missing.
+    content += '\n';
     if (!disk_interface_->WriteFile(rspfile, content))
       return false;
   }

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1581,7 +1581,7 @@ TEST_F(BuildTest, RspFileFailure) {
   ASSERT_EQ(0u, fs_.files_removed_.count("out.rsp"));
 
   // The RSP file contains what it should
-  ASSERT_EQ("Another very long command", fs_.files_["out.rsp"].contents);
+  ASSERT_EQ("Another very long command\n", fs_.files_["out.rsp"].contents);
 }
 
 // Test that contents of the RSP file behaves like a regular part of


### PR DESCRIPTION
Some compilers (at least the icecream parallel wrappers) drop the last
flag if there is not trailing whitespace in the file.

See: https://gitlab.kitware.com/cmake/cmake/issues/16664