### PR TITLE
Fix part of UBSAN report in #1248

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -510,7 +510,7 @@ struct FakeCommandRunner : public CommandRunner {
 
 struct BuildTest : public StateTestWithBuiltinRules, public BuildLogUser {
   BuildTest() : config_(MakeConfig()), command_runner_(&fs_),
-                builder_(&state_, config_, NULL, NULL, &fs_),
+                builder_(&state_, config_, NULL, &deps_log_, &fs_),
                 status_(config_) {
   }
 
@@ -552,6 +552,7 @@ struct BuildTest : public StateTestWithBuiltinRules, public BuildLogUser {
   BuildConfig config_;
   FakeCommandRunner command_runner_;
   VirtualFileSystem fs_;
+  DepsLog deps_log_;
   Builder builder_;
 
   BuildStatus status_;
@@ -1934,7 +1935,8 @@ TEST_F(BuildWithDepsLogTest, DepsIgnoredInDryRun) {
 
   // The deps log is NULL in dry runs.
   config_.dry_run = true;
-  Builder builder(&state, config_, NULL, NULL, &fs_);
+  DepsLog deps_log;
+  Builder builder(&state, config_, NULL, &deps_log, &fs_);
   builder.command_runner_.reset(&command_runner_);
   command_runner_.commands_ran_.clear();
 


### PR DESCRIPTION
This fixes the ubsan reported errors in graph.cc. This happened to work before because the node passed in earlied out of DepsLog::GetDeps() before any members were accessed.

(The ones in test.cc are a bit trickier.)