### PR TITLE
Fix UBSAN (out of order test setup) from #1248

### DIFF
--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -116,12 +116,18 @@ bool ReadFlags(int* argc, char*** argv, const char** test_filter) {
 
 }  // namespace
 
+// static
 bool testing::Test::Check(bool condition, const char* file, int line,
                           const char* error) {
   if (!condition) {
     printer.PrintOnNewLine(
         StringPrintf("*** Failure in %s:%d\n%s\n", file, line, error));
-    failed_ = true;
+    if (!g_current_test) {
+      printer.PrintOnNewLine(
+          StringPrintf("*** No current test fixture, aborting\n"));
+      abort();
+    }
+    g_current_test->failed_ = true;
   }
   return condition;
 }
@@ -150,6 +156,7 @@ int main(int argc, char **argv) {
     test->SetUp();
     test->Run();
     test->TearDown();
+    g_current_test = NULL;
     if (test->Failed())
       passed = false;
     delete test;

--- a/src/test.h
+++ b/src/test.h
@@ -39,7 +39,8 @@ class Test {
   bool Failed() const { return failed_; }
   int AssertionFailures() const { return assertion_failures_; }
   void AddAssertionFailure() { assertion_failures_++; }
-  bool Check(bool condition, const char* file, int line, const char* error);
+  static bool Check(bool condition, const char* file, int line,
+                    const char* error);
 };
 }
 
@@ -61,21 +62,21 @@ extern testing::Test* g_current_test;
 #define TEST(x, y) TEST_F_(testing::Test, x##y, #x "." #y)
 
 #define EXPECT_EQ(a, b) \
-  g_current_test->Check(a == b, __FILE__, __LINE__, #a " == " #b)
+  testing::Test::Check(a == b, __FILE__, __LINE__, #a " == " #b)
 #define EXPECT_NE(a, b) \
-  g_current_test->Check(a != b, __FILE__, __LINE__, #a " != " #b)
+  testing::Test::Check(a != b, __FILE__, __LINE__, #a " != " #b)
 #define EXPECT_GT(a, b) \
-  g_current_test->Check(a > b, __FILE__, __LINE__, #a " > " #b)
+  testing::Test::Check(a > b, __FILE__, __LINE__, #a " > " #b)
 #define EXPECT_LT(a, b) \
-  g_current_test->Check(a < b, __FILE__, __LINE__, #a " < " #b)
+  testing::Test::Check(a < b, __FILE__, __LINE__, #a " < " #b)
 #define EXPECT_GE(a, b) \
-  g_current_test->Check(a >= b, __FILE__, __LINE__, #a " >= " #b)
+  testing::Test::Check(a >= b, __FILE__, __LINE__, #a " >= " #b)
 #define EXPECT_LE(a, b) \
-  g_current_test->Check(a <= b, __FILE__, __LINE__, #a " <= " #b)
+  testing::Test::Check(a <= b, __FILE__, __LINE__, #a " <= " #b)
 #define EXPECT_TRUE(a) \
-  g_current_test->Check(static_cast<bool>(a), __FILE__, __LINE__, #a)
+  testing::Test::Check(static_cast<bool>(a), __FILE__, __LINE__, #a)
 #define EXPECT_FALSE(a) \
-  g_current_test->Check(!static_cast<bool>(a), __FILE__, __LINE__, #a)
+  testing::Test::Check(!static_cast<bool>(a), __FILE__, __LINE__, #a)
 
 #define ASSERT_EQ(a, b) \
   if (!EXPECT_EQ(a, b)) { g_current_test->AddAssertionFailure(); return; }


### PR DESCRIPTION
Seems like abort()ing is reasonable, as this shouldn't really ever come up in practice.