### PR TITLE
allow edge weight > 1

### DIFF
--- a/src/graph.h
+++ b/src/graph.h
@@ -128,7 +128,7 @@ private:
 
 /// An edge in the dependency graph; links between Nodes using Rules.
 struct Edge {
-  Edge() : rule_(NULL), pool_(NULL), env_(NULL),
+  Edge() : rule_(NULL), pool_(NULL), weight_(1), env_(NULL),
            outputs_ready_(false), deps_missing_(false),
            implicit_deps_(0), order_only_deps_(0), implicit_outs_(0) {}
 
@@ -153,6 +153,7 @@ struct Edge {
 
   const Rule* rule_;
   Pool* pool_;
+  int weight_;
   vector<Node*> inputs_;
   vector<Node*> outputs_;
   BindingEnv* env_;
@@ -161,7 +162,7 @@ struct Edge {
 
   const Rule& rule() const { return *rule_; }
   Pool* pool() const { return pool_; }
-  int weight() const { return 1; }
+  int weight() const { return weight_; }
   bool outputs_ready() const { return outputs_ready_; }
 
   // There are three types of inputs.

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -338,6 +338,14 @@ bool ManifestParser::ParseEdge(string* err) {
     edge->pool_ = pool;
   }
 
+  string weight_string = edge->GetBinding("weight");
+  if (!weight_string.empty()) {
+    int weight = atol(weight_string.c_str());
+    if (weight < 1)
+      return lexer_.Error("invalid weight '" + weight_string + "'", err);
+    edge->weight_ = weight;
+  }
+
   edge->outputs_.reserve(outs.size());
   for (size_t i = 0, e = outs.size(); i != e; ++i) {
     string path = outs[i].Evaluate(env);

--- a/src/version.cc
+++ b/src/version.cc
@@ -18,7 +18,7 @@
 
 #include "util.h"
 
-const char* kNinjaVersion = "1.7.1.git";
+const char* kNinjaVersion = "1.7.2.git";
 
 void ParseVersion(const string& version, int* major, int* minor) {
   size_t end = version.find('.');


### PR DESCRIPTION
This is a very simple extension on what has already been started with the pools depth.

I find the adjustable weights very useful for running a suite of CPU intensive tests for a physics simulation package. Many tests use MPI and/or OpenMP parallelism and have different core count requirements making it a lot more messy to achieve good utilisation with external tools like semaphores and locks.

If there is interest in the idea I can try to improve the implementation and describe the feature in the manual.