### PR TITLE
Faster clparser

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -489,6 +489,7 @@ for name in ['build',
              'manifest_parser',
              'metrics',
              'state',
+             'string_piece_util',
              'util',
              'version']:
     objs += cxx(name)
@@ -551,6 +552,7 @@ for name in ['build_log_test',
              'manifest_parser_test',
              'ninja_test',
              'state_test',
+             'string_piece_util_test',
              'subprocess_test',
              'test',
              'util_test']:

--- a/src/clparser.cc
+++ b/src/clparser.cc
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include "metrics.h"
+#include "string_piece_util.h"
 
 #ifdef _WIN32
 #include "includes_normalize.h"
@@ -56,7 +57,7 @@ string CLParser::FilterShowIncludes(const string& line,
 
 // static
 bool CLParser::IsSystemInclude(string path) {
-  transform(path.begin(), path.end(), path.begin(), ::tolower);
+  transform(path.begin(), path.end(), path.begin(), ToLowerASCII);
   // TODO: this is a heuristic, perhaps there's a better way?
   return (path.find("program files") != string::npos ||
           path.find("microsoft visual studio") != string::npos);
@@ -64,7 +65,7 @@ bool CLParser::IsSystemInclude(string path) {
 
 // static
 bool CLParser::FilterInputFilename(string line) {
-  transform(line.begin(), line.end(), line.begin(), ::tolower);
+  transform(line.begin(), line.end(), line.begin(), ToLowerASCII);
   // TODO: other extensions, like .asm?
   return EndsWith(line, ".c") ||
       EndsWith(line, ".cc") ||

--- a/src/clparser_perftest.cc
+++ b/src/clparser_perftest.cc
@@ -145,7 +145,7 @@ int main(int argc, char* argv[]) {
     }
     int64_t end = GetTimeMillis();
 
-    if (end - start > 100) {
+    if (end - start > 2000) {
       int delta_ms = (int)(end - start);
       printf("Parse %d times in %dms avg %.1fus\n",
              limit, delta_ms, float(delta_ms * 1000) / limit);

--- a/src/includes_normalize-win32.cc
+++ b/src/includes_normalize-win32.cc
@@ -72,6 +72,7 @@ bool SameDrive(StringPiece a, StringPiece b)  {
 
 // Check path |s| is FullPath style returned by GetFullPathName.
 // This ignores difference of path separator.
+// This is used not to call very slow GetFullPathName API.
 bool IsFullPathName(StringPiece s) {
   if (s.size() < 3 ||
       !islatinalpha(s[0]) ||
@@ -164,11 +165,12 @@ bool IncludesNormalize::Normalize(const string& input,
   if (!CanonicalizePath(copy, &len, &slash_bits, err))
     return false;
   StringPiece partially_fixed(copy, len);
+  string abs_input = AbsPath(partially_fixed);
 
-  if (!SameDrive(partially_fixed, relative_to_)) {
+  if (!SameDrive(abs_input, relative_to_)) {
     *result = partially_fixed.AsString();
     return true;
   }
-  *result = Relativize(partially_fixed, split_relative_to_);
+  *result = Relativize(abs_input, split_relative_to_);
   return true;
 }

--- a/src/includes_normalize.h
+++ b/src/includes_normalize.h
@@ -21,15 +21,19 @@ struct StringPiece;
 /// Utility functions for normalizing include paths on Windows.
 /// TODO: this likely duplicates functionality of CanonicalizePath; refactor.
 struct IncludesNormalize {
+  /// Normalize path relative to |relative_to|.
+  IncludesNormalize(const string& relative_to);
+
   // Internal utilities made available for testing, maybe useful otherwise.
-  static string Join(const vector<string>& list, char sep);
-  static vector<string> Split(const string& input, char sep);
-  static string ToLower(const string& s);
   static string AbsPath(StringPiece s);
-  static string Relativize(StringPiece path, const string& start);
+  static string Relativize(StringPiece path,
+                           const vector<StringPiece>& start_list);
 
   /// Normalize by fixing slashes style, fixing redundant .. and . and makes the
-  /// path relative to |relative_to|.
-  static bool Normalize(const string& input, const char* relative_to,
-                        string* result, string* err);
+  /// path relative to |relative_to_|.
+  bool Normalize(const string& input, string* result, string* err) const;
+
+ private:
+  string relative_to_;
+  vector<StringPiece> splitted_relative_to_;
 };

--- a/src/includes_normalize.h
+++ b/src/includes_normalize.h
@@ -30,10 +30,10 @@ struct IncludesNormalize {
                            const vector<StringPiece>& start_list);
 
   /// Normalize by fixing slashes style, fixing redundant .. and . and makes the
-  /// path relative to |relative_to_|.
+  /// path |input| relative to |this->relative_to_| and store to |result|.
   bool Normalize(const string& input, string* result, string* err) const;
 
  private:
   string relative_to_;
-  vector<StringPiece> splitted_relative_to_;
+  vector<StringPiece> split_relative_to_;
 };

--- a/src/string_piece.h
+++ b/src/string_piece.h
@@ -56,6 +56,14 @@ struct StringPiece {
     return str_ + len_;
   }
 
+  char operator[](size_t pos) const {
+    return str_[pos];
+  }
+
+  size_t size() const {
+    return len_;
+  }
+
   const char* str_;
   size_t len_;
 };

--- a/src/string_piece.h
+++ b/src/string_piece.h
@@ -25,6 +25,8 @@ using namespace std;
 /// externally.  It is useful for reducing the number of std::strings
 /// we need to allocate.
 struct StringPiece {
+  typedef const char* const_iterator;
+
   StringPiece() : str_(NULL), len_(0) {}
 
   /// The constructors intentionally allow for implicit conversions.
@@ -44,6 +46,14 @@ struct StringPiece {
   /// data into a new string.
   string AsString() const {
     return len_ ? string(str_, len_) : string();
+  }
+
+  const_iterator begin() const {
+    return str_;
+  }
+
+  const_iterator end() const {
+    return str_ + len_;
   }
 
   const char* str_;

--- a/src/string_piece_util.cc
+++ b/src/string_piece_util.cc
@@ -1,0 +1,78 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "string_piece_util.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+using namespace std;
+
+vector<StringPiece> SplitStringPiece(StringPiece input, char sep) {
+  vector<StringPiece> elems;
+  elems.reserve(count(input.begin(), input.end(), sep) + 1);
+
+  StringPiece::const_iterator pos = input.begin();
+
+  for (;;) {
+    const char* next_pos = find(pos, input.end(), sep);
+    if (next_pos == input.end()) {
+      elems.push_back(StringPiece(pos, input.end() - pos));
+      break;
+    }
+    elems.push_back(StringPiece(pos, next_pos - pos));
+    pos = next_pos + 1;
+  }
+
+  return elems;
+}
+
+string JoinStringPiece(const vector<StringPiece>& list, char sep) {
+  if (list.size() == 0){
+    return "";
+  }
+
+  string ret;
+
+  {
+    size_t cap = list.size() - 1;
+    for (size_t i = 0; i < list.size(); ++i) {
+      cap += list[i].len_;
+    }
+    ret.reserve(cap);
+  }
+
+  for (size_t i = 0; i < list.size(); ++i) {
+    if (i != 0) {
+      ret += sep;
+    }
+    ret.append(list[i].str_, list[i].len_);
+  }
+
+  return ret;
+}
+
+bool EqualsCaseInsensitiveASCII(StringPiece a, StringPiece b) {
+  if (a.len_ != b.len_) {
+    return false;
+  }
+
+  for (size_t i = 0; i < a.len_; ++i) {
+    if (ToLowerASCII(a.str_[i]) != ToLowerASCII(b.str_[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/string_piece_util.h
+++ b/src/string_piece_util.h
@@ -1,0 +1,34 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NINJA_STRINGPIECE_UTIL_H_
+#define NINJA_STRINGPIECE_UTIL_H_
+
+#include <string>
+#include <vector>
+
+#include "string_piece.h"
+using namespace std;
+
+vector<StringPiece> SplitStringPiece(StringPiece input, char sep);
+
+string JoinStringPiece(const vector<StringPiece>& list, char sep);
+
+inline char ToLowerASCII(char c) {
+  return (c >= 'A' && c <= 'Z') ? (c + ('a' - 'A')) : c;
+}
+
+bool EqualsCaseInsensitiveASCII(StringPiece a, StringPiece b);
+
+#endif  // NINJA_STRINGPIECE_UTIL_H_

--- a/src/string_piece_util_test.cc
+++ b/src/string_piece_util_test.cc
@@ -1,0 +1,129 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "string_piece_util.h"
+
+#include "test.h"
+
+TEST(StringPieceUtilTest, SplitStringPiece) {
+  {
+    string input("a:b:c");
+    vector<StringPiece> list = SplitStringPiece(input, ':');
+
+    EXPECT_EQ(list.size(), 3);
+
+    EXPECT_EQ(list[0], "a");
+    EXPECT_EQ(list[1], "b");
+    EXPECT_EQ(list[2], "c");
+  }
+
+  {
+    string empty("");
+    vector<StringPiece> list = SplitStringPiece(empty, ':');
+
+    EXPECT_EQ(list.size(), 1);
+
+    EXPECT_EQ(list[0], "");
+  }
+
+  {
+    string one("a");
+    vector<StringPiece> list = SplitStringPiece(one, ':');
+
+    EXPECT_EQ(list.size(), 1);
+
+    EXPECT_EQ(list[0], "a");
+  }
+
+  {
+    string sep_only(":");
+    vector<StringPiece> list = SplitStringPiece(sep_only, ':');
+
+    EXPECT_EQ(list.size(), 2);
+
+    EXPECT_EQ(list[0], "");
+    EXPECT_EQ(list[1], "");
+  }
+
+  {
+    string sep(":a:b:c:");
+    vector<StringPiece> list = SplitStringPiece(sep, ':');
+
+    EXPECT_EQ(list.size(), 5);
+
+    EXPECT_EQ(list[0], "");
+    EXPECT_EQ(list[1], "a");
+    EXPECT_EQ(list[2], "b");
+    EXPECT_EQ(list[3], "c");
+    EXPECT_EQ(list[4], "");
+  }
+}
+
+TEST(StringPieceUtilTest, JoinStringPiece) {
+  {
+    string input("a:b:c");
+    vector<StringPiece> list = SplitStringPiece(input, ':');
+
+    EXPECT_EQ("a:b:c", JoinStringPiece(list, ':'));
+    EXPECT_EQ("a/b/c", JoinStringPiece(list, '/'));
+  }
+
+  {
+    string empty("");
+    vector<StringPiece> list = SplitStringPiece(empty, ':');
+
+    EXPECT_EQ("", JoinStringPiece(list, ':'));
+  }
+
+  {
+    vector<StringPiece> empty_list;
+
+    EXPECT_EQ("", JoinStringPiece(empty_list, ':'));
+  }
+
+  {
+    string one("a");
+    vector<StringPiece> single_list = SplitStringPiece(one, ':');
+
+    EXPECT_EQ("a", JoinStringPiece(single_list, ':'));
+  }
+
+  {
+    string sep(":a:b:c:");
+    vector<StringPiece> list = SplitStringPiece(sep, ':');
+
+    EXPECT_EQ(":a:b:c:", JoinStringPiece(list, ':'));
+  }
+}
+
+TEST(StringPieceUtilTest, ToLowerASCII) {
+  EXPECT_EQ('a', ToLowerASCII('A'));
+  EXPECT_EQ('z', ToLowerASCII('Z'));
+  EXPECT_EQ('a', ToLowerASCII('a'));
+  EXPECT_EQ('z', ToLowerASCII('z'));
+  EXPECT_EQ('/', ToLowerASCII('/'));
+  EXPECT_EQ('1', ToLowerASCII('1'));
+}
+
+TEST(StringPieceUtilTest, EqualsCaseInsensitiveASCII) {
+  EXPECT_TRUE(EqualsCaseInsensitiveASCII("abc", "abc"));
+  EXPECT_TRUE(EqualsCaseInsensitiveASCII("abc", "ABC"));
+  EXPECT_TRUE(EqualsCaseInsensitiveASCII("abc", "aBc"));
+  EXPECT_TRUE(EqualsCaseInsensitiveASCII("AbC", "aBc"));
+  EXPECT_TRUE(EqualsCaseInsensitiveASCII("", ""));
+
+  EXPECT_FALSE(EqualsCaseInsensitiveASCII("a", "ac"));
+  EXPECT_FALSE(EqualsCaseInsensitiveASCII("/", "\\"));
+  EXPECT_FALSE(EqualsCaseInsensitiveASCII("1", "10"));
+}

--- a/src/util.cc
+++ b/src/util.cc
@@ -471,7 +471,7 @@ void Win32Fatal(const char* function) {
 }
 #endif
 
-static bool islatinalpha(int c) {
+bool islatinalpha(int c) {
   // isalpha() is locale-dependent.
   return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 }

--- a/src/util.h
+++ b/src/util.h
@@ -70,6 +70,8 @@ const char* SpellcheckStringV(const string& text,
 /// Like SpellcheckStringV, but takes a NULL-terminated list.
 const char* SpellcheckString(const char* text, ...);
 
+bool islatinalpha(int c);
+
 /// Removes all Ansi escape codes (http://www.termsys.demon.co.uk/vtansi.htm).
 string StripAnsiEscapeCodes(const string& in);
 


### PR DESCRIPTION
I improved clparser.

* Reduce the number of calling GetFullPathName.
* Use StringPiece for Split and Join.
* Add EqualsCaseInsensitiveASCII for StringPiece not to generate new string instance.
* Add some utility member in StringPiece class.

With these changes I compared building time of chrome under following setting.
Machine: Z840 Windows10
chromium/src revision: `e84a36378d78316e10dd54398977d8f85a040a92`
args.gn:
```
use_goma=true
goma_dir = "C:\\goma"
symbol_level=0
is_component_build=true
is_debug=false

use_lld = true
enable_nacl = false
```
command: ```ninja -d stats -C out/Release -j 1000 chrome```
Before each build, I restart goma and clean build directory.

Build results with ninja in master branch.
```
metric                  count   avg (us)        total (ms)
.ninja parse            2771    1151.0          3189.5
canonicalize str        701014  0.0             6.7
canonicalize path       10164351        0.0             127.3
lookup node             9391196 0.0             138.1
.ninja_log load         1       53844.0         53.8
.ninja_deps load        1       217241.0        217.2
node stat               83322   5.6             468.0
depfile load            896     18.6            16.6
StartEdge               28284   3556.7          100596.6
FinishCommand           28283   6623.6          187336.5
 
path->node hash load 0.93 (122492 entries / 131072 buckets)
 
real    5m22.290s
user    0m0.000s
sys     0m0.000s
```

Build results with ninja in this pull request.
```
metric                  count   avg (us)        total (ms)
.ninja parse            2771    1149.5          3185.4
canonicalize str        701014  0.0             5.2
canonicalize path       10164351        0.0             48.6
lookup node             9424852 0.0             94.8
.ninja_log load         1       75764.0         75.8
.ninja_log recompact    1       356286.0        356.3
.ninja_deps load        1       211452.0        211.5
node stat               83322   6.1             511.4
depfile load            896     20.4            18.3
StartEdge               28284   3988.5          112811.3
FinishCommand           28283   2961.1          83749.0
CLParser::Parse         21228   2175.9          46190.2
 
path->node hash load 0.93 (122492 entries / 131072 buckets)
 
real    4m21.726s
user    0m0.000s
sys     0m0.016s
 ```

Building time is reduced roughly 20%.