### PR TITLE
Use DETACHED_PROCESS to mitigate Windows close-process bug

### DIFF
--- a/src/msvc_helper-win32.cc
+++ b/src/msvc_helper-win32.cc
@@ -65,8 +65,10 @@ int CLWrapper::Run(const string& command, string* output) {
   startup_info.hStdOutput = stdout_write;
   startup_info.dwFlags |= STARTF_USESTDHANDLES;
 
+  // Use DETACHED_PROCESS when possible to work around Windows bug:
+  // https://github.com/ninja-build/ninja/issues/1283
   if (!CreateProcessA(NULL, (char*)command.c_str(), NULL, NULL,
-                      /* inherit handles */ TRUE, 0,
+                      /* inherit handles */ TRUE, DETACHED_PROCESS,
                       env_block_, NULL,
                       &startup_info, &process_info)) {
     Win32Fatal("CreateProcess");

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -102,7 +102,9 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
   memset(&process_info, 0, sizeof(process_info));
 
   // Ninja handles ctrl-c, except for subprocesses in console pools.
-  DWORD process_flags = use_console_ ? 0 : CREATE_NEW_PROCESS_GROUP;
+  // Use DETACHED_PROCESS when possible to work around Windows bug:
+  // https://github.com/ninja-build/ninja/issues/1283
+  DWORD process_flags = use_console_ ? DETACHED_PROCESS : CREATE_NEW_PROCESS_GROUP;
 
   // Do not prepend 'cmd /c' on Windows, this breaks command
   // lines greater than 8,191 chars.


### PR DESCRIPTION
Windows 10 has a close-process performance bug which can significantly
affect the performance of ninja builds. This bug causes process
destruction to be quite expensive (5-8 ms). Because process destruction
happens while holding a system-global lock it is serialized and it
causes micro-hangs in the UI (mouse pointer freezes for seconds at a
time, especially when many processes are terminating simultaneously).

This change specifies DETACHED_PROCESS when possible because this avoids
the expensive shutdown path, for some reason. It is effectively only
applied to compiler processes, so the problem is not entirely avoided,
but in some cases this fix is enough to improve build speeds by 20-30%.

Fixes #1283, at least partially