### PR TITLE
Fix segfault on edge with no inputs

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1305,6 +1305,37 @@ TEST_F(BuildWithLogTest, RebuildAfterFailure) {
   EXPECT_EQ("", err);
 }
 
+TEST_F(BuildWithLogTest, RebuildWithNoInputs) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule touch\n"
+"  command = touch\n"
+"build out1: touch\n"
+"build out2: touch in\n"));
+
+  string err;
+
+  fs_.Create("in", "");
+
+  EXPECT_TRUE(builder_.AddTarget("out1", &err));
+  EXPECT_TRUE(builder_.AddTarget("out2", &err));
+  EXPECT_TRUE(builder_.Build(&err));
+  EXPECT_EQ("", err);
+  EXPECT_EQ(2u, command_runner_.commands_ran_.size());
+
+  command_runner_.commands_ran_.clear();
+  state_.Reset();
+
+  fs_.Tick();
+
+  fs_.Create("in", "");
+
+  EXPECT_TRUE(builder_.AddTarget("out1", &err));
+  EXPECT_TRUE(builder_.AddTarget("out2", &err));
+  EXPECT_TRUE(builder_.Build(&err));
+  EXPECT_EQ("", err);
+  EXPECT_EQ(1u, command_runner_.commands_ran_.size());
+}
+
 TEST_F(BuildWithLogTest, RestatTest) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule true\n"

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -193,7 +193,7 @@ bool DependencyScan::RecomputeOutputDirty(Edge* edge,
         EXPLAIN("command line changed for %s", output->path().c_str());
         return true;
       }
-      if (entry->mtime < most_recent_input->mtime()) {
+      if (most_recent_input && entry->mtime < most_recent_input->mtime()) {
         // May also be dirty due to the mtime in the log being older than the
         // mtime of the most recent input.  This can occur even when the mtime
         // on disk is newer if a previous run wrote to the output file but


### PR DESCRIPTION
PR #1281 added a deference of most_recent_input without checking
for NULL, which can occur if a build rule has no inputs.
Check it for null before dereferencing, and add a test.

Fixes #1290.