### PR TITLE
Work around mtime being set to 0 sometimes

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -187,6 +187,11 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
     *err = "stat(" + path + "): " + strerror(errno);
     return -1;
   }
+  // Some users (Flatpak) set mtime to 0, this should be harmless
+  // and avoids conflicting with our return value of 0 meaning
+  // that it doesn't exist.
+  if (st.st_mtime == 0)
+    return 1;
   return st.st_mtime;
 #endif
 }


### PR DESCRIPTION
For the time being, I'm proposing Patrick Griffis' patch which has been in use for some months in the Flatpak freedesktop SDK as I need a solution to this also for using build sandboxes with intentionally zeroed timestamps.

Not sure this should be the best solution long term but it's a decent stop gap, the 1 timestamp is much more rare than a 0 timestamp.
