### PR TITLE
Untangle mtime state

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1732,8 +1732,8 @@ TEST_F(BuildTest, InterruptCleanup) {
   EXPECT_FALSE(builder_.Build(&err));
   EXPECT_EQ("interrupted by user", err);
   builder_.Cleanup();
-  EXPECT_GT(fs_.Stat("out1", &err), 0);
-  err = "";
+
+  EXPECT_STAT_EXISTS(fs_, "out1", true);
 
   // A touched output of an interrupted command should be deleted.
   EXPECT_TRUE(builder_.AddTarget("out2", &err));
@@ -1741,7 +1741,8 @@ TEST_F(BuildTest, InterruptCleanup) {
   EXPECT_FALSE(builder_.Build(&err));
   EXPECT_EQ("interrupted by user", err);
   builder_.Cleanup();
-  EXPECT_EQ(0, fs_.Stat("out2", &err));
+
+  EXPECT_STAT_EXISTS(fs_, "out2", false);
 }
 
 TEST_F(BuildTest, StatFailureAbortsBuild) {
@@ -1885,7 +1886,8 @@ TEST_F(BuildWithDepsLogTest, Straightforward) {
     EXPECT_EQ("", err);
 
     // The deps file should have been removed.
-    EXPECT_EQ(0, fs_.Stat("in1.d", &err));
+    EXPECT_STAT_EXISTS(fs_, "in1.d", false);
+
     // Recreate it for the next step.
     fs_.Create("in1.d", "out: in2");
     deps_log.Close();
@@ -1965,7 +1967,7 @@ TEST_F(BuildWithDepsLogTest, ObsoleteDeps) {
   fs_.Create("out", "");
 
   // The deps file should have been removed, so no need to timestamp it.
-  EXPECT_EQ(0, fs_.Stat("in1.d", &err));
+  EXPECT_STAT_EXISTS(fs_, "in1.d", false);
 
   {
     State state;

--- a/src/clean.cc
+++ b/src/clean.cc
@@ -50,10 +50,12 @@ int Cleaner::RemoveFile(const string& path) {
 
 bool Cleaner::FileExists(const string& path) {
   string err;
-  TimeStamp mtime = disk_interface_->Stat(path, &err);
-  if (mtime == -1)
+
+  // Treat Stat() errors as "file does not exist".
+  StatResult file_stat = { 0, false };
+  if (!disk_interface_->Stat(path, &file_stat, &err))
     Error("%s", err.c_str());
-  return mtime > 0;  // Treat Stat() errors as "file does not exist".
+  return file_stat.exists;
 }
 
 void Cleaner::Report(const string& path) {

--- a/src/clean_test.cc
+++ b/src/clean_test.cc
@@ -44,11 +44,10 @@ TEST_F(CleanTest, CleanAll) {
   EXPECT_EQ(4u, fs_.files_removed_.size());
 
   // Check they are removed.
-  string err;
-  EXPECT_EQ(0, fs_.Stat("in1", &err));
-  EXPECT_EQ(0, fs_.Stat("out1", &err));
-  EXPECT_EQ(0, fs_.Stat("in2", &err));
-  EXPECT_EQ(0, fs_.Stat("out2", &err));
+  EXPECT_STAT_EXISTS(fs_, "in1", false);
+  EXPECT_STAT_EXISTS(fs_, "out1", false);
+  EXPECT_STAT_EXISTS(fs_, "in2", false);
+  EXPECT_STAT_EXISTS(fs_, "out2", false);
   fs_.files_removed_.clear();
 
   EXPECT_EQ(0, cleaner.CleanAll());
@@ -76,11 +75,10 @@ TEST_F(CleanTest, CleanAllDryRun) {
   EXPECT_EQ(0u, fs_.files_removed_.size());
 
   // Check they are not removed.
-  string err;
-  EXPECT_LT(0, fs_.Stat("in1", &err));
-  EXPECT_LT(0, fs_.Stat("out1", &err));
-  EXPECT_LT(0, fs_.Stat("in2", &err));
-  EXPECT_LT(0, fs_.Stat("out2", &err));
+  EXPECT_STAT_EXISTS(fs_, "in1", true);
+  EXPECT_STAT_EXISTS(fs_, "out1", true);
+  EXPECT_STAT_EXISTS(fs_, "in2", true);
+  EXPECT_STAT_EXISTS(fs_, "out2", true);
   fs_.files_removed_.clear();
 
   EXPECT_EQ(0, cleaner.CleanAll());
@@ -107,11 +105,10 @@ TEST_F(CleanTest, CleanTarget) {
   EXPECT_EQ(2u, fs_.files_removed_.size());
 
   // Check they are removed.
-  string err;
-  EXPECT_EQ(0, fs_.Stat("in1", &err));
-  EXPECT_EQ(0, fs_.Stat("out1", &err));
-  EXPECT_LT(0, fs_.Stat("in2", &err));
-  EXPECT_LT(0, fs_.Stat("out2", &err));
+  EXPECT_STAT_EXISTS(fs_, "in1", false);
+  EXPECT_STAT_EXISTS(fs_, "out1", false);
+  EXPECT_STAT_EXISTS(fs_, "in2", true);
+  EXPECT_STAT_EXISTS(fs_, "out2", true);
   fs_.files_removed_.clear();
 
   ASSERT_EQ(0, cleaner.CleanTarget("out1"));
@@ -139,11 +136,10 @@ TEST_F(CleanTest, CleanTargetDryRun) {
   EXPECT_EQ(0u, fs_.files_removed_.size());
 
   // Check they are not removed.
-  string err;
-  EXPECT_LT(0, fs_.Stat("in1", &err));
-  EXPECT_LT(0, fs_.Stat("out1", &err));
-  EXPECT_LT(0, fs_.Stat("in2", &err));
-  EXPECT_LT(0, fs_.Stat("out2", &err));
+  EXPECT_STAT_EXISTS(fs_, "in1", true);
+  EXPECT_STAT_EXISTS(fs_, "out1", true);
+  EXPECT_STAT_EXISTS(fs_, "in2", true);
+  EXPECT_STAT_EXISTS(fs_, "out2", true);
   fs_.files_removed_.clear();
 
   ASSERT_EQ(0, cleaner.CleanTarget("out1"));
@@ -172,11 +168,10 @@ TEST_F(CleanTest, CleanRule) {
   EXPECT_EQ(2u, fs_.files_removed_.size());
 
   // Check they are removed.
-  string err;
-  EXPECT_EQ(0, fs_.Stat("in1", &err));
-  EXPECT_LT(0, fs_.Stat("out1", &err));
-  EXPECT_EQ(0, fs_.Stat("in2", &err));
-  EXPECT_LT(0, fs_.Stat("out2", &err));
+  EXPECT_STAT_EXISTS(fs_, "in1", false);
+  EXPECT_STAT_EXISTS(fs_, "out1", true);
+  EXPECT_STAT_EXISTS(fs_, "in2", false);
+  EXPECT_STAT_EXISTS(fs_, "out2", true);
   fs_.files_removed_.clear();
 
   ASSERT_EQ(0, cleaner.CleanRule("cat_e"));
@@ -206,11 +201,10 @@ TEST_F(CleanTest, CleanRuleDryRun) {
   EXPECT_EQ(0u, fs_.files_removed_.size());
 
   // Check they are not removed.
-  string err;
-  EXPECT_LT(0, fs_.Stat("in1", &err));
-  EXPECT_LT(0, fs_.Stat("out1", &err));
-  EXPECT_LT(0, fs_.Stat("in2", &err));
-  EXPECT_LT(0, fs_.Stat("out2", &err));
+  EXPECT_STAT_EXISTS(fs_, "in1", true);
+  EXPECT_STAT_EXISTS(fs_, "out1", true);
+  EXPECT_STAT_EXISTS(fs_, "in2", true);
+  EXPECT_STAT_EXISTS(fs_, "out2", true);
   fs_.files_removed_.clear();
 
   ASSERT_EQ(0, cleaner.CleanRule("cat_e"));
@@ -334,13 +328,12 @@ TEST_F(CleanTest, CleanRsp) {
   EXPECT_EQ(6u, fs_.files_removed_.size());
 
   // Check they are removed.
-  string err;
-  EXPECT_EQ(0, fs_.Stat("in1", &err));
-  EXPECT_EQ(0, fs_.Stat("out1", &err));
-  EXPECT_EQ(0, fs_.Stat("in2", &err));
-  EXPECT_EQ(0, fs_.Stat("out2", &err));
-  EXPECT_EQ(0, fs_.Stat("in2.rsp", &err));
-  EXPECT_EQ(0, fs_.Stat("out2.rsp", &err));
+  EXPECT_STAT_EXISTS(fs_, "in1", false);
+  EXPECT_STAT_EXISTS(fs_, "out1", false);
+  EXPECT_STAT_EXISTS(fs_, "in2", false);
+  EXPECT_STAT_EXISTS(fs_, "out2", false);
+  EXPECT_STAT_EXISTS(fs_, "in2.rsp", false);
+  EXPECT_STAT_EXISTS(fs_, "out2.rsp", false);
 }
 
 TEST_F(CleanTest, CleanFailure) {
@@ -352,7 +345,6 @@ TEST_F(CleanTest, CleanFailure) {
 }
 
 TEST_F(CleanTest, CleanPhony) {
-  string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "build phony: phony t1 t2\n"
 "build t1: cat\n"
@@ -366,7 +358,7 @@ TEST_F(CleanTest, CleanPhony) {
   Cleaner cleaner(&state_, config_, &fs_);
   EXPECT_EQ(0, cleaner.CleanAll());
   EXPECT_EQ(2, cleaner.cleaned_files_count());
-  EXPECT_LT(0, fs_.Stat("phony", &err));
+  EXPECT_STAT_EXISTS(fs_, "phony", true);
 
   fs_.Create("t1", "");
   fs_.Create("t2", "");
@@ -374,7 +366,7 @@ TEST_F(CleanTest, CleanPhony) {
   // Check that CleanTarget does not remove "phony".
   EXPECT_EQ(0, cleaner.CleanTarget("phony"));
   EXPECT_EQ(2, cleaner.cleaned_files_count());
-  EXPECT_LT(0, fs_.Stat("phony", &err));
+  EXPECT_STAT_EXISTS(fs_, "phony", true);
 }
 
 TEST_F(CleanTest, CleanDepFileAndRspFileWithSpaces) {
@@ -399,9 +391,8 @@ TEST_F(CleanTest, CleanDepFileAndRspFileWithSpaces) {
   EXPECT_EQ(4, cleaner.cleaned_files_count());
   EXPECT_EQ(4u, fs_.files_removed_.size());
 
-  string err;
-  EXPECT_EQ(0, fs_.Stat("out 1", &err));
-  EXPECT_EQ(0, fs_.Stat("out 2", &err));
-  EXPECT_EQ(0, fs_.Stat("out 1.d", &err));
-  EXPECT_EQ(0, fs_.Stat("out 2.rsp", &err));
+  EXPECT_STAT_EXISTS(fs_, "out 1", false);
+  EXPECT_STAT_EXISTS(fs_, "out 2", false);
+  EXPECT_STAT_EXISTS(fs_, "out 1.d", false);
+  EXPECT_STAT_EXISTS(fs_, "out 2.rsp", false);
 }

--- a/src/disk_interface.h
+++ b/src/disk_interface.h
@@ -39,14 +39,21 @@ struct FileReader {
                           string* err) = 0;
 };
 
+/// The normalized results of a disk stat, only the parts
+/// that we care about
+struct StatResult {
+  TimeStamp mtime;
+  bool exists;
+};
+
 /// Interface for accessing the disk.
 ///
 /// Abstract so it can be mocked out for tests.  The real implementation
 /// is RealDiskInterface.
 struct DiskInterface: public FileReader {
-  /// stat() a file, returning the mtime, or 0 if missing and -1 on
-  /// other errors.
-  virtual TimeStamp Stat(const string& path, string* err) const = 0;
+  /// stat() a file, filling in the passed StatResult
+  /// returns false on error
+  virtual bool Stat(const string& path, StatResult* result, string* err) const = 0;
 
   /// Create a directory, returning false on failure.
   virtual bool MakeDir(const string& path) = 0;
@@ -75,7 +82,7 @@ struct RealDiskInterface : public DiskInterface {
 #endif
                       {}
   virtual ~RealDiskInterface() {}
-  virtual TimeStamp Stat(const string& path, string* err) const;
+  virtual bool Stat(const string& path, StatResult* result, string* err) const;
   virtual bool MakeDir(const string& path);
   virtual bool WriteFile(const string& path, const string& contents);
   virtual Status ReadFile(const string& path, string* contents, string* err);

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -28,7 +28,14 @@
 #include "util.h"
 
 bool Node::Stat(DiskInterface* disk_interface, string* err) {
-  return (mtime_ = disk_interface->Stat(path_, err)) != -1;
+  StatResult result;
+  if (!disk_interface->Stat(path_, &result, err))
+    return false;
+
+  status_known_ = true;
+  exists_ = result.exists;
+  mtime_ = result.mtime;
+  return true;
 }
 
 bool DependencyScan::RecomputeDirty(Edge* edge, string* err) {

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -39,9 +39,13 @@
 
 bool WriteFakeManifests(const string& dir, string* err) {
   RealDiskInterface disk_interface;
-  TimeStamp mtime = disk_interface.Stat(dir + "/build.ninja", err);
-  if (mtime != 0)  // 0 means that the file doesn't exist yet.
-    return mtime != -1;
+  StatResult stat_result;
+
+  if (!disk_interface.Stat(dir + "/build.ninja", &stat_result, err))
+    return false;
+  if (!stat_result.exists)
+    // Early return if file doesnt exist, true as long as no error occurs
+    return true;
 
   string command = "python misc/write_fake_manifests.py " + dir;
   printf("Creating manifest data..."); fflush(stdout);

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -158,10 +158,10 @@ struct NinjaMain : public BuildLogUser {
     // Do keep entries around for files which still exist on disk, for
     // generators that want to use this information.
     string err;
-    TimeStamp mtime = disk_interface_.Stat(s.AsString(), &err);
-    if (mtime == -1)
+    StatResult result = { 0, false };
+    if (!disk_interface_.Stat(s.AsString(), &result, &err))
       Error("%s", err.c_str());  // Log and ignore Stat() errors.
-    return mtime == 0;
+    return !result.exists;
   }
 };
 
@@ -488,12 +488,12 @@ int NinjaMain::ToolDeps(const Options* options, int argc, char** argv) {
     }
 
     string err;
-    TimeStamp mtime = disk_interface.Stat((*it)->path(), &err);
-    if (mtime == -1)
+    StatResult result = { 0, false };
+    if (!disk_interface.Stat((*it)->path(), &result, &err))
       Error("%s", err.c_str());  // Log and ignore Stat() errors;
     printf("%s: #deps %d, deps mtime %d (%s)\n",
            (*it)->path().c_str(), deps->node_count, deps->mtime,
-           (!mtime || mtime > deps->mtime ? "STALE":"VALID"));
+           (!result.exists || result.mtime > deps->mtime ? "STALE":"VALID"));
     for (int i = 0; i < deps->node_count; ++i)
       printf("    %s\n", deps->nodes[i]->path().c_str());
     printf("\n");

--- a/src/test.cc
+++ b/src/test.cc
@@ -146,13 +146,23 @@ void VirtualFileSystem::Create(const string& path,
   files_created_.insert(path);
 }
 
-TimeStamp VirtualFileSystem::Stat(const string& path, string* err) const {
+bool VirtualFileSystem::Stat(const string& path, StatResult* result, string* err) const {
   FileMap::const_iterator i = files_.find(path);
+
+  *err = "";
+
   if (i != files_.end()) {
-    *err = i->second.stat_error;
-    return i->second.mtime;
+    if (i->second.mtime < 0) {
+      *err = i->second.stat_error;
+      return false;
+    }
+    result->mtime = i->second.mtime;
+    result->exists = true;
+    return true;
   }
-  return 0;
+  result->mtime = 0;
+  result->exists = false;
+  return true;
 }
 
 bool VirtualFileSystem::WriteFile(const string& path, const string& contents) {

--- a/src/test.h
+++ b/src/test.h
@@ -77,6 +77,28 @@ extern testing::Test* g_current_test;
 #define EXPECT_FALSE(a) \
   g_current_test->Check(!static_cast<bool>(a), __FILE__, __LINE__, #a)
 
+#define EXPECT_STAT(disk, path, _success, _exists)    \
+  do {                                                \
+    string errstr;                                    \
+    StatResult result;                                \
+    bool success = disk.Stat(path, &result, &errstr); \
+    g_current_test->Check(success == _success,        \
+			  __FILE__, __LINE__,         \
+			  "success == " #_success);   \
+    if (_success) {                                   \
+      EXPECT_EQ("", errstr);                          \
+      g_current_test->Check(result.exists == _exists, \
+			    __FILE__, __LINE__,       \
+			    "exists == " #_exists);   \
+    } else {                                          \
+      EXPECT_NE("", errstr);                          \
+    }                                                 \
+  } while (0)
+#define EXPECT_STAT_EXISTS(di, path, exists) \
+  EXPECT_STAT(di, path, true, exists)
+#define EXPECT_STAT_ERR(di, path) \
+  EXPECT_STAT(di, path, false, false)
+
 #define ASSERT_EQ(a, b) \
   if (!EXPECT_EQ(a, b)) { g_current_test->AddAssertionFailure(); return; }
 #define ASSERT_NE(a, b) \
@@ -142,7 +164,7 @@ struct VirtualFileSystem : public DiskInterface {
   }
 
   // DiskInterface
-  virtual TimeStamp Stat(const string& path, string* err) const;
+  virtual bool Stat(const string& path, StatResult* result, string* err) const;
   virtual bool WriteFile(const string& path, const string& contents);
   virtual bool MakeDir(const string& path);
   virtual Status ReadFile(const string& path, string* contents, string* err);


### PR DESCRIPTION
This branch fixes #1120 more cleanly.

This changes the `Stat()` semantics so that it does not try to store additional state in the mtime, any mtime is valid, including 0 and negative mtimes.

The graph Node now should have a reduced memory signature, by storing various boolean states as single bits, storing the file existence state separately from the mtime of course.

Test cases are updated and still passing.

