### PR TITLE
Two concurrency related fixes

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <limits.h>
 #include <functional>
 
 #ifdef _WIN32
@@ -130,6 +131,18 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
 
   if (!edge->use_console())
     PrintStatus(edge, kEdgeFinished);
+  if (printer_.is_smart_terminal()) {
+    int oldest_start = INT_MAX;
+    Edge *oldest = NULL;
+    for (i = running_edges_.begin(); i != running_edges_.end(); i++) {
+      if (i->second < oldest_start) {
+        oldest_start = i->second;
+        oldest = i->first;
+      }
+    }
+    if (oldest)
+      PrintStatus(oldest, kEdgeRunning);
+  }
 
   // Print the command that is spewing before printing its output.
   if (!success) {

--- a/src/build.h
+++ b/src/build.h
@@ -206,6 +206,7 @@ struct BuildStatus {
 
   enum EdgeStatus {
     kEdgeStarted,
+    kEdgeRunning,
     kEdgeFinished,
   };
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -216,19 +216,6 @@ void Usage(const BuildConfig& config) {
           kNinjaVersion, config.parallelism);
 }
 
-/// Choose a default value for the -j (parallelism) flag.
-int GuessParallelism() {
-  switch (int processors = GetProcessorCount()) {
-  case 0:
-  case 1:
-    return 2;
-  case 2:
-    return 3;
-  default:
-    return processors + 2;
-  }
-}
-
 /// Rebuild the build manifest, if necessary.
 /// Returns true if the manifest was rebuilt.
 bool NinjaMain::RebuildManifest(const char* input_file, string* err) {
@@ -1025,7 +1012,7 @@ int ExceptionFilter(unsigned int code, struct _EXCEPTION_POINTERS *ep) {
 /// Returns an exit code, or -1 if Ninja should continue.
 int ReadFlags(int* argc, char*** argv,
               Options* options, BuildConfig* config) {
-  config->parallelism = GuessParallelism();
+  config->parallelism = GetProcessorCount();
 
   enum { OPT_VERSION = 1 };
   const option kLongOptions[] = {


### PR DESCRIPTION
1) Change concurrent smart console builds to "blame" the right task that is taking too long.
2) Change the amount of concurrency to be conservative. Users can still use their own heuristics with -j if they want to.