### PR TITLE
Support building without "browse" command

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -218,6 +218,8 @@ parser.add_option('--with-python', metavar='EXE',
 parser.add_option('--force-pselect', action='store_true',
                   help='ppoll() is used by default where available, '
                        'but some platforms may need to use pselect instead',)
+parser.add_option('--without-browse', action='store_true',
+                  help='build without support for the "browse" command')
 (options, args) = parser.parse_args()
 if args:
     print('ERROR: extra unparsed command-line arguments:', args)
@@ -378,7 +380,7 @@ else:
 
 if platform.supports_ppoll() and not options.force_pselect:
     cflags.append('-DUSE_PPOLL')
-if platform.supports_ninja_browse():
+if not options.without_browse and platform.supports_ninja_browse():
     cflags.append('-DNINJA_HAVE_BROWSE')
 
 # Search for generated headers relative to build dir.


### PR DESCRIPTION
This commit adds a configure argument --without-browse to build without support for the browse command.
This might help packagers provide an option to users to build ninja in a way that it does not run-depend on python.