### PR TITLE
correction of location of binary

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -13,7 +13,7 @@ run `ninja_test` when developing.
 Ninja is built using itself.  To bootstrap the first binary, run the
 configure script as `./configure.py --bootstrap`.  This first compiles
 all non-test source files together, then re-builds Ninja using itself.
-You should end up with a `ninja` binary (or `ninja.exe`) in the source root.
+You should end up with a `ninja` binary (or `ninja.exe`) in the project root.
 
 #### Windows
 


### PR DESCRIPTION
original said "source root", but actual location is project root.  Perhaps it is mean to be "src" parent, but that's a bit confusing.