### PR TITLE
Follow GCC/Clang behavior wrt depfiles

### DIFF
--- a/src/depfile_parser_test.cc
+++ b/src/depfile_parser_test.cc
@@ -101,15 +101,36 @@ TEST_F(DepfileParserTest, Spaces) {
             parser_.ins_[2].AsString());
 }
 
+TEST_F(DepfileParserTest, MultipleBackslashes) {
+  // Successive 2N+1 backslashes followed by space (' ') are replaced by N >= 0
+  // backslashes and the space. A single backslash before hash sign is removed.
+  // Other backslashes remain untouched (including 2N backslashes followed by
+  // space).
+  string err;
+  EXPECT_TRUE(Parse(
+"a\\ b\\#c.h: \\\\\\\\\\  \\\\\\\\ \\\\share\\info\\\\#1",
+      &err));
+  ASSERT_EQ("", err);
+  EXPECT_EQ("a b#c.h",
+            parser_.out_.AsString());
+  ASSERT_EQ(3u, parser_.ins_.size());
+  EXPECT_EQ("\\\\ ",
+            parser_.ins_[0].AsString());
+  EXPECT_EQ("\\\\\\\\",
+            parser_.ins_[1].AsString());
+  EXPECT_EQ("\\\\share\\info\\#1",
+            parser_.ins_[2].AsString());
+}
+
 TEST_F(DepfileParserTest, Escapes) {
   // Put backslashes before a variety of characters, see which ones make
   // it through.
   string err;
   EXPECT_TRUE(Parse(
-"\\!\\@\\#$$\\%\\^\\&\\\\:",
+"\\!\\@\\#$$\\%\\^\\&\\[\\]\\\\:",
       &err));
   ASSERT_EQ("", err);
-  EXPECT_EQ("\\!\\@#$\\%\\^\\&\\",
+  EXPECT_EQ("\\!\\@#$\\%\\^\\&\\[\\]\\\\",
             parser_.out_.AsString());
   ASSERT_EQ(0u, parser_.ins_.size());
 }
@@ -123,7 +144,7 @@ TEST_F(DepfileParserTest, SpecialChars) {
 " en@quot.header~ t+t-x!=1 \\\n"
 " openldap/slapd.d/cn=config/cn=schema/cn={0}core.ldif\\\n"
 " Fu\303\244ball\\\n"
-" a\\[1\\]b@2%c",
+" a[1]b@2%c",
       &err));
   ASSERT_EQ("", err);
   EXPECT_EQ("C:/Program Files (x86)/Microsoft crtdefs.h",


### PR DESCRIPTION
Option is called "depfile = gcc" which should support depfiles generated
by GCC. GCC does not escape backslashes and GNU Make does not try to
unescape it, so neither should Ninja try to "unescape" it.

Fixes https://github.com/ninja-build/ninja/issues/1262
___
Performance is **better** than current master, but slightly worse than regenerating current master using re2c 1.0.2 (on an i7-6700HQ).

Elapsed time (n=10) for `./depfile_parser_perftest deps/*.cpp.d` on a desktop with a i7-3770:

| code                                | min    | avg    | max    | mdev    |
| --- | --- | --- | --- | --- |
| git master 887eccf-re2c-0.13.5      | 39.706 | 40.268 | 40.565 | 0.24238 |
| git master 887eccf-re2c-1.0.2       | 41.757 | 42.015 | 42.331 | 0.20303 |
| this patch 0e5cd97-re2c-1.0.2       | 39.662 | 40.099 | 40.385 | 0.26273 |

A bit surprising, but with exactly the same binaries, master+re2c 1.0.2 is faster on an i7-6700HQ. Following is a n=3 result, but I observed this in many repeated tests within an hour (to double-check if I did something wrong).

| code                                | min    | avg    | max    | mdev    |
| --- | --- | --- | --- | --- |
| git master 887eccf-re2c-0.13.5      | 45.094 | 45.453 | 46.006 | 0.48577 |
| git master 887eccf-re2c-1.0.2       | 38.546 | 38.882 | 39.192 | 0.32378 |
| this patch 0e5cd97-re2c-1.0.2       | 43.453 | 43.564 | 43.637 | 0.09771 |

The 170 cpp.d files are taken from the Wireshark build using clang (for convenience: [deps.tar.gz](https://github.com/ninja-build/ninja/files/1373861/deps.tar.gz)).
Above tests were done using Ninja, built using GCC 7.2.0-1 on Arch Linux with files located on a tmpfs.

Note for self:
```
mkdir res && for bin in ./depfile_parser_perftest-*; do what=${bin##*perftest-}; mkdir "res/$what" && date -R && for i in {0..9};do (time "$bin" deps/*.d) &>"res/$what/$i"; done; done
for f in res/*; do awk -F'[ms]' '/^real/{print $2}' "$f"/* | ~/scripts/calc-stats.py | awk '/min/{min=$2} /max/{max=$2} /Mean/{mean=$2} /sd/{sd=$2} END{ printf("| %-35s | %.3f | %.3f | %.3f | %.5f |\n","'"${f##**/}"'", min, mean, max, sd) }'; done
```