### PR TITLE
Fix potential buffer overrun

### DIFF
--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -209,7 +209,7 @@ bool DepsLog::Load(const string& path, State* state, string* err) {
     bool is_deps = (size >> 31) != 0;
     size = size & 0x7FFFFFFF;
 
-    if (fread(buf, size, 1, f) < 1 || size > kMaxRecordSize) {
+    if (size > kMaxRecordSize || fread(buf, size, 1, f) < 1) {
       read_failed = true;
       break;
     }


### PR DESCRIPTION
This commit rearranges record size comparison and fread() to make sure
fread() only reads the data that can fit into the buffer.