### PR TITLE
escape usage examples

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -212,10 +212,10 @@ void Usage(const BuildConfig& config) {
 "  -n       dry run (don't run commands but act like they succeeded)\n"
 "  -v       show all command lines while building\n"
 "\n"
-"  -d MODE  enable debugging (use -d list to list modes)\n"
-"  -t TOOL  run a subtool (use -t list to list subtools)\n"
+"  -d MODE  enable debugging (use '-d list' to list modes)\n"
+"  -t TOOL  run a subtool (use '-t list' to list subtools)\n"
 "    terminates toplevel options; further flags are passed to the tool\n"
-"  -w FLAG  adjust warnings (use -w list to list warnings)\n",
+"  -w FLAG  adjust warnings (use '-w list' to list warnings)\n",
           kNinjaVersion, config.parallelism);
 }
 


### PR DESCRIPTION
Fixes: https://github.com/ninja-build/ninja/issues/1168

quick glance at the output of `ninja -h` can skip the `list` argument in the example
![image](https://user-images.githubusercontent.com/96947/31793659-d4d6f7bc-b4ed-11e7-93f9-37d1aa7a4aab.png)
Maybe as part of the Gestalt Effect:
![image](https://user-images.githubusercontent.com/96947/31793835-5ec53128-b4ee-11e7-81a2-9248ad3feac7.png)
