### PR TITLE
Flush changes into .ninja_log right away.

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -167,6 +167,9 @@ bool BuildLog::RecordCommand(Edge* edge, int start_time, int end_time,
     if (log_file_) {
       if (!WriteEntry(log_file_, *log_entry))
         return false;
+      if (fflush(log_file_) != 0) {
+          return false;
+      }
     }
   }
   return true;


### PR DESCRIPTION
This change flushes new records to the disk (as soon as possible). The same approach is used in .ninja_deps log.
It's also helpful to read log file on the fly (without waiting possibly a few seconds to read new lines).