### PR TITLE
build_log: make sure to carry the old uid and gid

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -366,8 +366,6 @@ bool BuildLog::Recompact(const string& path, const BuildLogUser& user,
 
   Close();
   string temp_path = path + ".recompact";
-  struct stat old_file;
-  bool found_uid_gid = true;
   FILE* f = fopen(temp_path.c_str(), "wb");
   if (!f) {
     *err = strerror(errno);
@@ -397,30 +395,9 @@ bool BuildLog::Recompact(const string& path, const BuildLogUser& user,
   for (size_t i = 0; i < dead_outputs.size(); ++i)
     entries_.erase(dead_outputs[i]);
 
-  //get the stat
-  if (stat(path.c_str(), &old_file) < 0) {
-    //save if we found the stat
-    found_uid_gid = false;
-  }
-
   fclose(f);
-  if (unlink(path.c_str()) < 0) {
-    *err = strerror(errno);
-    return false;
-  }
 
-  if (rename(temp_path.c_str(), path.c_str()) < 0) {
-    *err = strerror(errno);
-    return false;
-  }
-
-  //apply uid and gid again so we always stay as the uid and gid of the first caller that created a file
-  if (found_uid_gid) {
-    if (chown(path.c_str(), old_file.st_uid, old_file.st_gid)) {
-      *err = strerror(errno);
-      return false;
-    }
-  }
+  ReplaceContent(path, temp_path, err);
 
   return true;
 }

--- a/src/util.cc
+++ b/src/util.cc
@@ -36,6 +36,8 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/time.h>
+#else
+#include <windows.h>
 #endif
 
 #include <vector>
@@ -606,6 +608,7 @@ bool Truncate(const string& path, size_t size, string* err) {
 }
 
 bool ReplaceContent(const string& path, const string& old_path, string* err) {
+#ifndef _WIN32
   struct stat old_file;
   bool found_uid_gid = true;
 
@@ -632,5 +635,22 @@ bool ReplaceContent(const string& path, const string& old_path, string* err) {
       return false;
     }
   }
+#else
+  if (!CopyFile(old_path.c_str(), path.c_str(), false))
+    {
+       *err = "Cannot copy file";
+       return false;
+    }
+
+  if (!DeleteFile(old_path.c_str()))
+    {
+       if (GetLastError() == ERROR_ACCESS_DENIED)
+         {
+            *err = "Access Denied";
+            return false;
+         }
+    }
+#endif
+
   return true;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -100,6 +100,8 @@ bool Truncate(const string& path, size_t size, string* err);
 #define PATH_MAX _MAX_PATH
 #endif
 
+bool ReplaceContent(const string& old_path, const string& new_path, string* err);
+
 #ifdef _WIN32
 /// Convert the value returned by GetLastError() into a string.
 string GetLastErrorString();


### PR DESCRIPTION
see #1302 as a normal workflow you do things like "ninja all && sudo
ninja install" for the case that the install target executes a build
target then ninja_log will be writte ntwo which will result in its
permissions to be root / root, which is a problem since you cannot
execute the workflow from above again.