### PR TITLE
Multiple outputs with deps

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -402,11 +402,13 @@ bool ManifestParser::ParseEdge(string* err) {
     }
   }
 
-  // Multiple outputs aren't (yet?) supported with depslog.
+  // Exactly one non-implicit output with zero or more implicit outputs is
+  // supported, although the regular output is not (yet?) used for matching
+  // the output in the deps file.
   string deps_type = edge->GetBinding("deps");
-  if (!deps_type.empty() && edge->outputs_.size() - edge->implicit_outs_ > 1) {
-    return lexer_.Error("multiple outputs aren't (yet?) supported by depslog; "
-                        "bring this up on the mailing list if it affects you",
+  if (!deps_type.empty() && edge->outputs_.size() - edge->implicit_outs_ != 1) {
+    return lexer_.Error("multiple implicit outputs are supported by depslog, "
+                        "but only exactly one non-implicit output",
                         err);
   }
 

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -404,7 +404,7 @@ bool ManifestParser::ParseEdge(string* err) {
 
   // Multiple outputs aren't (yet?) supported with depslog.
   string deps_type = edge->GetBinding("deps");
-  if (!deps_type.empty() && edge->outputs_.size() > 1) {
+  if (!deps_type.empty() && edge->outputs_.size() - edge->implicit_outs_ > 1) {
     return lexer_.Error("multiple outputs aren't (yet?) supported by depslog; "
                         "bring this up on the mailing list if it affects you",
                         err);

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -864,15 +864,26 @@ TEST_F(ParserTest, MultipleImplicitOutputsWithDeps) {
   EXPECT_EQ("", err);
 }
 
-TEST_F(ParserTest, MultipleOutputsWithDeps) {
+TEST_F(ParserTest, NoExplicitOutputWithDeps) {
+  State local_state;
+  ManifestParser parser(&local_state, NULL);
+  string err;
+  EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n  deps = gcc\n"
+                               "build | a.gcno b.gcno: cc c.cc\n",
+                               &err));
+  EXPECT_EQ("input:5: multiple implicit outputs are supported by depslog, "
+            "but only exactly one non-implicit output\n", err);
+}
+
+TEST_F(ParserTest, MultipleExplicitOutputsWithDeps) {
   State local_state;
   ManifestParser parser(&local_state, NULL);
   string err;
   EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n  deps = gcc\n"
                                "build a.o b.o: cc c.cc\n",
                                &err));
-  EXPECT_EQ("input:5: multiple outputs aren't (yet?) supported by depslog; "
-            "bring this up on the mailing list if it affects you\n", err);
+  EXPECT_EQ("input:5: multiple implicit outputs are supported by depslog, "
+            "but only exactly one non-implicit output\n", err);
 }
 
 TEST_F(ParserTest, SubNinja) {

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -854,6 +854,16 @@ TEST_F(ParserTest, MultipleOutputs) {
   EXPECT_EQ("", err);
 }
 
+TEST_F(ParserTest, MultipleImplicitOutputsWithDeps) {
+  State local_state;
+  ManifestParser parser(&local_state, NULL);
+  string err;
+  EXPECT_TRUE(parser.ParseTest("rule cc\n  command = foo\n  deps = gcc\n"
+                               "build a.o | a.gcno: cc c.cc\n",
+                               &err));
+  EXPECT_EQ("", err);
+}
+
 TEST_F(ParserTest, MultipleOutputsWithDeps) {
   State local_state;
   ManifestParser parser(&local_state, NULL);


### PR DESCRIPTION
This PR is a rebase https://github.com/ninja-build/ninja/pull/1236 with more tests added. When adding the tests, I realised that deps for the implicit outputs also have to be recorded.