### PR TITLE
Update Usage to show "-k 0" behavior

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -207,7 +207,7 @@ void Usage(const BuildConfig& config) {
 "  -f FILE  specify input build file [default=build.ninja]\n"
 "\n"
 "  -j N     run N jobs in parallel [default=%d, derived from CPUs available]\n"
-"  -k N     keep going until N jobs fail [default=1]\n"
+"  -k N     keep going until N jobs fail (0 means infinity) [default=1]\n"
 "  -l N     do not start new jobs if the load average is greater than N\n"
 "  -n       dry run (don't run commands but act like they succeeded)\n"
 "  -v       show all command lines while building\n"


### PR DESCRIPTION
For "-k N", N==0 is interpreted as infinite. It's useful but not documented in the help, unfortunately.