### PR TITLE
Add 'output' field to compdb output

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -691,6 +691,8 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc, char* a
         EncodeJSONString((*e)->EvaluateCommand().c_str());
         printf("\",\n    \"file\": \"");
         EncodeJSONString((*e)->inputs_[0]->path().c_str());
+        printf("\",\n    \"output\": \"");
+        EncodeJSONString((*e)->outputs_[0]->path().c_str());
         printf("\"\n  }");
 
         first = false;


### PR DESCRIPTION
https://clang.llvm.org/docs/JSONCompilationDatabase.html mentions an optional "output" field in the compdb format. It seems useful to be able to tell what the output of (re-)running a command will be.