### PR TITLE
Enable color printing in verbose mode.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -83,10 +83,6 @@ BuildStatus::BuildStatus(const BuildConfig& config)
       progress_status_format_(NULL),
       overall_rate_(), current_rate_(config.parallelism) {
 
-  // Don't do anything fancy in verbose mode.
-  if (config_.verbosity != BuildConfig::NORMAL)
-    printer_.set_smart_terminal(false);
-
   progress_status_format_ = getenv("NINJA_STATUS");
   if (!progress_status_format_)
     progress_status_format_ = "[%f/%t] ";


### PR DESCRIPTION
Removed conditional that unilaterally turned off smart_terminal, which
controls how escape characters are treated, in verbose mode.

Escape character handling for smart terminals was added in
a2c4b6780dcf105821e4f2ec1f0b591adbeb6dca, making this conditional
unnecessary.

This conditional was added in b9a26e0e5d1045f5814e3ce6341647c92045e3c3,
and the smart_terminal flag was added in
b9a26e0e5d1045f5814e3ce6341647c92045e3c3.