### PR TITLE
Fix build on Solaris.

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -195,11 +195,12 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
   return ((int64_t)st.st_mtimespec.tv_sec * 1000000000LL +
           st.st_mtimespec.tv_nsec);
 #elif (_POSIX_C_SOURCE >= 200809L || _XOPEN_SOURCE >= 700 || defined(_BSD_SOURCE) || defined(_SVID_SOURCE) || \
-       defined(__BIONIC__))
+       defined(__BIONIC__) || (defined (__SVR4) && defined (__sun)))
   // For glibc, see "Timestamp files" in the Notes of http://www.kernel.org/doc/man-pages/online/pages/man2/stat.2.html
   // newlib, uClibc and musl follow the kernel (or Cygwin) headers and define the right macro values above.
   // For bsd, see https://github.com/freebsd/freebsd/blob/master/sys/sys/stat.h and similar
   // For bionic, C and POSIX API is always enabled.
+  // For solaris, see https://docs.oracle.com/cd/E88353_01/html/E37841/stat-2.html.
   return (int64_t)st.st_mtim.tv_sec * 1000000000LL + st.st_mtim.tv_nsec;
 #else
   return (int64_t)st.st_mtime * 1000000000LL + st.st_mtimensec;


### PR DESCRIPTION
Solaris also does not define struct stat's st_mtimensec field.