### PR TITLE
Make path matching case insensitive on Windows

### DIFF
--- a/src/state.h
+++ b/src/state.h
@@ -15,6 +15,9 @@
 #ifndef NINJA_STATE_H_
 #define NINJA_STATE_H_
 
+#ifdef _WIN32
+#include <list>
+#endif  // _WIN32
 #include <map>
 #include <set>
 #include <string>
@@ -116,7 +119,18 @@ struct State {
 
   /// Mapping of path -> Node.
   typedef ExternalStringHashMap<Node*>::Type Paths;
+#ifdef _WIN32
+  mutable Paths paths_;
+#else
   Paths paths_;
+#endif  // _WIN32
+#ifdef _WIN32
+  /// Storage of lowercase versions and othe case insensitive versions of the
+  /// paths that are put into paths_. Using list instead of vector to assure
+  /// the strings are not reallocated when adding more strings, as that would
+  /// destroy the StringPieces used in paths_.
+  mutable list<string> path_storage_;
+#endif  // _WIN32
 
   /// All the pools used in the graph.
   map<string, Pool*> pools_;


### PR DESCRIPTION
This commit makes the path matching on Windows case insensitive because
the header paths reported by Microsoft's Visual C++ compiler cl.exe
sometimes are reported as lowercase.

The following files has been created in C:\ninja-case-test\DiR\subdir
a.c: #include "a.h"
a.h is empty

Then compile using
C:\ninja-case-test\DiR\subdir>cl -c /showIncludes /nologo a.c
a.c
Note: including file: c:\ninja-case-test\dir\subdir\a.h

Apparently, the "DiR" casing becomes lowercase "dir".

Now consider changing your build.ninja to generate DiR/subdir/a.h.
This will trigger a rebuild of DiR/subdir/a.h, but if case sensitive
matching is done, Ninja will not understand that DiR/subdir/a.c needs
dir/subdir/a.h generated before compiling.

To solve the problem, case insensitive matching has been introduced in
the node lookup. Another solution would be to match the dependencies
from cl.exe with all the order-only and other inputs for the
compilation to find the correct casing. That would require generated
headers to be specified as input and not just as e.g. a phony grouped
input. The benefit would to isolate the case insensitive matching
to the CLParser only.

Signed-off-by: Fredrik Medley <fredrik.medley@autoliv.com>