### PR TITLE
Added support for environment variable NINJA_FLAGS

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -191,7 +191,7 @@ you don't need to pass `-j`.)
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 
-Ninja supports one environment variable to control its behavior:
+Ninja supports two environment variables to control its behavior:
 `NINJA_STATUS`, the progress status printed before the rule being run.
 
 Several placeholders are available:
@@ -211,6 +211,16 @@ specified by `-j` or its default)
 The default progress status is `"[%f/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status
 could be `"[%u/%r/%f] "`.
+
+`NINJA_FLAGS`, flags to be set before the command line arguments are parsed.
+
+The value of the variable is parsed like command line arguments. You can for
+instance use less cores than available (-j), or limit the parallelism based
+on the system load (-l). For instance, on a build server used by multiple
+users, you may want to set `NINJA_FLAGS=-l 1` on the system level, so that
+the server never gets overloaded by parallel ninja builds. Command line
+parameters override the flags set with NINJA_FLAGS.
+
 
 Extra tools
 ~~~~~~~~~~~


### PR DESCRIPTION
The value of the variable is parsed like command line arguments. You can for
instance use less cores than available (-j), or limit the parallelism based
on the system load (-l). For instance, on a build server used by multiple
users, you may want to set `NINJA_FLAGS=-l 1` on the system level, so that
the server never gets overloaded by parallel ninja builds. Command line
parameters override the flags set with NINJA_FLAGS.
