### PR TITLE
make ninja build with -std=c++17

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -441,7 +441,12 @@ bool Plan::CleanNode(DependencyScan* scan, Node* node, string* err) {
     vector<Node*>::iterator
         begin = (*oe)->inputs_.begin(),
         end = (*oe)->inputs_.end() - (*oe)->order_only_deps_;
-    if (find_if(begin, end, mem_fun(&Node::dirty)) == end) {
+#if __cplusplus < 201703L
+#define MEM_FN mem_fun
+#else
+#define MEM_FN mem_fn  // mem_fun was removed in C++17.
+#endif
+    if (find_if(begin, end, MEM_FN(&Node::dirty)) == end) {
       // Recompute most_recent_input.
       Node* most_recent_input = NULL;
       for (vector<Node*>::iterator i = begin; i != end; ++i) {

--- a/src/build.h
+++ b/src/build.h
@@ -178,7 +178,11 @@ struct Builder {
   State* state_;
   const BuildConfig& config_;
   Plan plan_;
+#if __cplusplus < 201703L
   auto_ptr<CommandRunner> command_runner_;
+#else
+  unique_ptr<CommandRunner> command_runner_;  // auto_ptr was removed in C++17.
+#endif
   BuildStatus* status_;
 
  private:


### PR DESCRIPTION
Ninja is supposed to be able to build as C++98 so it can run on old
systems, but it should also be possible to optionally build it with
newer dialects.

Fixes #1349.