### PR TITLE
Fix confusing smart console output from concurrent builds

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -16,6 +16,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <functional>
@@ -130,6 +131,18 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
 
   if (!edge->use_console())
     PrintStatus(edge, kEdgeFinished);
+  if (printer_.is_smart_terminal()) {
+    int oldest_start = INT_MAX;
+    Edge* oldest = NULL;
+    for (i = running_edges_.begin(); i != running_edges_.end(); i++) {
+      if (i->second < oldest_start) {
+        oldest_start = i->second;
+        oldest = i->first;
+      }
+    }
+    if (oldest)
+      PrintStatus(oldest, kEdgeRunning);
+  }
 
   // Print the command that is spewing before printing its output.
   if (!success) {

--- a/src/build.h
+++ b/src/build.h
@@ -222,6 +222,7 @@ struct BuildStatus {
 
   enum EdgeStatus {
     kEdgeStarted,
+    kEdgeRunning,
     kEdgeFinished,
   };
 


### PR DESCRIPTION
Developers tend to blame the last printed line when a build takes too
long. Unfortunately, when building concurrently, the last printed line
may have actually finished a long time ago. Under the current system,
ninja does not update the status line to reflect what jobs are still
running. This change makes ninja always print the oldest still running job
instead. In other words, the likely build bottlenecks.

Patch from David Zarzycki, originally uploaded at #1320.