### PR TITLE
make `-w dupbuild` default to `err`

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1184,6 +1184,7 @@ NORETURN void real_main(int argc, char** argv) {
   BuildConfig config;
   Options options = {};
   options.input_file = "build.ninja";
+  options.dupe_edges_should_err = true;
 
   setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
   const char* ninja_command = argv[0];


### PR DESCRIPTION
You can still opt out of this by passing `-w dupbuild=warn`.
But if you're getting this diagnostic, your build files are incorrect
and you should ideally just fix them.

This is step 3 on https://github.com/ninja-build/ninja/issues/931
I sent an RfC to ninja-build a few months ago; nobody objected.