### PR TITLE
[wip/demo/do not merge] dramatically improve error messages in many c…

### DIFF
--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -23,12 +23,17 @@
 bool Lexer::Error(const string& message, string* err) {
   // Compute line/column.
   int line = 1;
-  const char* line_start = input_.str_;
+  const char* line_start = input_.str_, * prev_line_start = NULL;
   for (const char* p = input_.str_; p < last_token_; ++p) {
     if (*p == '\n') {
       ++line;
+      prev_line_start = line_start;
       line_start = p + 1;
     }
+  }
+  if (last_token_ == line_start && prev_line_start) {
+    --line;
+    line_start = prev_line_start;
   }
   int col = last_token_ ? (int)(last_token_ - line_start) : 0;
 

--- a/src/lexer.in.cc
+++ b/src/lexer.in.cc
@@ -22,12 +22,17 @@
 bool Lexer::Error(const string& message, string* err) {
   // Compute line/column.
   int line = 1;
-  const char* line_start = input_.str_;
+  const char* line_start = input_.str_, * prev_line_start = NULL;
   for (const char* p = input_.str_; p < last_token_; ++p) {
     if (*p == '\n') {
       ++line;
+      prev_line_start = line_start;
       line_start = p + 1;
     }
+  }
+  if (last_token_ == line_start && prev_line_start) {
+    --line;
+    line_start = prev_line_start;
   }
   int col = last_token_ ? (int)(last_token_ - line_start) : 0;
 


### PR DESCRIPTION
…ases

two changes (should be landed as two pull requests i suppose):
- Lexer::ReadIdent() now sets last_token_ before returning false, like
  Lexer::ReadEvalString() does.  So all "expected identifiers" and
  things that call ReadIdent (pool parser, rule parser, let parser,
  code parsing the rule name after a : in a build line) now point
  the "^ near here" at what was there instead of what we expected
  instead of the previous token. (landed in #1415)
- If last_token_ is a newline, the snippet would usually show an empty
  line. In that case, show the previous line instead, which is the line
  where the error would have been.

See the manifest_parser_test diff for what this changes.  Almost
everything is much better. Two things get slightly worse (the "expected
'command =' line for rules is now at the end of the rule line instead
of after it where it goes, and the same for the 'depth =' line for
pools). That's not ideal, but also not horrible.