### PR TITLE
Add appveyor.yml for build & test on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+build_script:
+- cmd: >-
+    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+    python configure.py --bootstrap
+
+    ninja.bootstrap.exe all
+
+    ninja_test
+
+    python misc/ninja_syntax_test.py
+test: off


### PR DESCRIPTION
I'd like to ninja repository has build & test for windows.

This configuration build & test like below.
https://ci.appveyor.com/project/atetubou/ninja/build/1.0.15