### PR TITLE
Revert "Fix disk_interface_test.cc on Windows for 64-bit timestamp"

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -113,11 +113,6 @@ bool StatAllFilesInDir(const string& dir, map<string, TimeStamp>* stamps,
   }
   do {
     string lowername = ffd.cFileName;
-    if (lowername == "..") {
-      // Seems to just copy the timestamp for ".." from ".", which is wrong.
-      // This is the case at least on NTFS under Windows 7.
-      continue;
-    }
     transform(lowername.begin(), lowername.end(), lowername.begin(), ::tolower);
     stamps->insert(make_pair(lowername,
                              TimeStampFromFileTime(ffd.ftLastWriteTime)));
@@ -170,11 +165,6 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
 
   string dir = DirName(path);
   string base(path.substr(dir.size() ? dir.size() + 1 : 0));
-  if (base == "..") {
-    // StatAllFilesInDir does not report any information for base = "..".
-    base = ".";
-    dir = path;
-  }
 
   transform(dir.begin(), dir.end(), dir.begin(), ::tolower);
   transform(base.begin(), base.end(), base.begin(), ::tolower);

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -108,8 +108,6 @@ TEST_F(DiskInterfaceTest, StatExistingDir) {
   string err;
   ASSERT_TRUE(disk_.MakeDir("subdir"));
   ASSERT_TRUE(disk_.MakeDir("subdir/subsubdir"));
-  EXPECT_GT(disk_.Stat("..", &err), 1);
-  EXPECT_EQ("", err);
   EXPECT_GT(disk_.Stat(".", &err), 1);
   EXPECT_EQ("", err);
   EXPECT_GT(disk_.Stat("subdir", &err), 1);
@@ -128,6 +126,7 @@ TEST_F(DiskInterfaceTest, StatExistingDir) {
 #ifdef _WIN32
 TEST_F(DiskInterfaceTest, StatCache) {
   string err;
+  disk_.AllowStatCache(true);
 
   ASSERT_TRUE(Touch("file1"));
   ASSERT_TRUE(Touch("fiLE2"));
@@ -136,10 +135,6 @@ TEST_F(DiskInterfaceTest, StatCache) {
   ASSERT_TRUE(Touch("subdir\\subfile1"));
   ASSERT_TRUE(Touch("subdir\\SUBFILE2"));
   ASSERT_TRUE(Touch("subdir\\SUBFILE3"));
-
-  disk_.AllowStatCache(false);
-  TimeStamp parent_stat_uncached = disk_.Stat("..", &err);
-  disk_.AllowStatCache(true);
 
   EXPECT_GT(disk_.Stat("FIle1", &err), 1);
   EXPECT_EQ("", err);
@@ -151,8 +146,6 @@ TEST_F(DiskInterfaceTest, StatCache) {
   EXPECT_GT(disk_.Stat("sUbdir\\suBFile1", &err), 1);
   EXPECT_EQ("", err);
 
-  EXPECT_GT(disk_.Stat("..", &err), 1);
-  EXPECT_EQ("", err);
   EXPECT_GT(disk_.Stat(".", &err), 1);
   EXPECT_EQ("", err);
   EXPECT_GT(disk_.Stat("subdir", &err), 1);
@@ -165,8 +158,6 @@ TEST_F(DiskInterfaceTest, StatCache) {
   EXPECT_EQ("", err);
   EXPECT_EQ(disk_.Stat("subdir", &err),
             disk_.Stat("subdir/subsubdir/..", &err));
-  EXPECT_EQ("", err);
-  EXPECT_EQ(disk_.Stat("..", &err), parent_stat_uncached);
   EXPECT_EQ("", err);
   EXPECT_EQ(disk_.Stat("subdir/subsubdir", &err),
             disk_.Stat("subdir/subsubdir/.", &err));


### PR DESCRIPTION
This reverts commit ed11516a03583602fbaae2748f3d428542096136.

This is just a test for Appveyor and not, initially, aimed to be merged.