### PR TITLE
Remove broken disk_interface test for Stat

### DIFF
--- a/src/disk_interface.h
+++ b/src/disk_interface.h
@@ -46,6 +46,7 @@ struct FileReader {
 struct DiskInterface: public FileReader {
   /// stat() a file, returning the mtime, or 0 if missing and -1 on
   /// other errors.
+  /// |path| should be canonicalized.
   virtual TimeStamp Stat(const string& path, string* err) const = 0;
 
   /// Create a directory, returning false on failure.

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -95,13 +95,6 @@ TEST_F(DiskInterfaceTest, StatExistingDir) {
   EXPECT_EQ("", err);
   EXPECT_GT(disk_.Stat("subdir/subsubdir", &err), 1);
   EXPECT_EQ("", err);
-
-  EXPECT_EQ(disk_.Stat("subdir", &err),
-            disk_.Stat("subdir/.", &err));
-  EXPECT_EQ(disk_.Stat("subdir", &err),
-            disk_.Stat("subdir/subsubdir/..", &err));
-  EXPECT_EQ(disk_.Stat("subdir/subsubdir", &err),
-            disk_.Stat("subdir/subsubdir/.", &err));
 }
 
 #ifdef _WIN32
@@ -139,16 +132,7 @@ TEST_F(DiskInterfaceTest, StatCache) {
   EXPECT_GT(disk_.Stat("subdir/subsubdir", &err), 1);
   EXPECT_EQ("", err);
 
-  EXPECT_EQ(disk_.Stat("subdir", &err),
-            disk_.Stat("subdir/.", &err));
-  EXPECT_EQ("", err);
-  EXPECT_EQ(disk_.Stat("subdir", &err),
-            disk_.Stat("subdir/subsubdir/..", &err));
-  EXPECT_EQ("", err);
   EXPECT_EQ(disk_.Stat("..", &err), parent_stat_uncached);
-  EXPECT_EQ("", err);
-  EXPECT_EQ(disk_.Stat("subdir/subsubdir", &err),
-            disk_.Stat("subdir/subsubdir/.", &err));
   EXPECT_EQ("", err);
 
   // Test error cases.


### PR DESCRIPTION
We don't want to pass non-canonicalized path to DiskInterface::Stat.

This makes test pass on appveyor.