### PR TITLE
Add a new NINJA_STATUS format: %E for ETA time.

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -205,7 +205,8 @@ Several placeholders are available:
 `%o`:: Overall rate of finished edges per second
 `%c`:: Current rate of finished edges per second (average over builds
 specified by `-j` or its default)
-`%e`:: Elapsed time in seconds.  _(Available since Ninja 1.2.)_
+`%e`:: Elapsed time in hh:mm:ss format.  _(Available since Ninja 1.2.)_
+`%E`:: Remaining time (ETA) in hh:mm:ss format.  _(Available since Ninja 1.8.2.)_
 `%%`:: A plain `%` character.
 
 The default progress status is `"[%f/%t] "` (note the trailing space

--- a/src/build.cc
+++ b/src/build.cc
@@ -266,10 +266,25 @@ string BuildStatus::FormatProgressStatus(
         out += buf;
         break;
 
+#define FORMAT_TIME(t) "%d:%02d:%02d", (t) / 3600, ((t) % 3600) / 60, (t) % 60
+
+      // Elapsed time
       case 'e': {
-        double elapsed = overall_rate_.Elapsed();
-        snprintf(buf, sizeof(buf), "%.3f", elapsed);
+        const int elapsed = overall_rate_.Elapsed();
+        snprintf(buf, sizeof(buf), FORMAT_TIME(elapsed));
         out += buf;
+        break;
+      }
+
+      // ETA
+      case 'E': {
+        if (finished_edges_ > 5 && overall_rate_.Elapsed() > 5.0) {
+          const int eta = (total_edges_ - finished_edges_) *
+                           overall_rate_.Elapsed() / finished_edges_;
+          snprintf(buf, sizeof(buf), FORMAT_TIME(eta));
+          out += buf;
+        } else
+          out.push_back('?');
         break;
       }
 


### PR DESCRIPTION
'%E' prints a time remaining to complete the build.
Now '%e' and '%E' both print not just seconds, but hh:mm:ss.