### PR TITLE
Fix older VS compatibility issues and PDB files generation issue.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -593,7 +593,7 @@ for name in ['build_log_perftest',
              'hash_collision_bench',
              'manifest_parser_perftest',
              'clparser_perftest']:
-  if platform.is_windows():
+  if platform.is_msvc():
     cxxvariables = [('pdb', name + '.pdb')]
   objs = cxx(name, variables=cxxvariables)
   all_targets += n.build(binary(name), 'link', objs,

--- a/configure.py
+++ b/configure.py
@@ -486,7 +486,7 @@ n.newline()
 
 n.comment('Core source files all build into ninja library.')
 cxxvariables = []
-if platform.is_windows():
+if platform.is_msvc():
     cxxvariables = [('pdb', 'ninja.pdb')]
 for name in ['build',
              'build_log',

--- a/configure.py
+++ b/configure.py
@@ -554,7 +554,7 @@ if options.bootstrap:
 n.comment('Tests all build into ninja_test executable.')
 
 objs = []
-if platform.is_windows():
+if platform.is_msvc():
     cxxvariables = [('pdb', 'ninja_test.pdb')]
 
 for name in ['build_log_test',

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -35,6 +35,9 @@
 #include "graph.h"
 #include "metrics.h"
 #include "util.h"
+#if (_MSC_VER < 1800)
+#define strtoll _strtoi64
+#endif
 
 // Implementation details:
 // Each run's log appends to the log file.

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -35,7 +35,7 @@
 #include "graph.h"
 #include "metrics.h"
 #include "util.h"
-#if (_MSC_VER < 1800)
+#if defined(_MSC_VER) && (_MSC_VER < 1800)
 #define strtoll _strtoi64
 #endif
 

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -20,6 +20,9 @@
 #include <string.h>
 #ifndef _WIN32
 #include <unistd.h>
+#elif (_MSC_VER < 1900)
+typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
 #endif
 
 #include "graph.h"

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -20,7 +20,7 @@
 #include <string.h>
 #ifndef _WIN32
 #include <unistd.h>
-#elif (_MSC_VER < 1900)
+#elif defined(_MSC_VER) && (_MSC_VER < 1900)
 typedef __int32 int32_t;
 typedef unsigned __int32 uint32_t;
 #endif

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -173,6 +173,8 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
     // StatAllFilesInDir does not report any information for base = "..".
     base = ".";
     dir = path;
+  } else if (!dir.size()) {
+    dir = ".";
   }
 
   transform(dir.begin(), dir.end(), dir.begin(), ::tolower);

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -173,8 +173,6 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
     // StatAllFilesInDir does not report any information for base = "..".
     base = ".";
     dir = path;
-  } else if (!dir.size()) {
-    dir = ".";
   }
 
   transform(dir.begin(), dir.end(), dir.begin(), ::tolower);


### PR DESCRIPTION
This fixes several windows builds related issue:
- the issue #1411 (with visual studio 2013 and earlier);
- another compilation issue with VS2012 (strtoll not defined)
- the PDB files related warnings when building ninja/ninja_test by providing a unique name per library/binary for the PDB file.
