### PR TITLE
browse.py: fix delay with multiple connections

### DIFF
--- a/src/browse.py
+++ b/src/browse.py
@@ -24,8 +24,10 @@ from __future__ import print_function
 
 try:
     import http.server as httpserver
+    import socketserver
 except ImportError:
     import BaseHTTPServer as httpserver
+    import SocketServer as socketserver
 import argparse
 import cgi
 import os
@@ -205,10 +207,14 @@ parser.add_argument('-f', default='build.ninja',
 parser.add_argument('initial_target', default='all', nargs='?',
     help='Initial target to show (default %(default)s)')
 
+class HTTPServer(socketserver.ThreadingMixIn, httpserver.HTTPServer):
+    # terminate server immediately when Python exits.
+    daemon_threads = True
+
 args = parser.parse_args()
 port = args.port
 hostname = args.hostname
-httpd = httpserver.HTTPServer((hostname,port), RequestHandler)
+httpd = HTTPServer((hostname,port), RequestHandler)
 try:
     if hostname == "":
         hostname = socket.gethostname()


### PR DESCRIPTION
When Firefox opens two TCP connections and sends a request over the
second connection, it is not processed until the first one is closed.
Use a threaded server to solve this issue. Tested with Python 2.7.15 and
3.6.5. (Also tested with 2.6, but that failed due to lack of argparse.)

Link: https://bugs.python.org/issue31639