### PR TITLE
Do not add two to the default job count

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -225,10 +225,8 @@ int GuessParallelism() {
   case 0:
   case 1:
     return 2;
-  case 2:
-    return 3;
   default:
-    return processors + 2;
+    return processors;
   }
 }
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -223,8 +223,7 @@ void Usage(const BuildConfig& config) {
 int GuessParallelism() {
   switch (int processors = GetProcessorCount()) {
   case 0:
-  case 1:
-    return 2;
+    return 1;
   default:
     return processors;
   }


### PR DESCRIPTION
Benchmarks show that increasing the number of make jobs past the number of CPUs decreases performance: https://blogs.gentoo.org/ago/2013/01/14/makeopts-jcore-1-is-not-the-best-optimization/. This was conducted 5 years ago. Since then, although context switching itself has become faster, both CPU cache size and compiler memory usage have increased (the latter particularly so for C++). Moreover, compilers spend even less time on I/O now than they did then; any reasonable software package's header files will all fit into main memory. Therefore, I believe the results should be even more significant today.