### PR TITLE
Emit color job progress and job failure messages by default

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -203,7 +203,21 @@ string BuildStatus::FormatProgressStatus(
   char buf[32];
   int percent;
   for (const char* s = progress_status_format; *s != '\0'; ++s) {
-    if (*s == '%') {
+    // Support ANSI color escape codes in NINJA_STATUS
+    if (strncmp(s, "\\033[", 5) == 0) {
+        const char *end = strchr(s + 5, 'm');
+        if (end == NULL) {
+            // Not a valid ANSI color sequence, treat as regular text
+        } else {
+            out.append("\x1B[");
+            for (const char *t = s + 5; t <= end; ++t) {
+                out.push_back(*t);
+            }
+            s = end;
+            continue;
+        }
+    }
+    else if (*s == '%') {
       ++s;
       switch (*s) {
       case '%':

--- a/src/build.cc
+++ b/src/build.cc
@@ -89,8 +89,12 @@ BuildStatus::BuildStatus(const BuildConfig& config)
     printer_.set_smart_terminal(false);
 
   progress_status_format_ = getenv("NINJA_STATUS");
-  if (!progress_status_format_)
-    progress_status_format_ = "[%f/%t] ";
+  if (!progress_status_format_) {
+    if (printer_.is_smart_terminal())
+      progress_status_format_ = "\\033[32m[%f/%t] \\033[0m";
+    else
+      progress_status_format_ = "[%f/%t] ";
+  }
 }
 
 void BuildStatus::PlanHasTotalEdges(int total) {
@@ -151,7 +155,10 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
          o != edge->outputs_.end(); ++o)
       outputs += (*o)->path() + " ";
 
-    printer_.PrintOnNewLine("FAILED: " + outputs + "\n");
+    if (printer_.is_smart_terminal())
+      printer_.PrintOnNewLine("\x1B[31m" "FAILED: " "\x1B[0m" + outputs + "\n");
+    else
+      printer_.PrintOnNewLine("FAILED: " + outputs + "\n");
     printer_.PrintOnNewLine(edge->EvaluateCommand() + "\n");
   }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -570,10 +570,23 @@ double GetLoadAverage() {
 }
 #endif // _WIN32
 
+// Calculate the width of a string accounting for ANSI escape codes
+size_t CalculateWidth(const string& str) {
+    const int initial_width = str.size();
+    size_t zero_width_start = str.find("\x1B[");
+    if (zero_width_start != string::npos) {
+       size_t zero_width_end = str.find("m", zero_width_start);
+       if (zero_width_end != string::npos) {
+           return initial_width - (zero_width_end - zero_width_start) - 1;
+       }
+    }
+    return initial_width;
+}
+
 string ElideMiddle(const string& str, size_t width) {
   const int kMargin = 3;  // Space for "...".
   string result = str;
-  if (result.size() + kMargin > width) {
+  if (CalculateWidth(result) + kMargin > width) {
     size_t elide_size = (width - kMargin) / 2;
     result = result.substr(0, elide_size)
       + "..."


### PR DESCRIPTION
Set the default `NINJA_STATUS` and the "FAILED" text on job failure to
use ANSI color code escapes if running under a smart terminal.

Requires #1454 to be merged first.