### PR TITLE
Fix wrong description of script installation

### DIFF
--- a/misc/zsh-completion
+++ b/misc/zsh-completion
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Add the following to your .zshrc to tab-complete ninja targets
-#   . path/to/ninja/misc/zsh-completion
+#   fpath=(path/to/ninja/misc/zsh-completion $fpath)
 
 __get_targets() {
   dir="."


### PR DESCRIPTION
The described way of installation makes zsh fail with `_arguments:comparguments:325: can only be called from completion function`. Per [zsh documentation](https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org#telling-zsh-which-function-to-use-for-completing-a-command) the correct way is to use `$fpath`.