### PR TITLE
Fix testcase failure in docker environment

### DIFF
--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -182,7 +182,7 @@ TEST_F(SubprocessTest, SetWithMulti) {
     "cmd /c echo hi",
     "cmd /c time /t",
 #else
-    "whoami",
+    "id -u",
     "pwd",
 #endif
   };


### PR DESCRIPTION
The ninja-build testcases execute the `whoami` command.
In our docker environment, this command fails because the running docker
user does not have a name associated with it. So, instead, use the `id
-u` command

Signed-off-by: Ritesh Raj Sarraf <ritesh.sarraf@collabora.com>