### PR TITLE
Fix compilation on FreeBSD 11.2 (use st_mtim.tv_nsec)

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -205,7 +205,7 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
   return ((int64_t)st.st_mtimespec.tv_sec * 1000000000LL +
           st.st_mtimespec.tv_nsec);
 #elif (_POSIX_C_SOURCE >= 200809L || _XOPEN_SOURCE >= 700 || defined(_BSD_SOURCE) || defined(_SVID_SOURCE) || \
-       defined(__BIONIC__) || (defined (__SVR4) && defined (__sun)))
+       defined(__BIONIC__) || (defined (__SVR4) && defined (__sun)) || defined(__FreeBSD__))
   // For glibc, see "Timestamp files" in the Notes of http://www.kernel.org/doc/man-pages/online/pages/man2/stat.2.html
   // newlib, uClibc and musl follow the kernel (or Cygwin) headers and define the right macro values above.
   // For bsd, see https://github.com/freebsd/freebsd/blob/master/sys/sys/stat.h and similar


### PR DESCRIPTION
```
./src/disk_interface.cc: In member function 'virtual TimeStamp RealDiskInterface::Stat(const string&, std::__cxx11::string*) const':
./src/disk_interface.cc:216:51: error: 'struct stat' has no member named 'st_mtimensec'; did you mean 'st_mtim'?
   return (int64_t)st.st_mtime * 1000000000LL + st.st_mtimensec;
                                                   ^~~~~~~~~~~~
                                                   st_mtim
```