### PR TITLE
util: don't add ellipses width when deciding if they're necessary

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -573,7 +573,7 @@ double GetLoadAverage() {
 string ElideMiddle(const string& str, size_t width) {
   const int kMargin = 3;  // Space for "...".
   string result = str;
-  if (result.size() + kMargin > width) {
+  if (result.size() > width) {
     size_t elide_size = (width - kMargin) / 2;
     result = result.substr(0, elide_size)
       + "..."


### PR DESCRIPTION
If the string fits, just use it. If we need the ellipses, *then* we need
to compute the width based on that.

---
Picked out from #912.