### PR TITLE
NINJA_STATUS_SLEEP: Avoid too frequent status updates

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -191,8 +191,10 @@ you don't need to pass `-j`.)
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 
-Ninja supports one environment variable to control its behavior:
-`NINJA_STATUS`, the progress status printed before the rule being run.
+Ninja supports two environment variables to control its behavior:
+- `NINJA_STATUS`, the progress status printed before the rule being run and
+- `NINJA_STATUS_SLEEP`, the minimum time, in milliseconds, between progress
+  status updates on a dumb terminal or `inf` to keep silent.
 
 Several placeholders are available:
 

--- a/src/build.h
+++ b/src/build.h
@@ -234,7 +234,7 @@ struct BuildStatus {
                               EdgeStatus status) const;
 
  private:
-  void PrintStatus(Edge* edge, EdgeStatus status);
+  void PrintStatus(Edge* edge, EdgeStatus status, bool skip_silence_timeout);
 
   const BuildConfig& config_;
 
@@ -252,6 +252,10 @@ struct BuildStatus {
 
   /// The custom progress status format to use.
   const char* progress_status_format_;
+  /// The number of milliseconds to wait between each
+  /// progress print on a dumb terminal.
+  int progress_sleep_millis_;
+  int64_t last_progress_print_millis_;
 
   template<size_t S>
   void SnprintfRate(double rate, char(&buf)[S], const char* format) const {


### PR DESCRIPTION
A build log on a dumb terminal can be big, even for a fast build. Reduce
the output on dumb terminal by printing less frequent if
NINJA_STATUS_SLEEP is set.

This is especially useful for build automation servers where the
terminal usually is dumb. You will be able to see progress, but do not
have to overflow the console output with status lines.