### PR TITLE
Emit "FAILED: " in red if terminal supports ANSI color output

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -138,7 +138,10 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
          o != edge->outputs_.end(); ++o)
       outputs += (*o)->path() + " ";
 
-    printer_.PrintOnNewLine("FAILED: " + outputs + "\n");
+    if (printer_.supports_color())
+        printer_.PrintOnNewLine("\x1B[31m" "FAILED: " "\x1B[0m" + outputs + "\n");
+    else
+        printer_.PrintOnNewLine("FAILED: " + outputs + "\n");
     printer_.PrintOnNewLine(edge->EvaluateCommand() + "\n");
   }
 

--- a/src/build.cc
+++ b/src/build.cc
@@ -138,10 +138,11 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
          o != edge->outputs_.end(); ++o)
       outputs += (*o)->path() + " ";
 
-    if (printer_.supports_color())
+    if (printer_.supports_color()) {
         printer_.PrintOnNewLine("\x1B[31m" "FAILED: " "\x1B[0m" + outputs + "\n");
-    else
+    } else {
         printer_.PrintOnNewLine("FAILED: " + outputs + "\n");
+    }
     printer_.PrintOnNewLine(edge->EvaluateCommand() + "\n");
   }
 

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -54,7 +54,9 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
   if (supports_color_) {
     DWORD mode;
     if (GetConsoleMode(console_, &mode)) {
-      SetConsoleMode(console_, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+      if (!SetConsoleMode(console_, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)) {
+        supports_color_ = false;
+      }
     }
   }
 #endif


### PR DESCRIPTION
Per [@jhasse's request](https://github.com/ninja-build/ninja/pull/1455#issuecomment-444128323)