### PR TITLE
Minor improvement [Reserve vector]

### DIFF
--- a/src/browse.cc
+++ b/src/browse.cc
@@ -47,6 +47,7 @@ void RunBrowsePython(State* state, const char* ninja_command,
       }
 
       std::vector<const char *> command;
+      command.reserve(argc + 7);
       command.push_back(NINJA_PYTHON);
       command.push_back("-");
       command.push_back("--ninja-command");


### PR DESCRIPTION
Save on reallocation cost, by reserving the vector we know the size of before hand.