### PR TITLE
ninja_syntax.py: remove unused has_path argument

### DIFF
--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -21,7 +21,7 @@ class Writer(object):
     def newline(self):
         self.output.write('\n')
 
-    def comment(self, text, has_path=False):
+    def comment(self, text):
         for line in textwrap.wrap(text, self.width - 2, break_long_words=False,
                                   break_on_hyphens=False):
             self.output.write('# ' + line + '\n')


### PR DESCRIPTION
The usage of the parameter was removed a long time ago and was never cleaned up. The argument is not provided in the test.