### PR TITLE
CI with Azure Pipelines (Linux, macOS and Windows at the same time)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
 - master
+- release
 
 jobs:
   - job: Linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ jobs:
         ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots
         ./misc/ninja_syntax_test.py
         ./misc/output_test.py
+        strip ninja
         mkdir package
         mv ninja package
       displayName: Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,14 +18,12 @@ jobs:
         ./misc/ninja_syntax_test.py
         ./misc/output_test.py
         strip ninja
-        mkdir package
-        mv ninja package
       displayName: Test
 
     - task: PublishPipelineArtifact@0
       inputs:
         artifactName: ninja-linux
-        targetPath: package
+        targetPath: ninja
 
   - job: macOS
     pool:
@@ -41,14 +39,12 @@ jobs:
         ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots
         ./misc/ninja_syntax_test.py
         ./misc/output_test.py
-        mkdir package
-        mv ninja package
       displayName: Test
-    
+
     - task: PublishPipelineArtifact@0
       inputs:
         artifactName: ninja-mac
-        targetPath: package
+        targetPath: ninja
 
   - job: Windows
     pool:
@@ -64,11 +60,9 @@ jobs:
     - script: |
         ninja_test
         python misc/ninja_syntax_test.py
-        mkdir package
-        move ninja.exe package
       displayName: Test
 
     - task: PublishPipelineArtifact@0
       inputs:
         artifactName: ninja-win
-        targetPath: package
+        targetPath: ninja.exe

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,72 @@
+trigger:
+- master
+
+jobs:
+  - job: Linux
+    pool:
+      vmImage: 'Ubuntu-16.04'
+
+    steps:
+    - script: |
+        ./configure.py --bootstrap
+        ./ninja all
+      displayName: Build
+
+    - script: |
+        ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots
+        ./misc/ninja_syntax_test.py
+        ./misc/output_test.py
+        mkdir package
+        mv ninja package
+      displayName: Test
+
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: ninja-linux
+        targetPath: package
+
+  - job: macOS
+    pool:
+      vmImage: 'macOS-10.13'
+
+    steps:
+    - script: |
+        ./configure.py --bootstrap
+        ./ninja all
+      displayName: Build
+
+    - script: |
+        ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots
+        ./misc/ninja_syntax_test.py
+        ./misc/output_test.py
+        mkdir package
+        mv ninja package
+      displayName: Test
+    
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: ninja-mac
+        targetPath: package
+
+  - job: Windows
+    pool:
+      vmImage: 'vs2017-win2016'
+
+    steps:
+    - script: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        python configure.py --bootstrap
+        ninja.bootstrap.exe all
+      displayName: Build
+
+    - script: |
+        ninja_test
+        python misc/ninja_syntax_test.py
+        mkdir package
+        move ninja.exe package
+      displayName: Test
+
+    - task: PublishPipelineArtifact@0
+      inputs:
+        artifactName: ninja-win
+        targetPath: package


### PR DESCRIPTION
Unlike Travis, Azure Pipelines has support for easy artifact uploading. And unlike AppVeyor it supports macOS.

For this to work, a project owner of ninja-build/ninja needs to enable it, and then it would look like this: https://dev.azure.com/jhasse/jhasse/_build/results?buildId=34

Fixes #1509.