### PR TITLE
Pass command-line options to child processes in an environment variable

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -192,7 +192,6 @@ Environment variables
 
 Ninja supports one environment variable to control its behavior:
 `NINJA_STATUS`, the progress status printed before the rule being run.
-
 Several placeholders are available:
 
 `%s`:: The number of started edges.
@@ -210,6 +209,15 @@ specified by `-j` or its default)
 The default progress status is `"[%f/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status
 could be `"[%u/%r/%f] "`.
+
+In addition, Ninja passes one environment variable to the commands it
+starts, `NINJAFLAGS`. `NINJAFLAGS` contains the `-k`, `-j`, `-l` and
+`-v` options that are in use for the build, except that `-j` is
+only present if the command is started in the <<ref_console_pool,
+"console" pool>>.  External programs can inspect the contents of the
+`NINJAFLAGS` variable, for example to control their own parallelism.
+Note that the exact set of options that it contains may vary in the
+future, so programs should ignore unknown options.
 
 Extra tools
 ~~~~~~~~~~~
@@ -663,6 +671,7 @@ build heavy_object2.obj: cc heavy_obj2.cc
 
 ----------------
 
+[[ref_console_pool]]
 The `console` pool
 ^^^^^^^^^^^^^^^^^^
 

--- a/src/build.cc
+++ b/src/build.cc
@@ -491,7 +491,8 @@ void Plan::Dump() {
 }
 
 struct RealCommandRunner : public CommandRunner {
-  explicit RealCommandRunner(const BuildConfig& config) : config_(config) {}
+  explicit RealCommandRunner(const BuildConfig& config) : config_(config),
+    subprocs_(config_) {}
   virtual ~RealCommandRunner() {}
   virtual bool CanRunMore();
   virtual bool StartCommand(Edge* edge);

--- a/src/build.cc
+++ b/src/build.cc
@@ -16,9 +16,11 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <functional>
+#include <sstream>
 
 #ifdef _WIN32
 #include <fcntl.h>
@@ -75,6 +77,27 @@ bool DryRunCommandRunner::WaitForCommand(Result* result) {
 }
 
 }  // namespace
+
+string BuildConfig::GetConfigAsEnv(bool console) const {
+  ostringstream env;
+  if (verbosity == VERBOSE) {
+    env << " -v";
+  }
+  if (failures_allowed > 1) {
+    if (failures_allowed == INT_MAX) {
+      env << " -k0";
+    } else {
+      env << " -k" << failures_allowed;
+    }
+  }
+  if (max_load_average > 0.0) {
+    env << " -l" << max_load_average;
+  }
+  if (console && parallelism > 1) {
+    env << " -j" << parallelism;
+  }
+  return env.str();
+}
 
 BuildStatus::BuildStatus(const BuildConfig& config)
     : config_(config),

--- a/src/build.h
+++ b/src/build.h
@@ -153,6 +153,8 @@ struct BuildConfig {
   /// means that we do not have any limit.
   double max_load_average;
   DepfileParserOptions depfile_parser_options;
+
+  string GetConfigAsEnv(bool console) const;
 };
 
 /// Builder wraps the build process: starting commands, updating status.

--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -22,6 +22,7 @@
 #include <poll.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>
 #include <spawn.h>
@@ -112,6 +113,8 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
     Fatal("posix_spawnattr_setflags: %s", strerror(err));
 
   const char* spawned_args[] = { "/bin/sh", "-c", command.c_str(), NULL };
+  std::string configstr = config_.GetConfigAsEnv(use_console_);
+  setenv("NINJAFLAGS", configstr.c_str(), true);
   err = posix_spawn(&pid_, "/bin/sh", &action, &attr,
         const_cast<char**>(spawned_args), environ);
   if (err != 0)

--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "subprocess.h"
+#include "build.h"
 
 #include <sys/select.h>
 #include <assert.h>
@@ -29,8 +30,8 @@ extern char** environ;
 
 #include "util.h"
 
-Subprocess::Subprocess(bool use_console) : fd_(-1), pid_(-1),
-                                           use_console_(use_console) {
+Subprocess::Subprocess(const BuildConfig &config, bool use_console) :
+  fd_(-1), pid_(-1), config_(config), use_console_(use_console) {
 }
 
 Subprocess::~Subprocess() {
@@ -188,7 +189,7 @@ void SubprocessSet::HandlePendingInterruption() {
     interrupted_ = SIGHUP;
 }
 
-SubprocessSet::SubprocessSet() {
+SubprocessSet::SubprocessSet(const BuildConfig &config) : config_(config) {
   sigset_t set;
   sigemptyset(&set);
   sigaddset(&set, SIGINT);
@@ -222,7 +223,7 @@ SubprocessSet::~SubprocessSet() {
 }
 
 Subprocess *SubprocessSet::Add(const string& command, bool use_console) {
-  Subprocess *subprocess = new Subprocess(use_console);
+  Subprocess *subprocess = new Subprocess(config_, use_console);
   if (!subprocess->Start(this, command)) {
     delete subprocess;
     return 0;

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -106,6 +106,9 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
   // Ninja handles ctrl-c, except for subprocesses in console pools.
   DWORD process_flags = use_console_ ? 0 : CREATE_NEW_PROCESS_GROUP;
 
+  std::string configstr = config_.GetConfigAsEnv(use_console_);
+  SetEnvironmentVariableA("NINJAFLAGS", configstr.c_str());
+
   // Do not prepend 'cmd /c' on Windows, this breaks command
   // lines greater than 8,191 chars.
   if (!CreateProcessA(NULL, (char*)command.c_str(), NULL, NULL,

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "subprocess.h"
+#include "build.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -21,9 +22,9 @@
 
 #include "util.h"
 
-Subprocess::Subprocess(bool use_console) : child_(NULL) , overlapped_(),
-                                           is_reading_(false),
-                                           use_console_(use_console) {
+Subprocess::Subprocess(const BuildConfig &config, bool use_console) :
+  child_(NULL) , overlapped_(), is_reading_(false),
+  config_(config), use_console_(use_console) {
 }
 
 Subprocess::~Subprocess() {
@@ -203,7 +204,7 @@ const string& Subprocess::GetOutput() const {
 
 HANDLE SubprocessSet::ioport_;
 
-SubprocessSet::SubprocessSet() {
+SubprocessSet::SubprocessSet(const BuildConfig &config) : config_(config) {
   ioport_ = ::CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 1);
   if (!ioport_)
     Win32Fatal("CreateIoCompletionPort");
@@ -229,7 +230,7 @@ BOOL WINAPI SubprocessSet::NotifyInterrupted(DWORD dwCtrlType) {
 }
 
 Subprocess *SubprocessSet::Add(const string& command, bool use_console) {
-  Subprocess *subprocess = new Subprocess(use_console);
+  Subprocess *subprocess = new Subprocess(config_, use_console);
   if (!subprocess->Start(this, command)) {
     delete subprocess;
     return 0;

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -36,6 +36,8 @@ using namespace std;
 
 #include "exit_status.h"
 
+struct BuildConfig;
+
 /// Subprocess wraps a single async subprocess.  It is entirely
 /// passive: it expects the caller to notify it when its fds are ready
 /// for reading, as well as call Finish() to reap the child once done()
@@ -52,7 +54,7 @@ struct Subprocess {
   const string& GetOutput() const;
 
  private:
-  Subprocess(bool use_console);
+  Subprocess(const BuildConfig &config, bool use_console);
   bool Start(struct SubprocessSet* set, const string& command);
   void OnPipeReady();
 
@@ -72,6 +74,7 @@ struct Subprocess {
   int fd_;
   pid_t pid_;
 #endif
+  const BuildConfig &config_;
   bool use_console_;
 
   friend struct SubprocessSet;
@@ -81,7 +84,7 @@ struct Subprocess {
 /// DoWork() waits for any state change in subprocesses; finished_
 /// is a queue of subprocesses as they finish.
 struct SubprocessSet {
-  SubprocessSet();
+  explicit SubprocessSet(const BuildConfig &config);
   ~SubprocessSet();
 
   Subprocess* Add(const string& command, bool use_console = false);
@@ -89,6 +92,7 @@ struct SubprocessSet {
   Subprocess* NextFinished();
   void Clear();
 
+  const BuildConfig &config_;
   vector<Subprocess*> running_;
   queue<Subprocess*> finished_;
 

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "subprocess.h"
+#include "build.h"
 
 #include "test.h"
 
@@ -33,6 +34,8 @@ const char* kSimpleCommand = "ls /";
 #endif
 
 struct SubprocessTest : public testing::Test {
+  SubprocessTest() : config_(), subprocs_(config_) {}
+  BuildConfig config_;
   SubprocessSet subprocs_;
 };
 


### PR DESCRIPTION
This pull request adds support for a NINJAFLAGS environment variable that passes a subset of the ninja command line option down to child processes. When ninja starts a subprocess, they can use `NINJAFLAGS` to control their own verbosity and parallelism. This is particularly useful for test suites.

~~This pull request adds support for a NINJAFLAGS environment variable that accepts a subset of the ninja command line option and passes them down to child processes.~~

~~The possible uses are many:~~

* ~~when ninja is invoked by the user or an automated build system, this allows a build system to set up a global load average cap, working around the lack of support for a global jobserver (#1139). Build systems would probably want to add a global `-v` option to ensure that build logs are more complete and failures are more easily understandable.~~

* ~~when ninja starts a subprocess, they can use `NINJAFLAGS` to control their own verbosity and parallelism. This is particularly useful for test suites.~~

* ~~in the rare case when ninja is invoked recursively, it will obey the verbosity and maximum load average of the parent too.  An example is Meson's `ninja clean` shortcut, it makes `ninja -t clean` obey the verbosity that was passed to `ninja clean'~~