### PR TITLE
Improve portability of getopt reset

### DIFF
--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -22,11 +22,14 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _WIN32
+#ifdef USE_BUNDLED_GETOPT
 #include "getopt.h"
-#include <direct.h>
 #else
 #include <getopt.h>
+#endif
+#ifdef _WIN32
+#include <direct.h>
+#else
 #include <unistd.h>
 #endif
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -403,7 +403,6 @@ int NinjaMain::ToolMSVC(const Options* options, int argc, char* argv[]) {
   // Reset getopt: push one argument onto the front of argv, reset optind.
   argc++;
   argv--;
-  optind = 0;
   return MSVCHelperMain(argc, argv);
 }
 #endif
@@ -579,7 +578,6 @@ int NinjaMain::ToolCommands(const Options* options, int argc, char* argv[]) {
 
   PrintCommandMode mode = PCM_All;
 
-  optind = 1;
   int opt;
   while ((opt = getopt(argc, argv, const_cast<char*>("hs"))) != -1) {
     switch (opt) {
@@ -622,7 +620,6 @@ int NinjaMain::ToolClean(const Options* options, int argc, char* argv[]) {
   bool generator = false;
   bool clean_rules = false;
 
-  optind = 1;
   int opt;
   while ((opt = getopt(argc, argv, const_cast<char*>("hgr"))) != -1) {
     switch (opt) {
@@ -708,7 +705,6 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
 
   EvaluateCommandMode eval_mode = ECM_NORMAL;
 
-  optind = 1;
   int opt;
   while ((opt = getopt(argc, argv, const_cast<char*>("hx"))) != -1) {
     switch(opt) {
@@ -1193,6 +1189,13 @@ int ReadFlags(int* argc, char*** argv,
   }
   *argv += optind;
   *argc -= optind;
+#if defined USE_BUNDLED_GETOPT || defined __GLIBC__
+  // Neither the bundled getopt nor glibc's do a full reset with
+  // optind = 1.
+  optind = 0;
+#else
+  optind = 1;
+#endif
 
   return -1;
 }

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -18,15 +18,15 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _WIN32
+#ifdef USE_BUNDLED_GETOPT
 #include "getopt.h"
-#include <direct.h>
-#include <windows.h>
-#elif defined(_AIX)
-#include "getopt.h"
-#include <unistd.h>
 #else
 #include <getopt.h>
+#endif
+#ifdef _WIN32
+#include <direct.h>
+#include <windows.h>
+#else
 #include <unistd.h>
 #endif
 

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -16,11 +16,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef _WIN32
+#ifdef USE_BUNDLED_GETOPT
 #include "getopt.h"
-#elif defined(_AIX)
-#include "getopt.h"
-#include <unistd.h>
 #else
 #include <getopt.h>
 #endif


### PR DESCRIPTION
getopt reset is done sometimes with "optind = 0", sometimes with "optind = 1".  Unfortunately, neither is portable.  For example, if the bundled getopt see "optind = 1" on the very first call it will implicitly add a dash in front of the first argument; and while some glibc versions even had reports of crashes if reset with "optind = 1", Apple's getopt did the same for "optind = 0".
    
Since we know that there will always be two getopt calls only, of which the first will be in ReadFlags, place the ugly code there so that it is not replicated all over ninja.cc.