### PR TITLE
make inline.sh more portable

### DIFF
--- a/src/inline.sh
+++ b/src/inline.sh
@@ -20,6 +20,6 @@
 
 varname="$1"
 echo "const char $varname[] ="
-od -t x1 -A n -v | sed -e 's|[ \t]||g; s|..|\\x&|g; s|^|"|; s|$|"|'
+od -t x1 -A n -v | sed -e 's|^[\t ]\{0,\}$||g; s|[\t ]\{1,\}| |g; s| \{1,\}$||g; s| |\\x|g; s|^|"|; s|$|"|'
 echo ";"
 


### PR DESCRIPTION
some implementations of the 'od' utility, in hex mode, will not print a leading 0 if the byte is less than 0x10. this causes the existing sed script in inline.sh to create a file which does not compile.

this patch fixes this issue in a manner that should also be portable to sed implementations which do
not support gnu extensions.

i have tested it with the following:

    gnu sed and od
    netbsd sed and od
    suckless sed and od

ninja built successfully in each case.