### PR TITLE
Unicode support for ninja

### DIFF
--- a/src/minidump-win32.cc
+++ b/src/minidump-win32.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #ifdef _MSC_VER
+#define UNICODE
+
 
 #include <windows.h>
 #include <DbgHelp.h>
@@ -57,10 +59,18 @@ void CreateWin32MiniDump(_EXCEPTION_POINTERS* pep) {
     return;
   }
 
-  HANDLE hFile = CreateFileA(temp_file, GENERIC_READ | GENERIC_WRITE, 0, NULL,
+#ifdef UNICODE
+  HANDLE hFile = CreateFile(Utf8ToWide(temp_file).c_str(), GENERIC_READ | GENERIC_WRITE, 0, NULL,
+#else
+  HANDLE hFile = CreateFile(temp_file, GENERIC_READ | GENERIC_WRITE, 0, NULL,
+#endif
                              CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
   if (hFile == NULL) {
-    Error("failed to create minidump: CreateFileA(%s): %s",
+#ifdef UNICODE
+	  Error("failed to create minidump: CreateFileW(%s): %s",
+#else
+	  Error("failed to create minidump: CreateFileA(%s): %s",
+#endif
           temp_file, GetLastErrorString().c_str());
     return;
   }

--- a/src/util.h
+++ b/src/util.h
@@ -115,6 +115,10 @@ bool Truncate(const string& path, size_t size, string* err);
 #endif
 
 #ifdef _WIN32
+/// UTF-8 converters
+std::wstring Utf8ToWide(const std::string& s);
+std::string WideToUtf8(const std::wstring& s);
+
 /// Convert the value returned by GetLastError() into a string.
 string GetLastErrorString();
 


### PR DESCRIPTION
Ninja lacks support for unicode chars on windows. I've updated all windows API:s to use Unicode and added a wmain as well, allowing for utf8 chars in file names, deps files etc, thus giving ninja support for UTF8.

The original version of ninja with non-UTF8 support is still there, and by removing the UNICODE definion one is able to build the original ninja.

I've added the conversions from wchar to char in util.cc using the <codecvt> library.

