### PR TITLE
Add CMake build file as an alternative to configure.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.pdb
 *.ilk
 TAGS
-/build
+/build*/
 /build.ninja
 /ninja
 /ninja.bootstrap

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,84 @@
+cmake_minimum_required(VERSION 3.1)
+project(ninja)
+
+if(MSVC)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /GR-")
+else()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -fdiagnostics-color")
+endif()
+
+# the depfile parser and ninja lexers are generated using re2c.
+function(re2c IN OUT)
+	add_custom_command(DEPENDS ${IN} OUTPUT ${OUT}
+		COMMAND re2c -b -i --no-generation-date -o ${OUT} ${IN}
+	)
+endfunction()
+re2c(${CMAKE_SOURCE_DIR}/src/depfile_parser.in.cc ${CMAKE_BINARY_DIR}/depfile_parser.cc)
+re2c(${CMAKE_SOURCE_DIR}/src/lexer.in.cc ${CMAKE_BINARY_DIR}/lexer.cc)
+add_library(libninja-re2c OBJECT ${CMAKE_BINARY_DIR}/depfile_parser.cc ${CMAKE_BINARY_DIR}/lexer.cc)
+target_include_directories(libninja-re2c PRIVATE src)
+
+# Core source files all build into ninja library.
+add_library(libninja OBJECT
+	src/build_log.cc
+	src/build.cc
+	src/clean.cc
+	src/clparser.cc
+	src/dyndep.cc
+	src/dyndep_parser.cc
+	src/debug_flags.cc
+	src/deps_log.cc
+	src/disk_interface.cc
+	src/edit_distance.cc
+	src/eval_env.cc
+	src/graph.cc
+	src/graphviz.cc
+	src/line_printer.cc
+	src/manifest_parser.cc
+	src/metrics.cc
+	src/parser.cc
+	src/state.cc
+	src/string_piece_util.cc
+	src/util.cc
+	src/version.cc
+)
+if(WIN32)
+	target_sources(libninja PRIVATE
+		src/subprocess-win32.cc
+		src/includes_normalize-win32.cc
+		src/msvc_helper-win32.cc
+		src/msvc_helper_main-win32.cc
+	)
+else()
+	target_sources(libninja PRIVATE src/subprocess-posix.cc)
+endif()
+
+# Main executable is library plus main() function.
+add_executable(ninja src/ninja.cc)
+target_link_libraries(ninja PRIVATE libninja libninja-re2c)
+
+# Tests all build into ninja_test executable.
+add_executable(ninja_test
+	src/build_log_test.cc
+	src/build_test.cc
+	src/clean_test.cc
+	src/clparser_test.cc
+	src/depfile_parser_test.cc
+	src/deps_log_test.cc
+	src/disk_interface_test.cc
+	src/dyndep_parser_test.cc
+	src/edit_distance_test.cc
+	src/graph_test.cc
+	src/lexer_test.cc
+	src/manifest_parser_test.cc
+	src/ninja_test.cc
+	src/state_test.cc
+	src/string_piece_util_test.cc
+	src/subprocess_test.cc
+	src/test.cc
+	src/util_test.cc
+)
+if(WIN32)
+	target_sources(ninja_test PRIVATE src/includes_normalize_test.cc src/msvc_helper_test.cc)
+endif()
+target_link_libraries(ninja_test PRIVATE libninja libninja-re2c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,21 @@ else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -fdiagnostics-color")
 endif()
 
-# the depfile parser and ninja lexers are generated using re2c.
-function(re2c IN OUT)
-	add_custom_command(DEPENDS ${IN} OUTPUT ${OUT}
-		COMMAND re2c -b -i --no-generation-date -o ${OUT} ${IN}
-	)
-endfunction()
-re2c(${CMAKE_SOURCE_DIR}/src/depfile_parser.in.cc ${CMAKE_BINARY_DIR}/depfile_parser.cc)
-re2c(${CMAKE_SOURCE_DIR}/src/lexer.in.cc ${CMAKE_BINARY_DIR}/lexer.cc)
-add_library(libninja-re2c OBJECT ${CMAKE_BINARY_DIR}/depfile_parser.cc ${CMAKE_BINARY_DIR}/lexer.cc)
+find_program(RE2C re2c)
+if(RE2C)
+	# the depfile parser and ninja lexers are generated using re2c.
+	function(re2c IN OUT)
+		add_custom_command(DEPENDS ${IN} OUTPUT ${OUT}
+			COMMAND ${RE2C} -b -i --no-generation-date -o ${OUT} ${IN}
+		)
+	endfunction()
+	re2c(${CMAKE_SOURCE_DIR}/src/depfile_parser.in.cc ${CMAKE_BINARY_DIR}/depfile_parser.cc)
+	re2c(${CMAKE_SOURCE_DIR}/src/lexer.in.cc ${CMAKE_BINARY_DIR}/lexer.cc)
+	add_library(libninja-re2c OBJECT ${CMAKE_BINARY_DIR}/depfile_parser.cc ${CMAKE_BINARY_DIR}/lexer.cc)
+else()
+	message(WARNING "re2c was not found; changes to src/*.in.cc will not affect your build.")
+	add_library(libninja-re2c OBJECT src/depfile_parser.cc src/lexer.cc)
+endif()
 target_include_directories(libninja-re2c PRIVATE src)
 
 # Core source files all build into ninja library.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,11 @@ if(WIN32)
 		src/includes_normalize-win32.cc
 		src/msvc_helper-win32.cc
 		src/msvc_helper_main-win32.cc
+		src/getopt.c
 	)
+	if(MSVC)
+		target_sources(libninja PRIVATE src/minidump-win32.cc)
+	endif()
 else()
 	target_sources(libninja PRIVATE src/subprocess-posix.cc)
 endif()
@@ -88,3 +92,6 @@ if(WIN32)
 	target_sources(ninja_test PRIVATE src/includes_normalize_test.cc src/msvc_helper_test.cc)
 endif()
 target_link_libraries(ninja_test PRIVATE libninja libninja-re2c)
+
+enable_testing()
+add_test(NinjaTest ninja_test)


### PR DESCRIPTION
This has come up [on the mailing list](https://groups.google.com/d/topic/ninja-build/q6FNVe8ziLc/discussion) multiple times. @evmar summed up the pros and cons already:

Pros:
* lets people who have cmake installed (in particular the cmake buildbots) build ninja without python
* more familiar to people who know how to use cmake

Cons:
* build system files listed in two places; any change that adjusts build rules needs to update both
* built executables unlikely to be identical (see e.g. the random cflags/ldflags within configure.py); debugging/diagnosing user issues may require asking where the executables came from

I'd also like to add some other pros:
* Everything is build out-of-tree:
  * `src/lexer.cc` and `src/depfile_parser.cc` don't get overwritten all the time.
  * Build multiple configurations in separate build directories at the same time.
* Faster Bootstrapping with e.g. `make -j$(nproc)`
* Visual Studio project generation, see https://groups.google.com/d/topic/ninja-build/wxjMv8jBfYU/discussion
* More portable / easier to add feature tests as suggested in #1560
* Easier to add dependencies also using CMake, e.g. GoogleTest

I've added [WIP] to the title, as there's a lot of stuff missing and I'm also not a CMake expert. This should also be tested in CI and maybe have a check which compares the binaries created by `configure.py` and CMake to see if they are identical (if that's even possible to achieve).

Then there's the question if this should be added at all (IMHO yes). Discuss ;)