### PR TITLE
set -std=c++98 in cflags

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -335,6 +335,7 @@ else:
               '-fno-rtti',
               '-fno-exceptions',
               '-fvisibility=hidden', '-pipe',
+              '-std=c++98',
               '-DNINJA_PYTHON="%s"' % options.with_python]
     if options.debug:
         cflags += ['-D_GLIBCXX_DEBUG', '-D_GLIBCXX_DEBUG_PEDANTIC']


### PR DESCRIPTION
We still want to stick to this standard.