### PR TITLE
build_log, deps_log: ignore ENOENT for unlink()

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -406,7 +406,7 @@ bool BuildLog::Recompact(const string& path, const BuildLogUser& user,
     entries_.erase(dead_outputs[i]);
 
   fclose(f);
-  if (unlink(path.c_str()) < 0) {
+  if (unlink(path.c_str()) < 0 && errno != ENOENT) {
     *err = strerror(errno);
     return false;
   }

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -353,7 +353,7 @@ bool DepsLog::Recompact(const string& path, string* err) {
   deps_.swap(new_log.deps_);
   nodes_.swap(new_log.nodes_);
 
-  if (unlink(path.c_str()) < 0) {
+  if (unlink(path.c_str()) < 0 && errno != ENOENT) {
     *err = strerror(errno);
     return false;
   }


### PR DESCRIPTION
The file is already gone, so it's not an error.