### PR TITLE
subninja chdir: just like ninja in a subshell

### DIFF
--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -237,6 +237,14 @@ struct TestDiskInterface : public DiskInterface {
     assert(false);
     return 0;
   }
+  virtual Status Chdir(const string& path, string* err) {
+    assert(false);
+    return OtherError;
+  }
+  virtual Status Getcwd(string* path, string* err) {
+    assert(false);
+    return OtherError;
+  }
 };
 
 TEST_F(BuildLogTest, Restat) {

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -2398,7 +2398,7 @@ TEST_F(BuildWithDepsLogTest, DepFileOKDepsLog) {
 
     Edge* edge = state.edges_.back();
 
-    state.GetNode("bar.h", 0)->MarkDirty();  // Mark bar.h as missing.
+    state.GetNode("bar.h", &state.bindings_, 0)->MarkDirty();  // Mark bar.h as missing.
     EXPECT_TRUE(builder.AddTarget("fo o.o", &err));
     ASSERT_EQ("", err);
 
@@ -2462,7 +2462,7 @@ TEST_F(BuildWithDepsLogTest, DepFileDepsLogCanonicalize) {
 
     Edge* edge = state.edges_.back();
 
-    state.GetNode("bar.h", 0)->MarkDirty();  // Mark bar.h as missing.
+    state.GetNode("bar.h", &state_.bindings_, 0)->MarkDirty();  // Mark bar.h as missing.
     EXPECT_TRUE(builder.AddTarget("a/b/c/d/e/fo o.o", &err));
     ASSERT_EQ("", err);
 

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -253,7 +253,7 @@ LoadStatus DepsLog::Load(const string& path, State* state, string* err) {
       // have a correct slash_bits that GetNode will look up), or it is an
       // implicit dependency from a .d which does not affect the build command
       // (and so need not have its slashes maintained).
-      Node* node = state->GetNode(subpath, 0);
+      Node* node = state->GetNode(subpath, &state->bindings_, 0);
 
       // Check that the expected index matches the actual index. This can only
       // happen if two ninja processes write to the same deps log concurrently.

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -46,16 +46,16 @@ TEST_F(DepsLogTest, WriteRead) {
 
   {
     vector<Node*> deps;
-    deps.push_back(state1.GetNode("foo.h", 0));
-    deps.push_back(state1.GetNode("bar.h", 0));
-    log1.RecordDeps(state1.GetNode("out.o", 0), 1, deps);
+    deps.push_back(state1.GetNode("foo.h", &state1.bindings_, 0));
+    deps.push_back(state1.GetNode("bar.h", &state1.bindings_, 0));
+    log1.RecordDeps(state1.GetNode("out.o", &state1.bindings_, 0), 1, deps);
 
     deps.clear();
-    deps.push_back(state1.GetNode("foo.h", 0));
-    deps.push_back(state1.GetNode("bar2.h", 0));
-    log1.RecordDeps(state1.GetNode("out2.o", 0), 2, deps);
+    deps.push_back(state1.GetNode("foo.h", &state1.bindings_, 0));
+    deps.push_back(state1.GetNode("bar2.h", &state1.bindings_, 0));
+    log1.RecordDeps(state1.GetNode("out2.o", &state1.bindings_, 0), 2, deps);
 
-    DepsLog::Deps* log_deps = log1.GetDeps(state1.GetNode("out.o", 0));
+    DepsLog::Deps* log_deps = log1.GetDeps(state1.GetNode("out.o", &state1.bindings_, 0));
     ASSERT_TRUE(log_deps);
     ASSERT_EQ(1, log_deps->mtime);
     ASSERT_EQ(2, log_deps->node_count);
@@ -79,7 +79,7 @@ TEST_F(DepsLogTest, WriteRead) {
   }
 
   // Spot-check the entries in log2.
-  DepsLog::Deps* log_deps = log2.GetDeps(state2.GetNode("out2.o", 0));
+  DepsLog::Deps* log_deps = log2.GetDeps(state2.GetNode("out2.o", &state2.bindings_, 0));
   ASSERT_TRUE(log_deps);
   ASSERT_EQ(2, log_deps->mtime);
   ASSERT_EQ(2, log_deps->node_count);
@@ -101,11 +101,11 @@ TEST_F(DepsLogTest, LotsOfDeps) {
     for (int i = 0; i < kNumDeps; ++i) {
       char buf[32];
       sprintf(buf, "file%d.h", i);
-      deps.push_back(state1.GetNode(buf, 0));
+      deps.push_back(state1.GetNode(buf, &state1.bindings_, 0));
     }
-    log1.RecordDeps(state1.GetNode("out.o", 0), 1, deps);
+    log1.RecordDeps(state1.GetNode("out.o", &state1.bindings_, 0), 1, deps);
 
-    DepsLog::Deps* log_deps = log1.GetDeps(state1.GetNode("out.o", 0));
+    DepsLog::Deps* log_deps = log1.GetDeps(state1.GetNode("out.o", &state1.bindings_, 0));
     ASSERT_EQ(kNumDeps, log_deps->node_count);
   }
 
@@ -116,7 +116,7 @@ TEST_F(DepsLogTest, LotsOfDeps) {
   EXPECT_TRUE(log2.Load(kTestFilename, &state2, &err));
   ASSERT_EQ("", err);
 
-  DepsLog::Deps* log_deps = log2.GetDeps(state2.GetNode("out.o", 0));
+  DepsLog::Deps* log_deps = log2.GetDeps(state2.GetNode("out.o", &state2.bindings_, 0));
   ASSERT_EQ(kNumDeps, log_deps->node_count);
 }
 
@@ -132,9 +132,9 @@ TEST_F(DepsLogTest, DoubleEntry) {
     ASSERT_EQ("", err);
 
     vector<Node*> deps;
-    deps.push_back(state.GetNode("foo.h", 0));
-    deps.push_back(state.GetNode("bar.h", 0));
-    log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
+    deps.push_back(state.GetNode("foo.h", &state.bindings_, 0));
+    deps.push_back(state.GetNode("bar.h", &state.bindings_, 0));
+    log.RecordDeps(state.GetNode("out.o", &state.bindings_, 0), 1, deps);
     log.Close();
 
     struct stat st;
@@ -154,9 +154,9 @@ TEST_F(DepsLogTest, DoubleEntry) {
     ASSERT_EQ("", err);
 
     vector<Node*> deps;
-    deps.push_back(state.GetNode("foo.h", 0));
-    deps.push_back(state.GetNode("bar.h", 0));
-    log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
+    deps.push_back(state.GetNode("foo.h", &state.bindings_, 0));
+    deps.push_back(state.GetNode("bar.h", &state.bindings_, 0));
+    log.RecordDeps(state.GetNode("out.o", &state.bindings_, 0), 1, deps);
     log.Close();
 
     struct stat st;
@@ -186,14 +186,14 @@ TEST_F(DepsLogTest, Recompact) {
     ASSERT_EQ("", err);
 
     vector<Node*> deps;
-    deps.push_back(state.GetNode("foo.h", 0));
-    deps.push_back(state.GetNode("bar.h", 0));
-    log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
+    deps.push_back(state.GetNode("foo.h", &state.bindings_, 0));
+    deps.push_back(state.GetNode("bar.h", &state.bindings_, 0));
+    log.RecordDeps(state.GetNode("out.o", &state.bindings_, 0), 1, deps);
 
     deps.clear();
-    deps.push_back(state.GetNode("foo.h", 0));
-    deps.push_back(state.GetNode("baz.h", 0));
-    log.RecordDeps(state.GetNode("other_out.o", 0), 1, deps);
+    deps.push_back(state.GetNode("foo.h", &state.bindings_, 0));
+    deps.push_back(state.GetNode("baz.h", &state.bindings_, 0));
+    log.RecordDeps(state.GetNode("other_out.o", &state.bindings_, 0), 1, deps);
 
     log.Close();
 
@@ -216,8 +216,8 @@ TEST_F(DepsLogTest, Recompact) {
     ASSERT_EQ("", err);
 
     vector<Node*> deps;
-    deps.push_back(state.GetNode("foo.h", 0));
-    log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
+    deps.push_back(state.GetNode("foo.h", &state.bindings_, 0));
+    log.RecordDeps(state.GetNode("out.o", &state.bindings_, 0), 1, deps);
     log.Close();
 
     struct stat st;
@@ -237,14 +237,14 @@ TEST_F(DepsLogTest, Recompact) {
     string err;
     ASSERT_TRUE(log.Load(kTestFilename, &state, &err));
 
-    Node* out = state.GetNode("out.o", 0);
+    Node* out = state.GetNode("out.o", &state.bindings_, 0);
     DepsLog::Deps* deps = log.GetDeps(out);
     ASSERT_TRUE(deps);
     ASSERT_EQ(1, deps->mtime);
     ASSERT_EQ(1, deps->node_count);
     ASSERT_EQ("foo.h", deps->nodes[0]->path());
 
-    Node* other_out = state.GetNode("other_out.o", 0);
+    Node* other_out = state.GetNode("other_out.o", &state.bindings_, 0);
     deps = log.GetDeps(other_out);
     ASSERT_TRUE(deps);
     ASSERT_EQ(1, deps->mtime);
@@ -286,14 +286,14 @@ TEST_F(DepsLogTest, Recompact) {
     string err;
     ASSERT_TRUE(log.Load(kTestFilename, &state, &err));
 
-    Node* out = state.GetNode("out.o", 0);
+    Node* out = state.GetNode("out.o", &state.bindings_, 0);
     DepsLog::Deps* deps = log.GetDeps(out);
     ASSERT_TRUE(deps);
     ASSERT_EQ(1, deps->mtime);
     ASSERT_EQ(1, deps->node_count);
     ASSERT_EQ("foo.h", deps->nodes[0]->path());
 
-    Node* other_out = state.GetNode("other_out.o", 0);
+    Node* other_out = state.GetNode("other_out.o", &state.bindings_, 0);
     deps = log.GetDeps(other_out);
     ASSERT_TRUE(deps);
     ASSERT_EQ(1, deps->mtime);
@@ -359,14 +359,14 @@ TEST_F(DepsLogTest, Truncated) {
     ASSERT_EQ("", err);
 
     vector<Node*> deps;
-    deps.push_back(state.GetNode("foo.h", 0));
-    deps.push_back(state.GetNode("bar.h", 0));
-    log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
+    deps.push_back(state.GetNode("foo.h", &state.bindings_, 0));
+    deps.push_back(state.GetNode("bar.h", &state.bindings_, 0));
+    log.RecordDeps(state.GetNode("out.o", &state.bindings_, 0), 1, deps);
 
     deps.clear();
-    deps.push_back(state.GetNode("foo.h", 0));
-    deps.push_back(state.GetNode("bar2.h", 0));
-    log.RecordDeps(state.GetNode("out2.o", 0), 2, deps);
+    deps.push_back(state.GetNode("foo.h", &state.bindings_, 0));
+    deps.push_back(state.GetNode("bar2.h", &state.bindings_, 0));
+    log.RecordDeps(state.GetNode("out2.o", &state.bindings_, 0), 2, deps);
 
     log.Close();
   }
@@ -418,14 +418,14 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
     ASSERT_EQ("", err);
 
     vector<Node*> deps;
-    deps.push_back(state.GetNode("foo.h", 0));
-    deps.push_back(state.GetNode("bar.h", 0));
-    log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
+    deps.push_back(state.GetNode("foo.h", &state.bindings_, 0));
+    deps.push_back(state.GetNode("bar.h", &state.bindings_, 0));
+    log.RecordDeps(state.GetNode("out.o", &state.bindings_, 0), 1, deps);
 
     deps.clear();
-    deps.push_back(state.GetNode("foo.h", 0));
-    deps.push_back(state.GetNode("bar2.h", 0));
-    log.RecordDeps(state.GetNode("out2.o", 0), 2, deps);
+    deps.push_back(state.GetNode("foo.h", &state.bindings_, 0));
+    deps.push_back(state.GetNode("bar2.h", &state.bindings_, 0));
+    log.RecordDeps(state.GetNode("out2.o", &state.bindings_, 0), 2, deps);
 
     log.Close();
   }
@@ -448,16 +448,16 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
     err.clear();
 
     // The truncated entry should've been discarded.
-    EXPECT_EQ(NULL, log.GetDeps(state.GetNode("out2.o", 0)));
+    EXPECT_EQ(NULL, log.GetDeps(state.GetNode("out2.o", &state.bindings_, 0)));
 
     EXPECT_TRUE(log.OpenForWrite(kTestFilename, &err));
     ASSERT_EQ("", err);
 
     // Add a new entry.
     vector<Node*> deps;
-    deps.push_back(state.GetNode("foo.h", 0));
-    deps.push_back(state.GetNode("bar2.h", 0));
-    log.RecordDeps(state.GetNode("out2.o", 0), 3, deps);
+    deps.push_back(state.GetNode("foo.h", &state.bindings_, 0));
+    deps.push_back(state.GetNode("bar2.h", &state.bindings_, 0));
+    log.RecordDeps(state.GetNode("out2.o", &state.bindings_, 0), 3, deps);
 
     log.Close();
   }
@@ -471,7 +471,7 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
     EXPECT_TRUE(log.Load(kTestFilename, &state, &err));
 
     // The truncated entry should exist.
-    DepsLog::Deps* deps = log.GetDeps(state.GetNode("out2.o", 0));
+    DepsLog::Deps* deps = log.GetDeps(state.GetNode("out2.o", &state.bindings_, 0));
     ASSERT_TRUE(deps);
   }
 }

--- a/src/disk_interface.h
+++ b/src/disk_interface.h
@@ -37,6 +37,14 @@ struct FileReader {
   /// On error, return another Status and fill |err|.
   virtual Status ReadFile(const string& path, string* contents,
                           string* err) = 0;
+
+  // Change the current working directory.  On success, return Okay.
+  // On error, return another Status and fill |err|.
+  virtual Status Chdir(const string& path, string* err) = 0;
+
+  // Get the current working directory.  On success, return Okay.
+  // On error, return another Status and fill |err|.
+  virtual Status Getcwd(string* path, string* err) = 0;
 };
 
 /// Interface for accessing the disk.
@@ -79,6 +87,8 @@ struct RealDiskInterface : public DiskInterface {
   virtual bool MakeDir(const string& path);
   virtual bool WriteFile(const string& path, const string& contents);
   virtual Status ReadFile(const string& path, string* contents, string* err);
+  virtual Status Chdir(const string& path, string* err);
+  virtual Status Getcwd(string* path, string* err);
   virtual int RemoveFile(const string& path);
 
   /// Whether stat information can be cached.  Only has an effect on Windows.

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -229,6 +229,14 @@ struct StatTest : public StateTestWithBuiltinRules,
     assert(false);
     return NotFound;
   }
+  virtual Status Chdir(const string& path, string* err) {
+    assert(false);
+    return NotFound;
+  }
+  virtual Status Getcwd(string* path, string* err) {
+    assert(false);
+    return NotFound;
+  }
   virtual int RemoveFile(const string& path) {
     assert(false);
     return 0;

--- a/src/dyndep_parser.cc
+++ b/src/dyndep_parser.cc
@@ -204,7 +204,7 @@ bool DyndepParser::ParseEdge(string* err) {
     uint64_t slash_bits;
     if (!CanonicalizePath(&path, &slash_bits, &path_err))
       return lexer_.Error(path_err, err);
-    Node* n = state_->GetNode(path, slash_bits);
+    Node* n = state_->GetNode(path, &env_, slash_bits);
     dyndeps->implicit_inputs_.push_back(n);
   }
 
@@ -215,7 +215,7 @@ bool DyndepParser::ParseEdge(string* err) {
     uint64_t slash_bits;
     if (!CanonicalizePath(&path, &slash_bits, &path_err))
       return lexer_.Error(path_err, err);
-    Node* n = state_->GetNode(path, slash_bits);
+    Node* n = state_->GetNode(path, &env_, slash_bits);
     dyndeps->implicit_outputs_.push_back(n);
   }
 

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -20,7 +20,7 @@ string BindingEnv::LookupVariable(const string& var) {
   map<string, string>::iterator i = bindings_.find(var);
   if (i != bindings_.end())
     return i->second;
-  if (parent_)
+  if (parent_ && !HasRelPath())
     return parent_->LookupVariable(var);
   return "";
 }
@@ -45,7 +45,7 @@ const Rule* BindingEnv::LookupRule(const string& rule_name) {
   map<string, const Rule*>::iterator i = rules_.find(rule_name);
   if (i != rules_.end())
     return i->second;
-  if (parent_)
+  if (parent_ && !HasRelPath())
     return parent_->LookupRule(rule_name);
   return NULL;
 }
@@ -90,7 +90,7 @@ string BindingEnv::LookupWithFallback(const string& var,
   if (eval)
     return eval->Evaluate(env);
 
-  if (parent_)
+  if (parent_ && !HasRelPath())
     return parent_->LookupVariable(var);
 
   return "";

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -473,10 +473,10 @@ TEST_F(GraphTest, Decanonicalize) {
   EXPECT_EQ(root_nodes[1]->path(), "out/out2/out3/out4");
   EXPECT_EQ(root_nodes[2]->path(), "out3");
   EXPECT_EQ(root_nodes[3]->path(), "out4/foo");
-  EXPECT_EQ(root_nodes[0]->PathDecanonicalized(), "out\\out1");
-  EXPECT_EQ(root_nodes[1]->PathDecanonicalized(), "out\\out2/out3\\out4");
-  EXPECT_EQ(root_nodes[2]->PathDecanonicalized(), "out3");
-  EXPECT_EQ(root_nodes[3]->PathDecanonicalized(), "out4\\foo");
+  EXPECT_EQ(root_nodes[0]->PathDecanonicalized(&state_.bindings_), "out\\out1");
+  EXPECT_EQ(root_nodes[1]->PathDecanonicalized(&state_.bindings_), "out\\out2/out3\\out4");
+  EXPECT_EQ(root_nodes[2]->PathDecanonicalized(&state_.bindings_), "out3");
+  EXPECT_EQ(root_nodes[3]->PathDecanonicalized(&state_.bindings_), "out4\\foo");
 }
 #endif
 

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -18,8 +18,11 @@
 #include "string_piece.h"
 
 // Windows may #define ERROR.
+#ifdef _WIN32
+#include <windows.h>
 #ifdef ERROR
 #undef ERROR
+#endif
 #endif
 
 struct EvalString;

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -115,4 +115,5 @@ int main(int argc, char* argv[]) {
   int max = *max_element(times.begin(), times.end());
   float total = accumulate(times.begin(), times.end(), 0.0f);
   printf("min %dms  max %dms  avg %.1fms\n", min, max, total / times.size());
+  return 0;
 }

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -298,8 +298,12 @@ Node* NinjaMain::CollectTarget(const char* cpath, string* err) {
     }
     return node;
   } else {
+    // About to abort, so corrupt state_ to get a valid Node* out of it.
+    node = state_.GetNode(path, &state_.bindings_, slash_bits);
     *err =
-        "unknown target '" + Node::PathDecanonicalized(path, slash_bits) + "'";
+        "unknown target '" + node->PathDecanonicalized(&state_.bindings_) + "'";
+    state_.paths_.erase(node->path());
+
     if (path == "clean") {
       *err += ", did you mean 'ninja -t clean'?";
     } else if (path == "help") {

--- a/src/state.h
+++ b/src/state.h
@@ -94,13 +94,13 @@ struct State {
 
   Edge* AddEdge(const Rule* rule);
 
-  Node* GetNode(StringPiece path, uint64_t slash_bits);
+  Node* GetNode(StringPiece path, BindingEnv* env, uint64_t slash_bits);
   Node* LookupNode(StringPiece path) const;
   Node* SpellcheckNode(const string& path);
 
   void AddIn(Edge* edge, StringPiece path, uint64_t slash_bits);
   bool AddOut(Edge* edge, StringPiece path, uint64_t slash_bits);
-  bool AddDefault(StringPiece path, string* error);
+  bool AddDefault(StringPiece path, BindingEnv* env, string* error);
 
   /// Reset state.  Keeps all nodes and edges, but restores them to the
   /// state where we haven't yet examined the disk for dirty state.

--- a/src/state_test.cc
+++ b/src/state_test.cc
@@ -38,9 +38,9 @@ TEST(State, Basic) {
 
   EXPECT_EQ("cat in1 in2 > out", edge->EvaluateCommand());
 
-  EXPECT_FALSE(state.GetNode("in1", 0)->dirty());
-  EXPECT_FALSE(state.GetNode("in2", 0)->dirty());
-  EXPECT_FALSE(state.GetNode("out", 0)->dirty());
+  EXPECT_FALSE(state.GetNode("in1", &state.bindings_, 0)->dirty());
+  EXPECT_FALSE(state.GetNode("in2", &state.bindings_, 0)->dirty());
+  EXPECT_FALSE(state.GetNode("out", &state.bindings_, 0)->dirty());
 }
 
 }  // namespace

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -18,6 +18,7 @@
 #include <stdio.h>
 
 #include <algorithm>
+#include <sstream>
 
 #include "util.h"
 
@@ -107,10 +108,38 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
 
   // Do not prepend 'cmd /c' on Windows, this breaks command
   // lines greater than 8,191 chars.
-  if (!CreateProcessA(NULL, (char*)command.c_str(), NULL, NULL,
+  std::string updatedCommand;
+  const char* pcommand = command.c_str();
+  char* chdir = NULL;
+  // Parse the command: if it starts with "cmd /c cd\"" and also has the
+  // endCD string, remove that much and call CreateProcessA(chdir). Even
+  // if the build.ninja somehow contained this string through some other
+  // means, this transformation will not cause the command to fail.
+  static const string hasCD = "cmd /c cd \"";
+  if (command.substr(0, hasCD.size()) == hasCD) {
+    auto endCD = command.find("\" && ", hasCD.size());
+    if (endCD == string::npos) {
+      chdir = _fullpath(NULL /*_fullpath will malloc*/,
+                        command.substr(hasCD.size(), endCD - hasCD.size())
+                               .c_str(),
+                        PATH_MAX);
+      if (!chdir) {
+        stringstream ss;
+        ss << "_fullpath(" << command << ") failed: errno=" << errno;
+        Fatal(ss.str().c_str());
+      }
+      updatedCommand = command.substr(endCD + 5);
+      pcommand = updatedCommand.c_str();
+    }
+  }
+  // CreateProcessA() here may have chdir == NULL.
+  if (!CreateProcessA(NULL, (char*)pcommand, NULL, NULL,
                       /* inherit handles */ TRUE, process_flags,
-                      NULL, NULL,
+                      NULL, chdir,
                       &startup_info, &process_info)) {
+    if (chdir) {
+      free(chdir);
+    }
     DWORD error = GetLastError();
     if (error == ERROR_FILE_NOT_FOUND) {
       // File (program) not found error is treated as a normal build
@@ -131,6 +160,9 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
     } else {
       Win32Fatal("CreateProcess");    // pass all other errors to Win32Fatal
     }
+  }
+  if (chdir) {
+    free(chdir);
   }
 
   // Close pipe channel only used by the child.

--- a/src/test.h
+++ b/src/test.h
@@ -148,6 +148,8 @@ struct VirtualFileSystem : public DiskInterface {
   virtual bool WriteFile(const string& path, const string& contents);
   virtual bool MakeDir(const string& path);
   virtual Status ReadFile(const string& path, string* contents, string* err);
+  virtual Status Chdir(const string& path, string* err);
+  virtual Status Getcwd(string* path, string* err);
   virtual int RemoveFile(const string& path);
 
   /// An entry for a single in-memory file.
@@ -166,6 +168,9 @@ struct VirtualFileSystem : public DiskInterface {
 
   /// A simple fake timestamp for file operations.
   int now_;
+
+  /// Current directory for file operations, should end in '/' if not empty.
+  string cwd_;
 };
 
 struct ScopedTempDir {


### PR DESCRIPTION
This feature lets a build.ninja depend on a submodule that has its own ninja build system. The submodule is built exactly as if it had been built independently on the command line.
```
rule cc
    command = gcc -o $out -Iinclude $in -Wall

build foo.exe: cc src/foo.c | submodules/bar/libbar.a

subninja build.ninja
    chdir = submodules/bar
```

This feature guarantees that variables defined in the parent cannot leak into the submodule, causing hard-to-fix bugs.

The parent must list a dependency on a file in the submodule for the submodule to actually be built. If there is a `default` in the submodule, it is ignored. The submodule build is invoked just as it would be with the specific file target on the command line.

When building in a chdir, `Edge::EvaluateCommand()` will prefix a command with `"cd " + chdir + " && "` (for posix) or `"cmd /c cd " + chdir + " && "` (for windows). See https://ninja-build.org/manual.html#ref_rule_command.

Other minor changes:

1. Each `Node` is still globally unique. `State::GetNode()` takes a new argument, `BindingEnv* env`, and `BindingEnv` now holds the `abs_path_` of any chdir for the target.

2. Variables cannot leak across a chdir. `BindingEnv`, `LookupVariable()`, `LookupRule()` and `LookupWithFallback()` stop all lookups at a chdir boundary.

3. `ManifestParser::ParseFileInclude()` will update any `Node` that starts with the chdir path. The `Node` is updated to point to the new chdir `BindingEnv`.

4. When expanding rspfiles and depfiles, the current chdir is added to the front of any filename.

5. The reverse is done in Node::PathDecanonicalized(), which strips off the chdir.

**Performance Impact**

The baseline chromium build, `ninja` binary in depot_tools as of 2018-Oct with 12 CPUs takes 59m59.473s:
```
chromium/src$ rm -rf out/Release; gn gen out/Release --args="is_debug = false use_jumbo_build = true enable_nacl = false"
Done. Made 10583 targets from 1756 files in 2699ms
chromium/src$ time ninja -C out/Release chrome -l 12
ninja: Entering directory `out/Release'
[20398/20398] LINK ./chrome

real    59m59.473s
user    570m51.021s
sys     15m48.949s
chromium/src$
```

This patched ninja builds chromium with times of:
* 59m48.549s = 3588.549s
* 59m12.656s = 3552.656s
```
chromium/src$ rm -rf out/Release; gn gen out/Release --args="is_debug = false use_jumbo_build = true enable_nacl = false"
Done. Made 10583 targets from 1756 files in 2431ms
chromium/src$ time path/to/my/subninja -d stats -C out/Release chrome -l 12
ninja: Entering directory `out/Release'
[20398/20398] LINK ./chrome
metric                  count   avg (us)        total (ms)
.ninja parse            4016    1314.6          5279.6
canonicalize str        2687737 0.1             306.1
canonicalize path       4557029 0.1             439.0
lookup node             4557028 0.2             953.1
.ninja_log load         1       19.0            0.0
.ninja_deps load        1       4.0             0.0
node stat               133389  3.6             484.5
depfile load            160     12.4            2.0
StartEdge               20398   10406.7         212276.1
FinishCommand           20398   342.7           6990.0

path->node hash load 0.74 (145294 entries / 196613 buckets)

real    59m48.549s
user    571m9.050s
sys     15m45.269s
chromium/src$ rm -rf out/Release; gn gen out/Release --args="is_debug = false use_jumbo_build = true enable_nacl = false"
Done. Made 10583 targets from 1756 files in 2429ms
chromium/src$ time path/to/my/subninja -d stats -C out/Release chrome -l 12
ninja: Entering directory `out/Release'
[20398/20398] LINK ./chrome
metric                  count   avg (us)        total (ms)
.ninja parse            4016    1349.3          5418.9
canonicalize str        2687737 0.1             311.0
canonicalize path       4557029 0.1             438.7
lookup node             4557028 0.2             964.9
.ninja_log load         1       23.0            0.0
.ninja_deps load        1       4.0             0.0
node stat               133389  3.6             483.8
depfile load            160     12.7            2.0
StartEdge               20398   10630.7         216844.4
FinishCommand           20398   345.9           7056.4

path->node hash load 0.74 (145294 entries / 196613 buckets)

real    59m12.656s
user    569m45.955s
sys     15m41.942s
chromium/src$
```

Baseline manifest_parser_perftest from a clean git clone of https://github.com/ninja-build/ninja
reports an average of 540.0ms:
```
ninja$ ./manifest_parser_perftest
Creating manifest data...done.
516ms (hash: 768e41c)
556ms (hash: 768e41c)
538ms (hash: 768e41c)
544ms (hash: 768e41c)
546ms (hash: 768e41c)
min 516ms  max 556ms  avg 540.0ms
ninja$
```

Using this patched version, manifest_parser_perftest reports 570.0ms average:
```
subninja$ ./manifest_parser_perftest
544ms (hash: 768e41c)
577ms (hash: 768e41c)
575ms (hash: 768e41c)
576ms (hash: 768e41c)
578ms (hash: 768e41c)
min 544ms  max 578ms  avg 570.0ms
subninja$
```