### PR TITLE
Prevent unnecessary reconfig by not writing build.ninja to .ninja_log.

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -117,8 +117,8 @@ BuildLog::LogEntry::LogEntry(const string& output, uint64_t command_hash,
     start_time(start_time), end_time(end_time), mtime(restat_mtime)
 {}
 
-BuildLog::BuildLog()
-  : log_file_(NULL), needs_recompaction_(false) {}
+BuildLog::BuildLog(const string& path)
+  : BuildFile(path), log_file_(NULL), needs_recompaction_(false) {}
 
 BuildLog::~BuildLog() {
   Close();
@@ -365,6 +365,9 @@ BuildLog::LogEntry* BuildLog::LookupByOutput(const string& path) {
 }
 
 bool BuildLog::WriteEntry(FILE* f, const LogEntry& entry) {
+  if (entry.output == BuildFile)
+    return true;
+
   return fprintf(f, "%d\t%d\t%" PRId64 "\t%s\t%" PRIx64 "\n",
           entry.start_time, entry.end_time, entry.mtime,
           entry.output.c_str(), entry.command_hash) > 0;

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -40,7 +40,7 @@ struct BuildLogUser {
 /// 2) timing information, perhaps for generating reports
 /// 3) restat information
 struct BuildLog {
-  BuildLog();
+  BuildLog(const string& path);
   ~BuildLog();
 
   bool OpenForWrite(const string& path, const BuildLogUser& user, string* err);
@@ -85,6 +85,7 @@ struct BuildLog {
   const Entries& entries() const { return entries_; }
 
  private:
+  string BuildFile;
   Entries entries_;
   FILE* log_file_;
   bool needs_recompaction_;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -82,8 +82,10 @@ struct Options {
 /// The Ninja main() loads up a series of data structures; various tools need
 /// to poke into these, so store them as fields on an object.
 struct NinjaMain : public BuildLogUser {
-  NinjaMain(const char* ninja_command, const BuildConfig& config) :
-      ninja_command_(ninja_command), config_(config) {}
+  NinjaMain(const char* ninja_command, const char* input_file,
+            const BuildConfig& config)
+    : ninja_command_(ninja_command), config_(config), build_log_(input_file) {
+  }
 
   /// Command line used to run Ninja.
   const char* ninja_command_;
@@ -1292,14 +1294,14 @@ NORETURN void real_main(int argc, char** argv) {
   if (options.tool && options.tool->when == Tool::RUN_AFTER_FLAGS) {
     // None of the RUN_AFTER_FLAGS actually use a NinjaMain, but it's needed
     // by other tools.
-    NinjaMain ninja(ninja_command, config);
+    NinjaMain ninja(ninja_command, options.input_file, config);
     exit((ninja.*options.tool->func)(&options, argc, argv));
   }
 
   // Limit number of rebuilds, to prevent infinite loops.
   const int kCycleLimit = 100;
   for (int cycle = 1; cycle <= kCycleLimit; ++cycle) {
-    NinjaMain ninja(ninja_command, config);
+    NinjaMain ninja(ninja_command, options.input_file, config);
 
     ManifestParserOptions parser_opts;
     if (options.dupe_edges_should_err) {


### PR DESCRIPTION
This is a fix to #1376.