### PR TITLE
Support for the question option

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -158,8 +158,9 @@ struct CommandRunner {
 
 /// Options (e.g. verbosity, parallelism) passed to a build.
 struct BuildConfig {
-  BuildConfig() : verbosity(NORMAL), dry_run(false), parallelism(1),
-                  failures_allowed(1), max_load_average(-0.0f) {}
+  BuildConfig() : verbosity(NORMAL), dry_run(false), question(false),
+                  parallelism(1), failures_allowed(1),
+                  max_load_average(-0.0f) {}
 
   enum Verbosity {
     NORMAL,
@@ -168,6 +169,7 @@ struct BuildConfig {
   };
   Verbosity verbosity;
   bool dry_run;
+  bool question;
   int parallelism;
   int failures_allowed;
   /// The maximum load average we must not exceed. A negative value


### PR DESCRIPTION
This change implements the -q (question) option which is analogous to
Make: when set Ninja doesn't produce any output and exits with zero
status if there's no work to do, non-zero otherwise. This is useful in
scenarios such as continuous integration build as a sanity check to
ensure there are no dirty targets after finishing the build (which will
happen if some outputs/dependencies aren't correctly tracked).