### PR TITLE
Add remaining time estimate to Ninja status.

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -205,6 +205,7 @@ Several placeholders are available:
 `%c`:: Current rate of finished edges per second (average over builds
 specified by `-j` or its default)
 `%e`:: Elapsed time in seconds.  _(Available since Ninja 1.2.)_
+`%h`:: Estimated time remaining.  _(Available since Ninja 1.10.)_
 `%%`:: A plain `%` character.
 
 The default progress status is `"[%f/%t] "` (note the trailing space

--- a/src/build.cc
+++ b/src/build.cc
@@ -274,6 +274,28 @@ string BuildStatus::FormatProgressStatus(
         break;
       }
 
+      case 'h': {
+        double ratio_finished = double(finished_edges_) / total_edges_;
+        if (overall_rate_.Elapsed() < 1.0 || ratio_finished < 0.01) {
+          snprintf(buf, sizeof(buf), "--m --s");
+        } else {
+          double time_remaining =
+              (1.0 / ratio_finished - 1) * overall_rate_.Elapsed();
+          int hours = int(time_remaining) / 3600;
+          int minutes = (int(time_remaining) % 3600) / 60;
+          int seconds = int(time_remaining) % 60;
+          if (hours > 0) {
+            snprintf(buf, sizeof(buf), "%dh %dm", hours, minutes);
+          } else if (minutes > 0) {
+            snprintf(buf, sizeof(buf), "%dm %ds", minutes, seconds);
+          } else {
+            snprintf(buf, sizeof(buf), "%ds", seconds);
+          }
+        }
+        out += buf;
+        break;
+      }
+
       default:
         Fatal("unknown placeholder '%%%c' in $NINJA_STATUS", *s);
         return "";


### PR DESCRIPTION
Creates a new token `%h` (for "human readable", more suitable letters were already taken) that displays an estimate on how long the current build will last.

It's meant to be informative rather than accurate. When there is a lot of time remaining it will look like this:

    1h 15m

and when there is only a small amount of work left it looks like this:

    53s
