### PR TITLE
Enable ninja to use > 64 CPUs on Windows

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -351,7 +351,7 @@ else:
     except:
         pass
     if platform.is_mingw():
-        cflags += ['-D_WIN32_WINNT=0x0501']
+        cflags += ['-D_WIN32_WINNT=0x0601']
     ldflags = ['-L$builddir']
     if platform.uses_usr_local():
         cflags.append('-I/usr/local/include')

--- a/src/util.cc
+++ b/src/util.cc
@@ -481,9 +481,7 @@ string StripAnsiEscapeCodes(const string& in) {
 
 int GetProcessorCount() {
 #ifdef _WIN32
-  SYSTEM_INFO info;
-  GetNativeSystemInfo(&info);
-  return info.dwNumberOfProcessors;
+  return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
 #else
 #ifdef CPU_COUNT
   // The number of exposed processors might not represent the actual number of


### PR DESCRIPTION
This incorporates a fix to ninja's calculation of the number of processors on Windows systems with more than 64 cores.

Windows systems with more than 64 logical processors divide the processors into groups, with most applications using only one group. Previously, ninja was using a Windows API call that only counted the number of processors in the first processor group, which resulted in only partial utilization of high-processing-power systems when no -j value was specified.

When building Chrome on a 72-core Windows system, this change has the following effect:

Before:
ninja detects 36 cores (i.e. one processor group only)
Average time to build Chrome over 10 builds: 5628 s

After:
ninja detects all 72 cores
Average time to build Chrome over 10 builds: 3215 s (57% of the time needed before)

This fixes #1603 .