### PR TITLE
add fix for ninja_test to build on AIX 6.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ for:
     build_script:
       ps: "C:\\msys64\\usr\\bin\\bash -lc @\"\n
       pacman -S --quiet --noconfirm --needed re2c 2>&1\n
-      sed -i 's|cmd /c $ar cqs $out.tmp $in && move /Y $out.tmp $out|$ar crs $out $in|g' configure.py\n
+      sed -i 's|cmd /c $ar cqs $out.tmp $in \&\& move /Y $out.tmp $out|$ar crs $out $in|g' configure.py\n
       ./configure.py --bootstrap --platform mingw 2>&1\n
       ./ninja all\n
       ./ninja_test 2>&1\n

--- a/src/test.cc
+++ b/src/test.cc
@@ -33,6 +33,16 @@
 #include "manifest_parser.h"
 #include "util.h"
 
+#ifdef _AIX
+extern "C" {
+	// GCC "helpfully" strips the definition of mkdtemp out on AIX.
+ 	// The function is still present, so if we define it ourselves
+	// it will work perfectly fine.       
+	extern char* mkdtemp(char* name_template);
+}
+#endif
+
+
 namespace {
 
 #ifdef _WIN32

--- a/src/test.cc
+++ b/src/test.cc
@@ -37,7 +37,7 @@
 extern "C" {
 	// GCC "helpfully" strips the definition of mkdtemp out on AIX.
  	// The function is still present, so if we define it ourselves
-	// it will work perfectly fine.
+	// it will work perfectly fine.       
 	extern char* mkdtemp(char* name_template);
 }
 #endif

--- a/src/test.cc
+++ b/src/test.cc
@@ -37,7 +37,7 @@
 extern "C" {
 	// GCC "helpfully" strips the definition of mkdtemp out on AIX.
  	// The function is still present, so if we define it ourselves
-	// it will work perfectly fine.       
+	// it will work perfectly fine.
 	extern char* mkdtemp(char* name_template);
 }
 #endif


### PR DESCRIPTION
this patch fixes issue #1618 and allows ninja_test to build on AIX.

the tests still do not complete successfully, with 1 failure. i will report that in a separate issue if this is merged.