### PR TITLE
fix building ninja_test on AIX 6.1

### DIFF
--- a/src/test.cc
+++ b/src/test.cc
@@ -33,6 +33,15 @@
 #include "manifest_parser.h"
 #include "util.h"
 
+#ifdef _AIX
+extern "C" {
+        // GCC "helpfully" strips the definition of mkdtemp out on AIX.
+        // The function is still present, so if we define it ourselves
+        // it will work perfectly fine.
+        extern char* mkdtemp(char* name_template);
+}
+#endif
+
 namespace {
 
 #ifdef _WIN32


### PR DESCRIPTION
this fixes building ninja_test on AIX 6.1 (issue #1618) but does not fix a failure that occurs when running the tests. i will file that as a separate issue if this is merged.