### PR TITLE
Recommend MD over MMD for header dependencies.

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -569,10 +569,10 @@ Use it like in the following example:
 ----
 rule cc
   depfile = $out.d
-  command = gcc -MMD -MF $out.d [other gcc flags here]
+  command = gcc -MD -MF $out.d [other gcc flags here]
 ----
 
-The `-MMD` flag to `gcc` tells it to output header dependencies, and
+The `-MD` flag to `gcc` tells it to output header dependencies, and
 the `-MF` flag tells it where to write them.
 
 deps


### PR DESCRIPTION
The MMD flag will silently omit includes found through pointy brackets or system include paths. This can lead to issues not only when system headers change, but any paths included through the isystem flag. Because the isystem flag implicitly turns off warnings as errors it has often come to be used as a "not my code" flag used with local third party dependencies which may be frequently updated or changed for debugging. As a result, it is far safer to default to MD (which includes all include dependencies) in this example.