### PR TITLE
List all clang-format options instead of relying on an upstream formatting style.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,10 +16,141 @@
 # Still use your best judgement for formatting decisions: clang-format
 # sometimes makes strange choices.
 
-BasedOnStyle: Google
+# Based on the Clang-7.0 documentation
+
+Language: Cpp
+Standard: Cpp03
+DisableFormat: false
+
+AccessModifierOffset: -2
+
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
+
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+
+BinPackArguments: true
+BinPackParameters: true
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+#  AfterObjCDeclaration
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+
+#BreakAfterJavaFieldAnnotations
+
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+
+ColumnLimit: 80
+
+CommentPragmas: ''
+
+CompactNamespaces: true
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+
 Cpp11BracedListStyle: false
+
+DerivePointerAlignment: false
+
+FixNamespaceComments: false
+
+ForEachMacros: ['']
+
+IncludeBlocks: Preserve
+
+IncludeCategories:
+  - Regex:           '^<.*'
+    Priority:        1
+  - Regex:           '^".*'
+    Priority:        2
+
+IncludeIsMainRegex: "(_test)?$"
+
 IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth: 2
+IndentWrappedFunctionNames: true
+
+#JavaScriptQuotes
+#JavaScriptWrapImports
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+
+#ObjCBinPackProtocolList
+#ObjCBlockIndentWidth
+#ObjCSpaceAfterProperty
+#ObjCSpaceBeforeProtocolList
+
+#PenaltyBreakAssignment
+#PenaltyBreakBeforeFirstCallParameter: 100
+#PenaltyBreakComment: 100
+#PenaltyBreakFirstLessLess: 0
+#PenaltyBreakString: 100
+#PenaltyBreakTemplateDeclaration
+#PenaltyExcessCharacter: 1
+#PenaltyReturnTypeOnItsOwnLine: 20
+
+PointerAlignment: Left
+
+#RawStringFormats:
+
+ReflowComments: false
+
+SortIncludes: false
+SortUsingDeclarations: false
+
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+#SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+TabWidth: 2
+UseTab: Never

--- a/src/clparser_perftest.cc
+++ b/src/clparser_perftest.cc
@@ -20,6 +20,7 @@
 
 int main(int argc, char* argv[]) {
   // Output of /showIncludes from #include <iostream>
+  // clang-format off
   string perf_testdata =
       "Note: including file: C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE\\iostream\r\n"
       "Note: including file:  C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE\\istream\r\n"
@@ -130,6 +131,7 @@ int main(int argc, char* argv[]) {
       "Note: including file:        C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE\\system_error\r\n"
       "Note: including file:         C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE\\cerrno\r\n"
       "Note: including file:        C:\\Program Files (x86)\\Windows Kits\\10\\include\\10.0.10240.0\\ucrt\\share.h\r\n";
+  // clang-format on
 
   for (int limit = 1 << 10; limit < (1<<20); limit *= 2) {
     int64_t start = GetTimeMillis();

--- a/src/lexer.in.cc
+++ b/src/lexer.in.cc
@@ -70,6 +70,7 @@ void Lexer::Start(StringPiece filename, StringPiece input) {
 }
 
 const char* Lexer::TokenName(Token t) {
+  // clang-format off
   switch (t) {
   case ERROR:    return "lexing error";
   case BUILD:    return "'build'";
@@ -87,6 +88,7 @@ const char* Lexer::TokenName(Token t) {
   case SUBNINJA: return "'subninja'";
   case TEOF:     return "eof";
   }
+  // clang-format on
   return NULL;  // not reached
 }
 


### PR DESCRIPTION
This allows for the project to individually tweak formatting options in the future.

The options are as close as I possibly could get to the *actual* coding style of the project, instead of the Google style.

I compared the number of differences with this shell script;

```
git checkout src ; clang-format -i src/*.h src/*.cc ;  git checkout src/getopt.h src/lexer.cc src/depfile_parser.cc src/*test*.cc ; git diff | grep -e "+" -e "-" | wc -l
```

And then compared the final result by hand to ensure nothing particularly egregious was happening. 