### PR TITLE
Use 'deps' with 'depfile'

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -568,8 +568,9 @@ Use it like in the following example:
 
 ----
 rule cc
-  depfile = $out.d
   command = gcc -MMD -MF $out.d [other gcc flags here]
+  depfile = $out.d
+  deps = gcc
 ----
 
 The `-MMD` flag to `gcc` tells it to output header dependencies, and


### PR DESCRIPTION
Without 'deps' stating the format of the 'depfile', the 'depfile' will be silently ignored. The 'depfile' example before this change is broken in that it will not actually store the deps in 'depfile' due to the lack of 'deps'.