### PR TITLE
Error on depfile without deps.

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -943,7 +943,7 @@ bool Builder::FinishCommand(CommandRunner::Result* result, string* err) {
   string deps_type = edge->GetBinding("deps");
   const string deps_prefix = edge->GetBinding("msvc_deps_prefix");
   if (deps_type.empty()) {
-    if (!edge->GetBindingBool("depfile")) {
+    if (edge->GetBindingBool("depfile")) {
       *err = string("edge with depfile but no deps makes no sense");
       return false;
     }

--- a/src/build.cc
+++ b/src/build.cc
@@ -942,7 +942,12 @@ bool Builder::FinishCommand(CommandRunner::Result* result, string* err) {
   vector<Node*> deps_nodes;
   string deps_type = edge->GetBinding("deps");
   const string deps_prefix = edge->GetBinding("msvc_deps_prefix");
-  if (!deps_type.empty()) {
+  if (deps_type.empty()) {
+    if (!edge->GetBindingBool("depfile")) {
+      *err = string("edge with depfile but no deps makes no sense");
+      return false;
+    }
+  } else {
     string extract_err;
     if (!ExtractDeps(result, deps_type, deps_prefix, &deps_nodes,
                      &extract_err) &&


### PR DESCRIPTION
If a rule specifies a depfile but no deps (to specify the format) the depfile is ignored. Make this an error instead of silently ignoring the depfile.