### PR TITLE
Enable build on IBM i platform

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -97,6 +97,9 @@ class Platform(object):
     def is_aix(self):
         return self._platform == 'aix'
 
+    def is_aix_os400_variant(self):
+        return self._platform == 'aix' and os.uname().sysname.startswith('OS400')
+
     def uses_usr_local(self):
         return self._platform in ('freebsd', 'openbsd', 'bitrig', 'dragonfly', 'netbsd')
 
@@ -536,7 +539,7 @@ if platform.is_msvc():
 else:
     libs.append('-lninja')
 
-if platform.is_aix():
+if platform.is_aix() and not platform.is_aix_os400_variant():
     libs.append('-lperfstat')
 
 all_targets = []

--- a/configure.py
+++ b/configure.py
@@ -60,6 +60,8 @@ class Platform(object):
             self._platform = 'netbsd'
         elif self._platform.startswith('aix'):
             self._platform = 'aix'
+        elif self._platform.startswith('os400'):
+            self._platform = 'os400'
         elif self._platform.startswith('dragonfly'):
             self._platform = 'dragonfly'
 
@@ -97,8 +99,8 @@ class Platform(object):
     def is_aix(self):
         return self._platform == 'aix'
 
-    def is_aix_os400_variant(self):
-        return self._platform == 'aix' and os.uname().sysname.startswith('OS400')
+    def is_os400(self):
+        return self._platform == 'os400' or os.uname().sysname.startswith('OS400')
 
     def uses_usr_local(self):
         return self._platform in ('freebsd', 'openbsd', 'bitrig', 'dragonfly', 'netbsd')
@@ -539,7 +541,7 @@ if platform.is_msvc():
 else:
     libs.append('-lninja')
 
-if platform.is_aix() and not platform.is_aix_os400_variant():
+if platform.is_aix() and not platform.is_os400():
     libs.append('-lperfstat')
 
 all_targets = []

--- a/configure.py
+++ b/configure.py
@@ -99,7 +99,7 @@ class Platform(object):
     def is_aix(self):
         return self._platform == 'aix'
 
-    def is_os400(self):
+    def is_os400_pase(self):
         return self._platform == 'os400' or os.uname().sysname.startswith('OS400')
 
     def uses_usr_local(self):
@@ -541,7 +541,7 @@ if platform.is_msvc():
 else:
     libs.append('-lninja')
 
-if platform.is_aix() and not platform.is_os400():
+if platform.is_aix() and not platform.is_os400_pase():
     libs.append('-lperfstat')
 
 all_targets = []

--- a/src/util.cc
+++ b/src/util.cc
@@ -45,7 +45,7 @@
 #elif defined(__SVR4) && defined(__sun)
 #include <unistd.h>
 #include <sys/loadavg.h>
-#elif defined(_AIX)
+#elif defined(_AIX) && !defined(__PASE__)
 #include <libperfstat.h>
 #elif defined(linux) || defined(__GLIBC__)
 #include <sys/sysinfo.h>
@@ -561,6 +561,10 @@ double GetLoadAverage() {
   }
 
   return posix_compatible_load;
+}
+#elif defined (__PASE__)
+double GetLoadAverage() {
+    return -0.0f;
 }
 #elif defined(_AIX)
 double GetLoadAverage() {

--- a/src/util.cc
+++ b/src/util.cc
@@ -562,9 +562,9 @@ double GetLoadAverage() {
 
   return posix_compatible_load;
 }
-#elif defined (__PASE__)
+#elif defined(__PASE__)
 double GetLoadAverage() {
-    return -0.0f;
+  return -0.0f;
 }
 #elif defined(_AIX)
 double GetLoadAverage() {


### PR DESCRIPTION
Python on the IBM i platform actually runs inside an AIX variant named "PASE". The system self-identifies as "OS400" (an unfortunate history of names, perhaps). 

There is no perfstat libraries available for IBM i, and IBM i has no good way to determine load averages. This patch allows builds without load average enforcement, which is better than a failing build. 