### PR TITLE
[PATCH] Fix MinGW bootstrap build.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,6 @@ for:
     build_script:
       ps: "C:\\msys64\\usr\\bin\\bash -lc @\"\n
       pacman -S --quiet --noconfirm --needed re2c 2>&1\n
-      sed -i 's|cmd /c `$ar cqs `$out.tmp `$in \\&\\& move /Y `$out.tmp `$out|`$ar crs `$out `$in|g' configure.py\n
       ./configure.py --bootstrap --platform mingw 2>&1\n
       ./ninja all\n
       ./ninja_test 2>&1\n

--- a/configure.py
+++ b/configure.py
@@ -437,7 +437,7 @@ if host.is_msvc():
            description='LIB $out')
 elif host.is_mingw():
     n.rule('ar',
-           command='cmd /c $ar cqs $out.tmp $in && move /Y $out.tmp $out',
+           command='$ar crs $out $in',
            description='AR $out')
 else:
     n.rule('ar',


### PR DESCRIPTION
I have taken this fix from https://github.com/ninja-build/ninja/blob/d849e8fc856adf1e11cb5100cdf38afb72c09a02/appveyor.yml#L19

Without that fix, it's impossible for me to build under MinGW. I'm getting the following error:

```
$ python configure.py --bootstrap --platform=mingw
bootstrapping ninja...
warning: A compatible version of re2c (>= 0.11.3) was not found; changes to src/*.in.cc will not affect your build.
"lean.o" is not recognized as an internal or external command, operable program or batch file.
when running:  cmd /c ar cqs build/libninja.a.tmp build/build.o build/build_log.o build/clean.o build/clparser.o build/debug_flags.o build/depfile_parser.o build/deps_log.o build/disk_interface.o build/edit_distance.o build/eval_env.o build/graph.o build/graphviz.o build/lexer.o build/line_printer.o build/manifest_parser.o build/metrics.o build/state.o build/string_piece_util.o build/util.o build/version.o build/subprocess-win32.o build/includes_normalize-win32.o build/msvc_helper-win32.o build/msvc_helper_main-win32.o build/getopt.o && move /Y build/libninja.a.tmp build/libninja.a
```

(look how it interprets `build/clean.o` as `build /c lean.o`, aka another command to send to `cmd`)