### PR TITLE
Travis CI: Use Python 3 to configure build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install re2c python ; fi
 script:
   - ./misc/ci.py
-  - ./configure.py --bootstrap
+  - python3 configure.py --bootstrap
   - ./ninja all
   - ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots
   - ./misc/ninja_syntax_test.py


### PR DESCRIPTION
Python 2 doesn't support nanosecond timestamps properly (see #1554).