### PR TITLE
Various continuous integration improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,28 @@ matrix:
     - os: linux
       dist: xenial
       compiler: clang
+    - os: linux
+      dist: bionic
+      compiler: gcc
+    - os: linux
+      dist: bionic
+      compiler: clang
     - os: osx
       osx_image: xcode9.4
     - os: osx
       osx_image: xcode10
     - os: osx
       osx_image: xcode10.1
+    - os: osx
+      osx_image: xcode10.2
+    - os: osx
+      osx_image: xcode10.3
+    - os: osx
+      osx_image: xcode11
 sudo: false
 language: cpp
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install re2c             ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install re2c ; fi
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install re2c python ; fi
 script:
   - ./misc/ci.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,24 +21,27 @@ matrix:
       MSYSTEM: MSVC
 
 for:
-  -
-    matrix:
+  - matrix:
       only:
         - MSYSTEM: MINGW64
+    install:
+      ps: "C:\\msys64\\usr\\bin\\bash -lc \"pacman -S --quiet --noconfirm --needed re2c 2>&1\""
     build_script:
       ps: "C:\\msys64\\usr\\bin\\bash -lc @\"\n
-      pacman -S --quiet --noconfirm --needed re2c 2>&1\n
+      ./misc/ci.py 2>&1\n
       ./configure.py --bootstrap --platform mingw 2>&1\n
       ./ninja all\n
       ./ninja_test 2>&1\n
       ./misc/ninja_syntax_test.py 2>&1\n\"@"
-  -
-    matrix:
+
+  - matrix:
       only:
         - MSYSTEM: MSVC
     build_script:
     - cmd: >-
         call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+
+        python misc/ci.py
 
         python configure.py --bootstrap
 
@@ -52,6 +55,7 @@ for:
       only:
         - image: Ubuntu1804
     build_script:
+      - ./misc/ci.py
       - ./configure.py --bootstrap
       - ./ninja all
       - ./ninja_test

--- a/misc/ci.py
+++ b/misc/ci.py
@@ -3,11 +3,15 @@
 import os
 
 ignores = [
+	'ninja_deps',
 	'.git/',
 	'misc/afl-fuzz-tokens/',
-	'ninja_deps',
 	'src/depfile_parser.cc',
 	'src/lexer.cc',
+	'.git\\',
+	'misc\\afl-fuzz-tokens\\',
+	'src\\depfile_parser.cc',
+	'src\\lexer.cc',
 ]
 
 error_count = 0


### PR DESCRIPTION
Generic: 
- Fix misc/ci.py for windows hosts

Travis CI:
- Add Ubuntu Bionic
- Add more XCode targets
- Configure homebrew using some environment variables that skip several very slow, unnecessary, steps.

Appveyor:
- Ensure misc/ci.py runs on windows hosts
- Run re2c install on mingw target in the dedicated "install" step, instead of during the build.