### PR TITLE
Fix test_issue_1418 to pass on 1-core VM

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -56,7 +56,7 @@ build b: echo
   delay = 2
 build c: echo
   delay = 1
-'''),
+''', '-j3'),
 '''[1/3] echo c\x1b[K
 c
 [2/3] echo b\x1b[K


### PR DESCRIPTION
the previous assert would fail because on a 1-core VM, the 3 outputs
were produced sequentially from top to bottom

This PR was done while working on reproducible builds for openSUSE.