### PR TITLE
Ensure substring indexing never goes negative

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -596,6 +596,12 @@ double GetLoadAverage() {
 #endif // _WIN32
 
 string ElideMiddle(const string& str, size_t width) {
+  switch (width) {
+      case 0: return "";
+      case 1: return ".";
+      case 2: return "..";
+      case 3: return "...";
+  }
   const int kMargin = 3;  // Space for "...".
   string result = str;
   if (result.size() > width) {

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -420,6 +420,10 @@ TEST(ElideMiddle, NothingToElide) {
   string input = "Nothing to elide in this short string.";
   EXPECT_EQ(input, ElideMiddle(input, 80));
   EXPECT_EQ(input, ElideMiddle(input, 38));
+  EXPECT_EQ("", ElideMiddle(input, 0));
+  EXPECT_EQ(".", ElideMiddle(input, 1));
+  EXPECT_EQ("..", ElideMiddle(input, 2));
+  EXPECT_EQ("...", ElideMiddle(input, 3));
 }
 
 TEST(ElideMiddle, ElideInTheMiddle) {


### PR DESCRIPTION
With widths lower than 4, the ElideMiddle function would crash because
its substring access would wrap around and attempt to access the max
size_t value. This patch fixes that.

This situation occasionally occurs on i3 with tmux, where  a new window may make the tmux window sub-3 in width. Ninja then crashes.