### PR TITLE
Add Bionic tweak for getloadavg

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -576,7 +576,7 @@ double GetLoadAverage() {
   // Calculation taken from comment in libperfstats.h
   return double(cpu_stats.loadavg[0]) / double(1 << SBITS);
 }
-#elif defined(__UCLIBC__)
+#elif defined(__UCLIBC__) || (defined(__BIONIC__) && __ANDROID_API__ < 29)
 double GetLoadAverage() {
   struct sysinfo si;
   if (sysinfo(&si) != 0)


### PR DESCRIPTION
Fixes #1560, though in a different way than suggested there. I submitted a native ninja package to the Termux app for Android two years back, termux/termux-packages#1518, and [a version of this patch has been in use on Android ever since](https://github.com/termux/termux-packages/blob/master/packages/ninja/src-util.cc.patch). I ran the tests on Android/ARM 6.0 with this pull and everything passed.

[`getloadavg` was finally added with the just-released Android 10](https://android.googlesource.com/platform/bionic/+/8c0ec114c58a76efcc1c195a03a36675b0967e39/libc/include/stdlib.h#157), [purportedly for ninja](https://android.googlesource.com/platform/bionic/+/2d0b28bc0da1ade2de2b72093dbdb740028fce7c), so this pull uses it if it's there.