### PR TITLE
Fixed processor count detection on Windows

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -481,7 +481,6 @@ string StripAnsiEscapeCodes(const string& in) {
 
 int GetProcessorCount() {
 #ifdef _WIN32
-#if _WIN32_WINNT >= _WIN32_WINNT_WIN7
   // Need to use GetLogicalProcessorInformationEx to get real core count on
   // machines with >64 cores. See https://stackoverflow.com/a/31209344/21475
   DWORD len = 0;
@@ -506,7 +505,7 @@ int GetProcessorCount() {
         return cores;
     }
   }
-#endif
+  // fallback just in case
   return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
 #else
 #ifdef CPU_COUNT

--- a/src/util.cc
+++ b/src/util.cc
@@ -481,6 +481,7 @@ string StripAnsiEscapeCodes(const string& in) {
 
 int GetProcessorCount() {
 #ifdef _WIN32
+#ifndef _WIN64
   // Need to use GetLogicalProcessorInformationEx to get real core count on
   // machines with >64 cores. See https://stackoverflow.com/a/31209344/21475
   DWORD len = 0;
@@ -508,7 +509,7 @@ int GetProcessorCount() {
       }
     }
   }
-  // fallback just in case
+#endif
   return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
 #else
 #ifdef CPU_COUNT

--- a/src/util.cc
+++ b/src/util.cc
@@ -492,9 +492,8 @@ int GetProcessorCount() {
           reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
             buf.data()), &len)) {
       for (DWORD i = 0; i < len; ) {
-        PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX info =
-            reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
-              buf.data() + i);
+        auto info = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
+            buf.data() + i);
         if (info->Relationship == RelationProcessorCore &&
             info->Processor.GroupCount == 1) {
           for (KAFFINITY core_mask = info->Processor.GroupMask[0].Mask;
@@ -504,7 +503,7 @@ int GetProcessorCount() {
         }
         i += info->Size;
       }
-      if (cores) {
+      if (cores != 0) {
         return cores;
       }
     }

--- a/src/util.cc
+++ b/src/util.cc
@@ -481,7 +481,7 @@ string StripAnsiEscapeCodes(const string& in) {
 
 int GetProcessorCount() {
 #ifdef _WIN32
-#if _WIN32_WINNT >= 0x0601
+#if _WIN32_WINNT >= _WIN32_WINNT_WIN7
   // Need to use GetLogicalProcessorInformationEx to get real core count on
   // machines with >64 cores. See https://stackoverflow.com/a/31209344/21475
   DWORD len = 0;

--- a/src/util.cc
+++ b/src/util.cc
@@ -489,20 +489,24 @@ int GetProcessorCount() {
     std::vector<char> buf(len);
     int cores = 0;
     if (GetLogicalProcessorInformationEx(RelationProcessorCore,
-          (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)buf.data(), &len)) {
+          reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
+            buf.data()), &len)) {
       for (DWORD i = 0; i < len; ) {
         PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX info =
-            (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)(buf.data() + i);
+            reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
+              buf.data() + i);
         if (info->Relationship == RelationProcessorCore &&
             info->Processor.GroupCount == 1) {
           for (KAFFINITY core_mask = info->Processor.GroupMask[0].Mask;
-               core_mask; core_mask >>= 1)
+               core_mask; core_mask >>= 1) {
             cores += (core_mask & 1);
+          }
         }
         i += info->Size;
       }
-      if (cores)
+      if (cores) {
         return cores;
+      }
     }
   }
   // fallback just in case


### PR DESCRIPTION
Fixed processor count detection on Windows when multiple process groups (e.g. >64 processors) are present.

On our 80-core system, ninja was defaulting to a parallelism of 42 (only detecting 40 cores). It turns out that this is because the Win32 `GetActiveProcessorCount` function only returns the number of cores in the current core group. Since `ninja` dispatches jobs across the entire system, it makes sense to count the total number of cores across all core groups.

With this fix, `ninja` correctly detects all 80 cores on our system (even when built as a 32-bit binary) and has a default parallelism level of 82.