### PR TITLE
Add GitHub Actions workflow for building release binaries

### DIFF
--- a/.github/workflows/release-ninja-binaries.yml
+++ b/.github/workflows/release-ninja-binaries.yml
@@ -40,6 +40,10 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Release ..
         cmake --build . --parallel --config Release --target ninja
         
+    - name: Strip Linux binary
+      if: matrix.os == 'ubuntu-latest'
+      run: cd build && strip ninja
+        
     - name: Create ninja archive
       shell: bash
       env:

--- a/.github/workflows/release-ninja-binaries.yml
+++ b/.github/workflows/release-ninja-binaries.yml
@@ -1,6 +1,9 @@
 name: Release Ninja Binaries
 
-on: [push]
+on:
+  push:
+  release:
+    types: published
 
 jobs:
   build:
@@ -37,7 +40,7 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Release ..
         cmake --build . --parallel --config Release --target ninja
         
-    - name: Create artifact
+    - name: Create ninja archive
       shell: bash
       env:
         ZIP_NAME: ${{ matrix.zip_name }}
@@ -52,4 +55,13 @@ jobs:
         name: ninja-binary-archives
         path: artifact
         
-        
+    - name: Upload release asset
+      if: github.event.action == 'published'
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./artifact/${{ matrix.zip_name }}.zip
+        asset_name: ${{ matrix.zip_name }}.zip
+        asset_content_type: application/zip

--- a/.github/workflows/release-ninja-binaries.yml
+++ b/.github/workflows/release-ninja-binaries.yml
@@ -1,0 +1,55 @@
+name: Release Ninja Binaries
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            zip_name: ninja-linux
+          - os: macOS-latest
+            zip_name: ninja-mac
+          - os: windows-latest
+            zip_name: ninja-win
+
+    steps:
+    - uses: actions/checkout@v1
+      
+    # Install OS specific dependencies
+    - name: Install Linux dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install re2c
+    - name: Install macOS dependencies
+      if: matrix.os == 'macOS-latest'
+      run: brew install re2c p7zip cmake
+    - name: Install Windows dependencies
+      if: matrix.os == 'windows-latest'
+      run: choco install re2c
+        
+    - name: Build ninja
+      shell: bash
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=Release ..
+        cmake --build . --parallel --config Release --target ninja
+        
+    - name: Create artifact
+      shell: bash
+      env:
+        ZIP_NAME: ${{ matrix.zip_name }}
+      run: |
+        mkdir artifact
+        7z a artifact/${ZIP_NAME}.zip $(find ./build -name ninja -or -name ninja.exe)
+        
+    # Upload ninja binary archive as an artifact
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: ninja-binary-archives
+        path: artifact
+        
+        

--- a/.github/workflows/release-ninja-binaries.yml
+++ b/.github/workflows/release-ninja-binaries.yml
@@ -1,6 +1,7 @@
 name: Release Ninja Binaries
 
 on:
+  pull_request:
   push:
   release:
     types: published

--- a/.github/workflows/release-ninja-binaries.yml
+++ b/.github/workflows/release-ninja-binaries.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-      
+
     # Install OS specific dependencies
     - name: Install Linux dependencies
       if: matrix.os == 'ubuntu-latest'
@@ -32,18 +32,18 @@ jobs:
     - name: Install Windows dependencies
       if: matrix.os == 'windows-latest'
       run: choco install re2c
-        
+
     - name: Build ninja
       shell: bash
       run: |
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release ..
         cmake --build . --parallel --config Release --target ninja
-        
+
     - name: Strip Linux binary
       if: matrix.os == 'ubuntu-latest'
       run: cd build && strip ninja
-        
+
     - name: Create ninja archive
       shell: bash
       env:
@@ -51,14 +51,14 @@ jobs:
       run: |
         mkdir artifact
         7z a artifact/${ZIP_NAME}.zip $(find ./build -name ninja -or -name ninja.exe)
-        
+
     # Upload ninja binary archive as an artifact
     - name: Upload artifact
       uses: actions/upload-artifact@v1
       with:
         name: ninja-binary-archives
         path: artifact
-        
+
     - name: Upload release asset
       if: github.event.action == 'published'
       uses: actions/upload-release-asset@v1.0.1


### PR DESCRIPTION
This adds a GitHub Actions workflow that builds Ninja release binaries for Windows, Linux, and macOS on each commit and stores them as artifacts. For published releases on GitHub, the compiled release binary archives are uploaded as assets.

Currently CMake is used instead of the Python script bootstrapping process, because it kept the steps more similar across platforms (using configure.py on Windows requires extra steps with vcvarsall.bat to make so that the MSVC compiler is found). If configure.py is preferred it should be fairly easy to switch.

Another issue that was mentioned is using the ubuntu-latest image (LTS 18.04), and wanting a binary that works with older versions of Linux. Two ideas to address this are static linking with system libraries, or switching the build to use a Docker image that has an older version of glibc and stdc++. These should also address issue #1533, which using Ubuntu 16.04 as the build image might not.