### PR TITLE
Small code improvement: add const to LookupPool method

### DIFF
--- a/src/state.cc
+++ b/src/state.cc
@@ -84,8 +84,8 @@ void State::AddPool(Pool* pool) {
   pools_[pool->name()] = pool;
 }
 
-Pool* State::LookupPool(const string& pool_name) {
-  map<string, Pool*>::iterator i = pools_.find(pool_name);
+Pool* State::LookupPool(const string& pool_name) const {
+  map<string, Pool*>::const_iterator i = pools_.find(pool_name);
   if (i == pools_.end())
     return NULL;
   return i->second;

--- a/src/state.h
+++ b/src/state.h
@@ -90,7 +90,7 @@ struct State {
   State();
 
   void AddPool(Pool* pool);
-  Pool* LookupPool(const string& pool_name);
+  Pool* LookupPool(const string& pool_name) const;
 
   Edge* AddEdge(const Rule* rule);
 


### PR DESCRIPTION
I have noticed that `LookupPool` method of `State` class can be `const`. Also it's used in `assert` in `AddPool` method and this change will emphasize that there are no side effects.