### PR TITLE
Work around test framework verbosity issue

### DIFF
--- a/.github/workflows/release-ninja-binaries.yml
+++ b/.github/workflows/release-ninja-binaries.yml
@@ -40,7 +40,7 @@ jobs:
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release ..
         cmake --build . --parallel --config Release
-        ctest -vv
+        ctest -vv --output-on-failure
 
     - name: Strip Linux binary
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
ctest knows how to get diagnostic information from a bunch of different unit test frameworks, but apparently not the custom one ninja is using.

This change should ensure we have full test output.