### PR TITLE
Added editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+end_of_line = lf
+
+[CMakeLists.txt]
+indent_style = tab


### PR DESCRIPTION
Automatically solves some issues rejected by ci.py script at edit time in the editors with the plugin installed or builtin support.