### PR TITLE
Add system runtime static linking

### DIFF
--- a/.github/workflows/release-ninja-binaries.yml
+++ b/.github/workflows/release-ninja-binaries.yml
@@ -15,10 +15,13 @@ jobs:
         include:
           - os: ubuntu-latest
             zip_name: ninja-linux
+            extra_cmake_flags: '-DNINJA_STATIC_SYSTEM_LIBS=ON'
           - os: macOS-latest
             zip_name: ninja-mac
+            extra_cmake_flags: ''
           - os: windows-latest
             zip_name: ninja-win
+            extra_cmake_flags: '-DNINJA_STATIC_SYSTEM_LIBS=ON'
 
     steps:
     - uses: actions/checkout@v1
@@ -38,7 +41,7 @@ jobs:
       shell: bash
       run: |
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Release ..
+        cmake -DCMAKE_BUILD_TYPE=Release ${{ matrix.extra_cmake_flags }} ..
         cmake --build . --parallel --config Release
         ctest -vv
 

--- a/.github/workflows/release-ninja-binaries.yml
+++ b/.github/workflows/release-ninja-binaries.yml
@@ -28,13 +28,13 @@ jobs:
 
     # Install OS specific dependencies
     - name: Install Linux dependencies
-      if: matrix.os == 'ubuntu-latest'
+      if: runner.os == 'Linux'
       run: sudo apt-get install re2c
     - name: Install macOS dependencies
-      if: matrix.os == 'macOS-latest'
+      if: runner.os == 'macOS'
       run: brew install re2c p7zip cmake
     - name: Install Windows dependencies
-      if: matrix.os == 'windows-latest'
+      if: runner.os == 'Windows'
       run: choco install re2c
 
     - name: Build ninja
@@ -46,7 +46,7 @@ jobs:
         ctest -vv
 
     - name: Strip Linux binary
-      if: matrix.os == 'ubuntu-latest'
+      if: runner.os == 'Linux'
       run: cd build && strip ninja
 
     - name: Create ninja archive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 project(ninja)
 
+option(NINJA_STATIC_SYSTEM_LIBS "Static link the system runtime libraries" OFF)
+
 if(CMAKE_BUILD_TYPE MATCHES "Release")
 	cmake_policy(SET CMP0069 NEW)
 	include(CheckIPOSupported)
@@ -18,6 +20,39 @@ if(MSVC)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /GR- /Zc:__cplusplus")
 else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -fdiagnostics-color")
+endif()
+
+# Add flags for static linking with system runtime libraries (e.g. MSVCRT, libstdc++)
+if(NINJA_STATIC_SYSTEM_LIBS)
+	# Macro to add static linking flags based on the compiler
+	macro(ninja_add_static_flags flags_var)
+		if(NOT MSVC)
+			# Defaults that should work with gcc and clang (with libstdc++), possibly other compilers
+			set(${flags_var} "${${flags_var}} -static-libstdc\\+\\+ -static-libgcc")
+		else()
+			# With MSVC the dynamic runtime flag /MD needs replacing
+			string(REGEX REPLACE "/MD" "/MT" ${flags_var} "${${flags_var}}")
+		endif()
+	endmacro()
+
+	if("${CMAKE_CONFIGURATION_TYPES}" STREQUAL "")
+		# Add flags for single configuration build systems (i.e. make, ninja)
+		if("${CMAKE_BUILD_TYPE}" STREQUAL "")
+			ninja_add_static_flags("CMAKE_C_FLAGS")
+			ninja_add_static_flags("CMAKE_CXX_FLAGS")
+		else()
+			string(TOUPPER ${CMAKE_BUILD_TYPE} build_type)
+			ninja_add_static_flags("CMAKE_C_FLAGS_${build_type}")
+			ninja_add_static_flags("CMAKE_CXX_FLAGS_${build_type}")
+		endif()
+	else()
+		# Add flags for multi configuration build systems (i.e. msvc, xcode)
+		foreach(build_type ${CMAKE_CONFIGURATION_TYPES})
+			string(TOUPPER ${build_type} build_type)
+			ninja_add_static_flags("CMAKE_C_FLAGS_${build_type}")
+			ninja_add_static_flags("CMAKE_CXX_FLAGS_${build_type}")
+		endforeach()
+	endif()
 endif()
 
 find_program(RE2C re2c)


### PR DESCRIPTION
Re: Issue #1692

This adds a `NINJA_STATIC_SYSTEM_LIBS` CMake option that can be used to add the flags needed for static linking with the system runtime libraries with VC++ on Windows and gcc/clang (using libstdc++) on other platforms. It should handle adding flags for multi-configuration and single build type CMake generators correctly.

By default the static linking option is off so users building and installing a copy of ninja from source on their systems will link with the shared system libraries and (in theory) be able to get whatever benefits come from updating the system libraries.

The builds on GitHub Actions enable the static linking option for Windows and Linux builds (checking the new Windows binary with `dumpbin /dependents` shows none of the VC++ runtime libraries, the Linux binaries have a significantly smaller number of system library dependencies).

There's also a minor switch from matrix.os to runner.os which should be more reliable for checking the OS type than using image names.

Some future areas for improving the compatibility of released binaries:
- This brings the Linux binaries close to working on more systems, the next step will be switching over to a CentOS 6 Docker image for building the Linux release binary.
- Apple doesn't support static linking with system libraries, so the option is not enabled for macOS builds (I have some other ideas to try). Gatekeeper on 10.15 is a challenge.

