### PR TITLE
CMake: Use static MSVC runtime, fixes #1692

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: Release Ninja Binaries
+name: macOS
 
 on:
   pull_request:
@@ -8,26 +8,13 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macOS-latest, windows-latest]
-        include:
-          - os: macOS-latest
-            zip_name: ninja-mac
-          - os: windows-latest
-            zip_name: ninja-win
+    runs-on: macOS-latest
 
     steps:
     - uses: actions/checkout@v1
 
-    # Install OS specific dependencies
-    - name: Install macOS dependencies
-      if: matrix.os == 'macOS-latest'
+    - name: Install dependencies
       run: brew install re2c p7zip cmake
-    - name: Install Windows dependencies
-      if: matrix.os == 'windows-latest'
-      run: choco install re2c
 
     - name: Build ninja
       shell: bash
@@ -39,11 +26,9 @@ jobs:
 
     - name: Create ninja archive
       shell: bash
-      env:
-        ZIP_NAME: ${{ matrix.zip_name }}
       run: |
         mkdir artifact
-        7z a artifact/${ZIP_NAME}.zip $(find ./build -name ninja -or -name ninja.exe)
+        7z a artifact/ninja-mac.zip ./build/ninja
 
     # Upload ninja binary archive as an artifact
     - name: Upload artifact
@@ -59,6 +44,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./artifact/${{ matrix.zip_name }}.zip
-        asset_name: ${{ matrix.zip_name }}.zip
+        asset_path: ./artifact/ninja-mac.zip
+        asset_name: ninja-mac.zip
         asset_content_type: application/zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,49 @@
+name: Windows
+
+on:
+  pull_request:
+  push:
+  release:
+    types: published
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install dependencies
+      run: choco install re2c
+
+    - name: Build ninja
+      shell: bash
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=Release ..
+        cmake --build . --parallel --config Release
+        ctest -vv
+
+    - name: Create ninja archive
+      shell: bash
+      run: |
+        mkdir artifact
+        7z a artifact/ninja-win.zip ./build/Release/ninja.exe
+
+    # Upload ninja binary archive as an artifact
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: ninja-binary-archives
+        path: artifact
+
+    - name: Upload release asset
+      if: github.event.action == 'published'
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./artifact/ninja-win.zip
+        asset_name: ninja-win.zip
+        asset_content_type: application/zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
+cmake_policy(SET CMP0091 NEW)
 project(ninja)
 
 if(CMAKE_BUILD_TYPE MATCHES "Release")
@@ -15,6 +16,7 @@ if(CMAKE_BUILD_TYPE MATCHES "Release")
 endif()
 
 if(MSVC)
+	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /GR- /Zc:__cplusplus")
 else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -fdiagnostics-color")


### PR DESCRIPTION
See https://github.com/ninja-build/ninja/pull/1705#issuecomment-562972980