### PR TITLE
recompact: no need for loading build.ninja

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -967,7 +967,7 @@ const Tool* ChooseTool(const string& tool_name) {
     { "compdb",  "dump JSON compilation database to stdout",
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolCompilationDatabase },
     { "recompact",  "recompacts ninja-internal data structures",
-      Tool::RUN_AFTER_LOAD, &NinjaMain::ToolRecompact },
+      Tool::RUN_AFTER_FLAGS, &NinjaMain::ToolRecompact },
     { "restat",  "restats all outputs in the build log",
       Tool::RUN_AFTER_FLAGS, &NinjaMain::ToolRestat },
     { "rules",  "list all rules",


### PR DESCRIPTION
Follows the same pattern as d986e4db5630cf1c5547e69b5556f006f7d3444a for
restat.

---
Cc: @jhasse 