### PR TITLE
Clarify order-only dependencies documentation

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -955,16 +955,22 @@ changes to the script should cause the output to rebuild.
 Note that dependencies as loaded through depfiles have slightly different
 semantics, as described in the <<ref_rule,rule reference>>.
 
-3. _Order-only dependencies_, expressed with the syntax +|| _dep1_
-   _dep2_+ on the end of a build line.  When these are out of date, the
-   output is not rebuilt until they are built, but changes in order-only
-   dependencies alone do not cause the output to be rebuilt.
+3. _Order-only dependencies_, expressed with the syntax
+   +build output: ... || _dep1_ _dep2_+ on the end of a build line.
+   When these are out of date, +output+ is not rebuilt until they
+   are built, but changes in order-only dependencies _alone_ do not cause
+   +output+ to be rebuilt.
 +
 Order-only dependencies can be useful for bootstrapping dependencies
-that are only discovered during build time: for example, to generate a
-header file before starting a subsequent compilation step.  (Once the
-header is used in compilation, a generated dependency file will then
-express the implicit dependency.)
+that are only discovered during build time: for example, to generate
+header files that the compiler may or may not need depending on the
+project's configuration. Once the compiler can run, a generated
+dependency file will then express real headers usage with implicit
+dependencies.
++
+Compared with an implicit dependency, the order-only dependency example
+above can save rebuilding +output+. However it does not save rebuilding
+out of date +dep1+ and +dep2+.
 
 File paths are compared as is, which means that an absolute path and a
 relative path, pointing to the same file, are considered different by Ninja.


### PR DESCRIPTION
Around 2011 and after "a lot of soul-searching" Evan Martin made an
important change with respect to rebuilding the "dependencies of
order-only dependencies":
 https://groups.google.com/forum/m/#!msg/ninja-build/lSiVYhWEIyM/qZtVh5k8AgAJ

Document this significant change and the fact that it removed this
feature:
https://stackoverflow.com/questions/31271493/prevent-order-only-prerequisite-from-being-rebuilt-if-out-of-date

Also clarify the depfile bootstrap example.