### PR TITLE
manual: remove "manifest" reference from the manual

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -272,7 +272,7 @@ tool takes in account the +-v+ and the +-n+ options (note that +-n+
 implies +-v+).
 
 `cleandead`:: remove files produced by previous builds that are no longer in the
-manifest. _Available since Ninja 1.10._
+build file. _Available since Ninja 1.10._
 
 `compdb`:: given a list of rules, each of which is expected to be a
 C family language compiler rule whose first input is the name of the


### PR DESCRIPTION
Nothing else describes what a "manifest" is in user-facing docs.