### PR TITLE
Add 'inputs' tool to print out all inputs for a set of targets

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -257,6 +257,10 @@ than the _depth_ mode.
 executed in order, may be used to rebuild those targets, assuming that all
 output files are out of date.
 
+`inputs`:: given a list of targets, print a list of all inputs which are used
+to rebuild those targets.
+_Available since Ninja 1.10._
+
 `clean`:: remove built files. By default it removes all built files
 except for those created by the generator.  Adding the `-g` flag also
 removes built files created by the generator (see <<ref_rule,the rule

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -259,7 +259,7 @@ output files are out of date.
 
 `inputs`:: given a list of targets, print a list of all inputs which are used
 to rebuild those targets.
-_Available since Ninja 1.10._
+_Available since Ninja 1.11._
 
 `clean`:: remove built files. By default it removes all built files
 except for those created by the generator.  Adding the `-g` flag also

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -119,6 +119,7 @@ struct NinjaMain : public BuildLogUser {
   int ToolMSVC(const Options* options, int argc, char* argv[]);
   int ToolTargets(const Options* options, int argc, char* argv[]);
   int ToolCommands(const Options* options, int argc, char* argv[]);
+  int ToolInputs(const Options* options, int argc, char* argv[]);
   int ToolClean(const Options* options, int argc, char* argv[]);
   int ToolCleanDead(const Options* options, int argc, char* argv[]);
   int ToolCompilationDatabase(const Options* options, int argc, char* argv[]);
@@ -628,7 +629,7 @@ void PrintCommands(Edge* edge, set<Edge*>* seen, PrintCommandMode mode) {
 }
 
 int NinjaMain::ToolCommands(const Options* options, int argc, char* argv[]) {
-  // The clean tool uses getopt, and expects argv[0] to contain the name of
+  // The commands tool uses getopt, and expects argv[0] to contain the name of
   // the tool, i.e. "commands".
   ++argc;
   --argv;
@@ -665,6 +666,35 @@ int NinjaMain::ToolCommands(const Options* options, int argc, char* argv[]) {
   set<Edge*> seen;
   for (vector<Node*>::iterator in = nodes.begin(); in != nodes.end(); ++in)
     PrintCommands((*in)->in_edge(), &seen, mode);
+
+  return 0;
+}
+
+void PrintInputs(Edge* edge, set<Edge*>* seen) {
+  if (!edge)
+    return;
+  if (!seen->insert(edge).second)
+    return;
+
+  for (vector<Node*>::iterator in = edge->inputs_.begin();
+       in != edge->inputs_.end(); ++in)
+    PrintInputs((*in)->in_edge(), seen);
+
+  if (!edge->is_phony())
+    puts(edge->GetBinding("in_newline").c_str());
+}
+
+int NinjaMain::ToolInputs(const Options* options, int argc, char* argv[]) {
+  vector<Node*> nodes;
+  string err;
+  if (!CollectTargetsFromArgs(argc, argv, &nodes, &err)) {
+    Error("%s", err.c_str());
+    return 1;
+  }
+
+  set<Edge*> seen;
+  for (vector<Node*>::iterator in = nodes.begin(); in != nodes.end(); ++in)
+    PrintInputs((*in)->in_edge(), &seen);
 
   return 0;
 }
@@ -956,6 +986,8 @@ const Tool* ChooseTool(const string& tool_name) {
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolClean },
     { "commands", "list all commands required to rebuild given targets",
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolCommands },
+    { "inputs", "list all inputs required to rebuild given targets",
+      Tool::RUN_AFTER_LOAD, &NinjaMain::ToolInputs},
     { "deps", "show dependencies stored in the deps log",
       Tool::RUN_AFTER_LOGS, &NinjaMain::ToolDeps },
     { "graph", "output graphviz dot file for targets",


### PR DESCRIPTION
Per discussion on ninja-build, this change introduces a ninja tool to enumerate all inputs for a set of targets:
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/ninja-build/vPM6COsFslY

This works almost identically to the `commands` tool except that it gets the `in_newline` binding instead of evaluating a command.