### PR TITLE
allow Intel compiler to build Ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,12 @@ if(CMAKE_BUILD_TYPE MATCHES "Release")
 	endif()
 endif()
 
+set(_gnulike GNU Clang)
+
 if(MSVC)
 	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 	string(APPEND CMAKE_CXX_FLAGS " /W4 /GR- /Zc:__cplusplus")
-else()
+elseif(CMAKE_CXX_COMPILER_ID IN_LIST _gnulike)
 	string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated -fdiagnostics-color")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ elseif(CMAKE_CXX_COMPILER_ID IN_LIST _gnulike)
 	string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated -fdiagnostics-color")
 endif()
 
+if(NOT MSVC)  # MSVC is too strict right now for Ninja code with C++17
+	set(CMAKE_CXX_STANDARD 17)
+endif()
+
 find_program(RE2C re2c)
 if(RE2C)
 	# the depfile parser and ninja lexers are generated using re2c.

--- a/src/util.h
+++ b/src/util.h
@@ -35,7 +35,7 @@ using namespace std;
 NORETURN void Fatal(const char* msg, ...);
 
 // Have a generic fall-through for different versions of C/C++.
-#if defined(__cplusplus) && __cplusplus >= 201703L
+#if defined(__cplusplus) && __cplusplus >= 201703L || defined(__INTEL_COMPILER)
 #define NINJA_FALLTHROUGH [[fallthrough]]
 #elif defined(__cplusplus) && __cplusplus >= 201103L && defined(__clang__)
 #define NINJA_FALLTHROUGH [[clang::fallthrough]]


### PR DESCRIPTION
These changes allow Intel compiler to work along with existing GNU, Clang or MSVC.

* cmake: only set gnu-like flags for gnu-like compilers
* src/utils.h: handle intel compiler in preprocessor macro selection

Ninja is using C++17 syntax (e.g. fallthrough), so set C++17 standard for non-MSVC compilers. MSVC is stricter about syntax when specifying C++17 and will fail to build Ninja, so we don't yet specify C++17 for MSVC.