### PR TITLE
browse.py: use html.escape for python3

### DIFF
--- a/src/browse.py
+++ b/src/browse.py
@@ -29,12 +29,15 @@ except ImportError:
     import BaseHTTPServer as httpserver
     import SocketServer as socketserver
 import argparse
-import cgi
 import os
 import socket
 import subprocess
 import sys
 import webbrowser
+if sys.version_info >= (3, 2):
+    from html import escape
+else:
+    from cgi import escape
 try:
     from urllib.request import unquote
 except ImportError:
@@ -62,7 +65,7 @@ def match_strip(line, prefix):
     return (True, line[len(prefix):])
 
 def html_escape(text):
-    return cgi.escape(text, quote=True)
+    return escape(text, quote=True)
 
 def parse(text):
     lines = iter(text.split('\n'))


### PR DESCRIPTION
fixes #1741
fixes #1736