### PR TITLE
enable Intel, IBM XL, and PGI compilers without header/source changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(ninja)
 
+# --- optional link-time optimization
 if(CMAKE_BUILD_TYPE MATCHES "Release")
 	include(CheckIPOSupported)
 	check_ipo_supported(RESULT lto_supported OUTPUT error)
@@ -13,13 +14,23 @@ if(CMAKE_BUILD_TYPE MATCHES "Release")
 	endif()
 endif()
 
+# --- compiler flags
 if(MSVC)
 	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 	string(APPEND CMAKE_CXX_FLAGS " /W4 /GR- /Zc:__cplusplus")
 else()
-	string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated -fdiagnostics-color")
+	include(CheckCXXCompilerFlag)
+	check_cxx_compiler_flag(-Wno-deprecated flag_no_deprecated)
+	if(flag_no_deprecated)
+		string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated")
+	endif()
+	check_cxx_compiler_flag(-fdiagnostics-color flag_color_diag)
+	if(flag_color_diag)
+		string(APPEND CMAKE_CXX_FLAGS " -fdiagnostics-color")
+	endif()
 endif()
 
+# --- optional re2c
 find_program(RE2C re2c)
 if(RE2C)
 	# the depfile parser and ninja lexers are generated using re2c.


### PR DESCRIPTION
The goal in the PR was to enable:

* Intel compiler `icpc` and `icl` on Linux, Mac, Windows. It turns out that Intel Mac/Linux compiler requires CMake command line options `cmake -DCMAKE_CXX_FLAGS=-std=c++17` 
* PGI compiler `pgc++` on Linux
* IBM Power XL compiler `xlc++`

while:

1. avoid modifying Ninja C++ source
2. avoid compiler specific CMake `if()` 
3. remain compatible with older compilers

## Results

* all `ninja_test` pass on PGI, IBM XL and Intel
* some benchmarks run faster as built by Intel compiler
* works with or without `re2c` 

### benchmark on Ubuntu 18.04

#### PGI 19.10

```sh
CXX=pgc++ CC=pgcc cmake -DCMAKE_BUILD_TYPE=Release
```

* canon_perftest: min 77ms  max 79ms  avg 78.0ms
* clparser_perftest: Parse 32768 times in 2069ms avg 63.1us

#### Intel 19.1

```sh
CXX=icpc CC=icc cmake -DCMAKE_BUILD_TYPE=Release
```

* canon_perftest: min 78ms  max 79ms  avg 78.8ms
* clparser_perftest: Parse 65536 times in 3435ms avg 52.4us

#### Gfortran 7.4.0

```sh
CXX=g++ CC=gcc cmake -DCMAKE_BUILD_TYPE=Release
```

* canon_perftest:  min 93ms  max 94ms  avg 93.4ms
* clparser_perftest: Parse 65536 times in 3453ms avg 52.7us