### PR TITLE
macOS workflow: specify the minimum version of macOS supported

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,6 +18,8 @@ jobs:
 
     - name: Build ninja
       shell: bash
+      env:
+        MACOSX_DEPLOYMENT_TARGET: 10.12
       run: |
         cmake -DCMAKE_BUILD_TYPE=Release -B build
         cmake --build build --parallel --config Release


### PR DESCRIPTION
Specifying `MACOSX_DEPLOYMENT_TARGET` is then [used by CMake](https://cmake.org/cmake/help/latest/envvar/MACOSX_DEPLOYMENT_TARGET.html) to set the default value for [CMAKE_OSX_DEPLOYMENT_TARGET](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html)

Should fix: #1764