### PR TITLE
configure.py Windows more reliable detect MinGW

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,9 @@ matrix:
     - image: Ubuntu1804
       MSYSTEM: MSVC
 
+init:
+- cmd: set PATH=C:\Python36;%PATH%
+
 for:
   -
     matrix:
@@ -28,7 +31,7 @@ for:
     build_script:
       ps: "C:\\msys64\\usr\\bin\\bash -lc @\"\n
       pacman -S --quiet --noconfirm --needed re2c 2>&1\n
-      ./configure.py --bootstrap --platform mingw 2>&1\n
+      ./configure.py --bootstrap 2>&1\n
       ./ninja all\n
       ./ninja_test 2>&1\n
       ./misc/ninja_syntax_test.py 2>&1\n\"@"

--- a/configure.py
+++ b/configure.py
@@ -27,6 +27,7 @@ import pipes
 import string
 import subprocess
 import sys
+import shutil
 
 sourcedir = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(sourcedir, 'misc'))
@@ -53,7 +54,12 @@ class Platform(object):
         elif self._platform.startswith('mingw'):
             self._platform = 'mingw'
         elif self._platform.startswith('win'):
-            self._platform = 'msvc'
+            if shutil.which('cl'):
+                self._platform = 'msvc'
+            elif shutil.which('g++'):
+                self._platform = 'mingw'
+            else:
+                raise FileNotFoundError('Could not find MinGW or MSVC compilers.')
         elif self._platform.startswith('bitrig'):
             self._platform = 'bitrig'
         elif self._platform.startswith('netbsd'):


### PR DESCRIPTION
Before this, the general Windows user not already in an MSVC prompt gets a vague FileNotFoundError if they run Ninja's configure.py.

This PR retains the original default of looking for MSVC first, adding the behavior of next looking for MinGW if MSVC not found and **gives a clear error message if neither is found**.
