### PR TITLE
test: skip non-Windows tests if on Windows

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -46,6 +46,7 @@ def run(build_ninja, flags='', pipe=False, env=default_env):
         final_output += line.replace('\r', '')
     return final_output
 
+@unittest.skipIf(platform.system() == 'Windows', 'These test methods do not work on Windows')
 class Output(unittest.TestCase):
     def test_issue_1418(self):
         self.assertEqual(run(


### PR DESCRIPTION
The `misc/output_test.py` tests are generally not suitable for Windows. This skips rather than have them fail.