### PR TITLE
cmake: print feature summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,7 @@ if(CMAKE_BUILD_TYPE MATCHES "Release")
 	check_ipo_supported(RESULT lto_supported OUTPUT error)
 
 	if(lto_supported)
-		message(STATUS "IPO / LTO enabled")
 		set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-	else()
-		message(STATUS "IPO / LTO not supported: <${error}>")
 	endif()
 endif()
 
@@ -138,3 +135,10 @@ enable_testing()
 add_test(NinjaTest ninja_test)
 
 install(TARGETS ninja DESTINATION bin)
+
+include(FeatureSummary)
+
+add_feature_info(LTO lto_supported "Link time / interprocess optimization  ${error}")
+add_feature_info(re2c RE2C "lexer generator")
+
+feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)


### PR DESCRIPTION
this prints the results of the CMake configuration at the end, helping users see if they omitted desired options.

For example, before this PR, if the user forgets to specify "Release" built type, not only do they get -O0, they also silently omit LTO. This may remind them to specify Release.

Example:

```
> cmake -B build
...
-- The following features have been enabled:

 * re2c, lexer generator

-- The following features have been disabled:

 * LTO, Link time / interprocess optimization

-- Configuring done
-- Generating done
```

Or 

```
> cmake -B build
...
CMake Warning at CMakeLists.txt:43 (message):
  re2c was not found; changes to src/*.in.cc will not affect your build.


-- The following features have been disabled:

 * LTO, Link time / interprocess optimization
 * re2c, lexer generator

-- Configuring done
-- Generating done

```