### PR TITLE
bugfix: MinGW in CMake like configure.py bootstrap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ else()
 	endif()
 endif()
 
+if(MINGW)
+	string(APPEND CMAKE_CXX_FLAGS " -static")
+endif()
+
 # --- optional re2c
 find_program(RE2C re2c)
 if(RE2C)


### PR DESCRIPTION
without this `-static` flag, MinGW ninja build ninja.exe has
error code 0xc0000139 even with gdb, instant crash

I noticed this flag was in configure.py, so I added it to CMake for MinGW and it fixed the problem for MinGW / MSYS2 built Ninja.

fixes #1888 