### PR TITLE
RFC: graph: batch stat() system calls using io_uring on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,17 @@ else()
 endif()
 target_include_directories(libninja-re2c PRIVATE src)
 
+# --- optional liburing for io_uring support
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  find_package(PkgConfig)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(LIBURING liburing)
+    if(LIBURING_FOUND)
+      add_compile_definitions(HAVE_LIBURING)
+    endif()
+  endif()
+endif()
+
 # Core source files all build into ninja library.
 add_library(libninja OBJECT
 	src/build_log.cc
@@ -72,6 +83,11 @@ add_library(libninja OBJECT
 	src/util.cc
 	src/version.cc
 )
+if(LIBURING_FOUND)
+  target_sources(libninja PRIVATE src/uring.cc)
+  target_include_directories(libninja SYSTEM PUBLIC ${LIBURING_INCLUDE_DIRS})
+  target_link_libraries(libninja ${LIBURING_LIBRARIES})
+endif()
 if(WIN32)
 	target_sources(libninja PRIVATE
 		src/subprocess-win32.cc

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -218,6 +218,7 @@ TEST_F(BuildLogTest, DuplicateVersionHeader) {
 }
 
 struct TestDiskInterface : public DiskInterface {
+  virtual bool IsReal() const { return false; }
   virtual TimeStamp Stat(const string& path, string* err) const {
     return 4;
   }

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -216,6 +216,7 @@ struct StatTest : public StateTestWithBuiltinRules,
   StatTest() : scan_(&state_, NULL, NULL, this, NULL) {}
 
   // DiskInterface implementation.
+  virtual bool IsReal() const { return false; }
   virtual TimeStamp Stat(const string& path, string* err) const;
   virtual bool WriteFile(const string& path, const string& contents) {
     assert(false);

--- a/src/test.h
+++ b/src/test.h
@@ -144,6 +144,7 @@ struct VirtualFileSystem : public DiskInterface {
   }
 
   // DiskInterface
+  virtual bool IsReal() const { return false; }
   virtual TimeStamp Stat(const string& path, string* err) const;
   virtual bool WriteFile(const string& path, const string& contents);
   virtual bool MakeDir(const string& path);

--- a/src/uring.cc
+++ b/src/uring.cc
@@ -1,0 +1,145 @@
+// Copyright 2020 Max Kellermann. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "uring.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+
+BulkStat *global_bulk_stat;
+
+BulkStat::BulkStat() : callback_(NULL), n_pending(0) {
+  if (io_uring_queue_init(1024, &ring, 0) < 0) {
+    ring.ring_fd = -1;
+    return;
+  }
+
+  struct io_uring_probe* probe = io_uring_get_probe_ring(&ring);
+  if (!probe) {
+    Close();
+    return;
+  }
+
+  bool supported = io_uring_opcode_supported(probe, IORING_OP_STATX);
+  free(probe);
+  if (!supported) {
+    Close();
+    return;
+  }
+}
+
+void BulkStat::Queue(const char* path, void* data) {
+  assert(callback_);
+
+  if (!IsAvailable()) {
+    callback_(-1, "io_uring is not available", data);
+    return;
+  }
+
+  struct io_uring_sqe* s = io_uring_get_sqe(&ring);
+  if (!s) {
+    Wait();
+
+    s = io_uring_get_sqe(&ring);
+    if (!s) {
+      callback_(-1, "io_uring_get_sqe() failed", data);
+      return;
+    }
+  }
+
+  std::pair<void*, struct statx> value;
+  value.first = data;
+  PendingMap::iterator i = pending.insert(value).first;
+
+  io_uring_prep_statx(s, AT_FDCWD, path, AT_STATX_FORCE_SYNC,
+                      STATX_MTIME, &i->second);
+  io_uring_sqe_set_data(s, data);
+
+  ++n_pending;
+}
+
+void BulkStat::Wait() {
+  assert(callback_);
+
+  if (pending.empty())
+    return;
+
+  assert(IsAvailable());
+
+  int error = io_uring_submit_and_wait(&ring, n_pending);
+  if (error < 0) {
+    // something went terribly wrong, shouldn't happen
+    FailAll(strerror(-error));
+    Close();
+    return;
+  }
+
+  while (!pending.empty()) {
+    struct io_uring_cqe *cqe;
+    error = io_uring_wait_cqe(&ring, &cqe);
+    if (error < 0) {
+      if (error == -EAGAIN)
+        break;
+
+      // something went terribly wrong, shouldn't happen
+      FailAll(strerror(-error));
+      Close();
+      return;
+    }
+
+    void* data = io_uring_cqe_get_data(cqe);
+    assert(data);
+    PendingMap::const_iterator i = pending.find(data);
+    assert(i != pending.end());
+
+    if (cqe->res == 0) {
+      TimeStamp t = 0;
+      if (i->second.stx_mask & STATX_MTIME) {
+        t = i->second.stx_mtime.tv_sec;
+        if (t == 0)
+          // Some users (Flatpak) set mtime to 0, this should be
+          // harmless and avoids conflicting with our return
+          // value of 0 meaning that it doesn't exist.
+          t = 1;
+      }
+
+      callback_(t, NULL, data);
+    } else {
+      callback_(-1, strerror(-cqe->res), data);
+    }
+
+    pending.erase(i);
+    --n_pending;
+    io_uring_cqe_seen(&ring, cqe);
+  }
+}
+
+void BulkStat::FailAll(const char* error) {
+  assert(callback_);
+
+  for (PendingMap::const_iterator i = pending.begin(); i != pending.end(); ++i)
+    callback_(-1, error, i->first);
+
+  pending.clear();
+}
+
+void BulkStat::Close() {
+  if (ring.ring_fd >= 0) {
+    io_uring_queue_exit(&ring);
+    ring.ring_fd = -1;
+  }
+}

--- a/src/uring.h
+++ b/src/uring.h
@@ -1,0 +1,71 @@
+// Copyright 2020 Max Kellermann. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NINJA_URING_H_
+#define NINJA_URING_H_
+
+#include "timestamp.h"
+
+#include <map>
+
+#include <liburing.h>
+#include <sys/stat.h>
+
+/// Helper class for submitting bulk statx() calls to the Linux kernel
+/// via io_uring
+class BulkStat {
+  typedef void (*Callback)(TimeStamp t, const char* error, void* data);
+
+public:
+  BulkStat();
+
+  ~BulkStat() {
+    Close();
+  }
+
+  /// Is io_uring/statx available?  This requires Linux 5.6 or newer.
+  bool IsAvailable() const {
+    return ring.ring_fd >= 0;
+  }
+
+  void SetCallback(Callback callback) {
+    callback_ = callback;
+  }
+
+  /// Queue a statx() call on the given path.  The callback will be
+  /// invoked later with the given "data" pointer.
+  void Queue(const char* path, void* data);
+
+  /// Wait for all queued operations to complete.  After returning,
+  /// all pending callbacks have been invoked.
+  void Wait();
+
+private:
+  void FailAll(const char* error);
+
+  void Close();
+
+  Callback callback_;
+
+  struct io_uring ring;
+
+  typedef std::map<void* , struct statx> PendingMap;
+  PendingMap pending;
+
+  PendingMap::size_type n_pending;
+};
+
+extern BulkStat *global_bulk_stat;
+
+#endif  // NINJA_URING_H_


### PR DESCRIPTION
This adds an optional dependency on liburing
(https://github.com/axboe/liburing) to use Linux's new io_uring API
which can batch I/O system calls, reducing overhead.

The new source "uring.cc" implements class BulkStat as a wrapper for
liburing, plugged into DependencyScan::RecomputeDirty() which walks
the graph and batches most of the necessary stat() calls before
RecomputeDirty() needs them.

This requires Linux kernel 5.6 or newer.

This patch is not yet integrated well; for example, it bypasses the
DiskInterface, and to avoid breaking the unit tests, this patch adds a
IsReal() method to DiskInterface so we can disable the io_uring code
in the unit tests.