### PR TITLE
clang-tidy fixes

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -77,12 +77,9 @@ bool DryRunCommandRunner::WaitForCommand(Result* result) {
 }  // namespace
 
 BuildStatus::BuildStatus(const BuildConfig& config)
-    : config_(config),
-      start_time_millis_(GetTimeMillis()),
-      started_edges_(0), finished_edges_(0), total_edges_(0),
-      progress_status_format_(NULL),
-      overall_rate_(), current_rate_(config.parallelism) {
-
+    : config_(config), start_time_millis_(GetTimeMillis()), started_edges_(0),
+      finished_edges_(0), total_edges_(0), progress_status_format_(NULL),
+      current_rate_(config.parallelism) {
   // Don't do anything fancy in verbose mode.
   if (config_.verbosity != BuildConfig::NORMAL)
     printer_.set_smart_terminal(false);

--- a/src/build.cc
+++ b/src/build.cc
@@ -14,10 +14,10 @@
 
 #include "build.h"
 
-#include <assert.h>
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
 #include <functional>
 
 #ifdef _WIN32

--- a/src/build.cc
+++ b/src/build.cc
@@ -1064,8 +1064,7 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
       // complexity in IncludesNormalize::Relativize.
       deps_nodes->push_back(state_->GetNode(*i, ~0u));
     }
-  } else
-  if (deps_type == "gcc") {
+  } else if (deps_type == "gcc") {
     string depfile = result->edge->GetUnescapedDepfile();
     if (depfile.empty()) {
       *err = string("edge with deps=gcc but no depfile makes no sense");

--- a/src/build.cc
+++ b/src/build.cc
@@ -95,7 +95,7 @@ void BuildStatus::PlanHasTotalEdges(int total) {
 
 void BuildStatus::BuildEdgeStarted(const Edge* edge) {
   assert(running_edges_.find(edge) == running_edges_.end());
-  int start_time = (int)(GetTimeMillis() - start_time_millis_);
+  int start_time = static_cast<int>(GetTimeMillis() - start_time_millis_);
   running_edges_.insert(make_pair(edge, start_time));
   ++started_edges_;
 
@@ -117,7 +117,7 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
 
   RunningEdgeMap::iterator i = running_edges_.find(edge);
   *start_time = i->second;
-  *end_time = (int)(now - start_time_millis_);
+  *end_time = static_cast<int>(now - start_time_millis_);
   running_edges_.erase(i);
 
   if (edge->use_console())
@@ -653,13 +653,13 @@ void Plan::UnmarkDependents(const Node* node, set<Node*>* dependents) {
 }
 
 void Plan::Dump() const {
-  printf("pending: %d\n", (int)want_.size());
+  printf("pending: %d\n", static_cast<int>(want_.size()));
   for (map<Edge*, Want>::const_iterator e = want_.begin(); e != want_.end(); ++e) {
     if (e->second != kWantNothing)
       printf("want ");
     e->first->Dump();
   }
-  printf("ready: %d\n", (int)ready_.size());
+  printf("ready: %d\n", static_cast<int>(ready_.size()));
 }
 
 struct RealCommandRunner : public CommandRunner {
@@ -691,9 +691,9 @@ void RealCommandRunner::Abort() {
 bool RealCommandRunner::CanRunMore() const {
   size_t subproc_number =
       subprocs_.running_.size() + subprocs_.finished_.size();
-  return (int)subproc_number < config_.parallelism
-    && ((subprocs_.running_.empty() || config_.max_load_average <= 0.0f)
-        || GetLoadAverage() < config_.max_load_average);
+  return static_cast<int>(subproc_number) < config_.parallelism &&
+         ((subprocs_.running_.empty() || config_.max_load_average <= 0.0f) ||
+          GetLoadAverage() < config_.max_load_average);
 }
 
 bool RealCommandRunner::StartCommand(Edge* edge) {

--- a/src/build.cc
+++ b/src/build.cc
@@ -1033,7 +1033,7 @@ bool Builder::FinishCommand(CommandRunner::Result* result, string* err) {
   }
 
   if (!deps_type.empty() && !config_.dry_run) {
-    assert(edge->outputs_.size() >= 1 && "should have been rejected by parser");
+    assert(!edge->outputs_.empty() && "should have been rejected by parser");
     for (std::vector<Node*>::const_iterator o = edge->outputs_.begin();
          o != edge->outputs_.end(); ++o) {
       TimeStamp deps_mtime = disk_interface_->Stat((*o)->path(), err);

--- a/src/build.h
+++ b/src/build.h
@@ -190,7 +190,7 @@ struct Builder {
 
   /// Add a target to the build, scanning dependencies.
   /// @return false on error.
-  bool AddTarget(Node* target, string* err);
+  bool AddTarget(Node* node, string* err);
 
   /// Returns true if the build targets are already up to date.
   bool AlreadyUpToDate() const;

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -65,7 +65,7 @@ uint64_t MurmurHash64A(const void* key, size_t len) {
   const uint64_t m = BIG_CONSTANT(0xc6a4a7935bd1e995);
   const int r = 47;
   uint64_t h = seed ^ (len * m);
-  const unsigned char* data = (const unsigned char*)key;
+  const unsigned char* data = static_cast<const unsigned char*>(key);
   while (len >= 8) {
     uint64_t k;
     memcpy(&k, data, sizeof k);
@@ -214,7 +214,8 @@ struct LineReader {
       line_start_ = line_end_ + 1;
     }
 
-    line_end_ = (char*)memchr(line_start_, '\n', buf_end_ - line_start_);
+    line_end_ =
+        static_cast<char*>(memchr(line_start_, '\n', buf_end_ - line_start_));
     if (!line_end_) {
       // No newline. Move rest of data to start of buffer, fill rest.
       size_t already_consumed = line_start_ - buf_;
@@ -224,7 +225,8 @@ struct LineReader {
       size_t read = fread(buf_ + size_rest, 1, sizeof(buf_) - size_rest, file_);
       buf_end_ = buf_ + size_rest + read;
       line_start_ = buf_;
-      line_end_ = (char*)memchr(line_start_, '\n', buf_end_ - line_start_);
+      line_end_ =
+          static_cast<char*>(memchr(line_start_, '\n', buf_end_ - line_start_));
     }
 
     *line_start = line_start_;
@@ -281,7 +283,8 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
     const char kFieldSeparator = '\t';
 
     char* start = line_start;
-    char* end = (char*)memchr(start, kFieldSeparator, line_end - start);
+    char* end =
+        static_cast<char*>(memchr(start, kFieldSeparator, line_end - start));
     if (!end)
       continue;
     *end = 0;
@@ -292,21 +295,21 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
     start_time = atoi(start);
     start = end + 1;
 
-    end = (char*)memchr(start, kFieldSeparator, line_end - start);
+    end = static_cast<char*>(memchr(start, kFieldSeparator, line_end - start));
     if (!end)
       continue;
     *end = 0;
     end_time = atoi(start);
     start = end + 1;
 
-    end = (char*)memchr(start, kFieldSeparator, line_end - start);
+    end = static_cast<char*>(memchr(start, kFieldSeparator, line_end - start));
     if (!end)
       continue;
     *end = 0;
     restat_mtime = strtoll(start, NULL, 10);
     start = end + 1;
 
-    end = (char*)memchr(start, kFieldSeparator, line_end - start);
+    end = static_cast<char*>(memchr(start, kFieldSeparator, line_end - start));
     if (!end)
       continue;
     string output = string(start, end - start);
@@ -330,7 +333,7 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
     entry->mtime = restat_mtime;
     if (log_version >= 5) {
       char c = *end; *end = '\0';
-      entry->command_hash = (uint64_t)strtoull(start, NULL, 16);
+      entry->command_hash = static_cast<uint64_t>(strtoull(start, NULL, 16));
       *end = c;
     } else {
       entry->command_hash = LogEntry::HashCommand(StringPiece(start,

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -21,11 +21,12 @@
 #endif
 
 #include "build_log.h"
-#include "disk_interface.h"
 
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+
+#include "disk_interface.h"
 
 #ifndef _WIN32
 #include <inttypes.h>

--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -123,7 +123,7 @@ int main() {
       fprintf(stderr, "Failed to read test data: %s\n", err.c_str());
       return 1;
     }
-    int delta = (int)(GetTimeMillis() - start);
+    int delta = static_cast<int>(GetTimeMillis() - start);
     printf("%dms\n", delta);
     times.push_back(delta);
   }

--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include "build_log.h"
 #include "graph.h"
 #include "manifest_parser.h"
+#include "metrics.h"
 #include "state.h"
 #include "util.h"
-#include "metrics.h"
 
 #ifndef _WIN32
 #include <unistd.h>

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -488,7 +488,7 @@ struct BuildTest : public StateTestWithBuiltinRules, public BuildLogUser {
                 status_(config_) {
   }
 
-  BuildTest(DepsLog* log) : config_(MakeConfig()), command_runner_(&fs_),
+  explicit BuildTest(DepsLog* log) : config_(MakeConfig()), command_runner_(&fs_),
                             builder_(&state_, config_, NULL, log, &fs_),
                             status_(config_) {
   }

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -672,7 +672,7 @@ bool FakeCommandRunner::WaitForCommand(Result* result) {
     bool verify_active_edge_found = false;
     for (vector<Edge*>::iterator i = active_edges_.begin();
          i != active_edges_.end(); ++i) {
-      if ((*i)->outputs_.size() >= 1 &&
+      if (!(*i)->outputs_.empty() &&
           (*i)->outputs_[0]->path() == verify_active_edge) {
         verify_active_edge_found = true;
       }

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -14,7 +14,7 @@
 
 #include "build.h"
 
-#include <assert.h>
+#include <cassert>
 
 #include "build_log.h"
 #include "deps_log.h"

--- a/src/canon_perftest.cc
+++ b/src/canon_perftest.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
-#include "util.h"
 #include "metrics.h"
+#include "util.h"
 
 const char kPath[] =
     "../../third_party/WebKit/Source/WebCore/"

--- a/src/canon_perftest.cc
+++ b/src/canon_perftest.cc
@@ -37,7 +37,7 @@ int main() {
     for (int i = 0; i < kNumRepetitions; ++i) {
       CanonicalizePath(buf, &len, &slash_bits, &err);
     }
-    int delta = (int)(GetTimeMillis() - start);
+    int delta = static_cast<int>(GetTimeMillis() - start);
     times.push_back(delta);
   }
 

--- a/src/clean.cc
+++ b/src/clean.cc
@@ -28,8 +28,6 @@ Cleaner::Cleaner(State* state,
   : state_(state),
     config_(config),
     dyndep_loader_(state, disk_interface),
-    removed_(),
-    cleaned_(),
     cleaned_files_count_(0),
     disk_interface_(disk_interface),
     status_(0) {

--- a/src/clean.cc
+++ b/src/clean.cc
@@ -14,8 +14,8 @@
 
 #include "clean.h"
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 #include "disk_interface.h"
 #include "graph.h"

--- a/src/clparser.cc
+++ b/src/clparser.cc
@@ -15,8 +15,8 @@
 #include "clparser.h"
 
 #include <algorithm>
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 #include "metrics.h"
 #include "string_piece_util.h"

--- a/src/clparser.cc
+++ b/src/clparser.cc
@@ -45,8 +45,8 @@ string CLParser::FilterShowIncludes(const string& line,
   const char* in = line.c_str();
   const char* end = in + line.size();
   const string& prefix = deps_prefix.empty() ? kDepsPrefixEnglish : deps_prefix;
-  if (end - in > (int)prefix.size() &&
-      memcmp(in, prefix.c_str(), (int)prefix.size()) == 0) {
+  if (end - in > static_cast<int>(prefix.size()) &&
+      memcmp(in, prefix.c_str(), static_cast<int>(prefix.size())) == 0) {
     in += prefix.size();
     while (*in == ' ')
       ++in;

--- a/src/clparser_perftest.cc
+++ b/src/clparser_perftest.cc
@@ -146,7 +146,7 @@ int main(int argc, char* argv[]) {
     int64_t end = GetTimeMillis();
 
     if (end - start > 2000) {
-      int delta_ms = (int)(end - start);
+      int delta_ms = static_cast<int>(end - start);
       printf("Parse %d times in %dms avg %.1fus\n",
              limit, delta_ms, float(delta_ms * 1000) / limit);
       break;

--- a/src/clparser_perftest.cc
+++ b/src/clparser_perftest.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include "clparser.h"
 #include "metrics.h"

--- a/src/depfile_parser_perftest.cc
+++ b/src/depfile_parser_perftest.cc
@@ -48,8 +48,8 @@ int main(int argc, char* argv[]) {
       int64_t end = GetTimeMillis();
 
       if (end - start > 100) {
-        int delta = (int)(end - start);
-        float time = delta*1000 / (float)limit;
+        int delta = static_cast<int>(end - start);
+        float time = delta * 1000 / static_cast<float>(limit);
         printf("%s: %.1fus\n", filename, time);
         times.push_back(time);
         break;

--- a/src/depfile_parser_perftest.cc
+++ b/src/depfile_parser_perftest.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include "depfile_parser.h"
-#include "util.h"
 #include "metrics.h"
+#include "util.h"
 
 int main(int argc, char* argv[]) {
   if (argc < 2) {

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -399,7 +399,7 @@ bool DepsLog::RecordId(Node* node) {
   if (fwrite(&size, 4, 1, file_) < 1)
     return false;
   if (fwrite(node->path().data(), path_size, 1, file_) < 1) {
-    assert(node->path().size() > 0);
+    assert(!node->path().empty());
     return false;
   }
   if (padding && fwrite("\0\0", padding, 1, file_) < 1)

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -14,10 +14,10 @@
 
 #include "deps_log.h"
 
-#include <assert.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 #ifndef _WIN32
 #include <unistd.h>
 #elif defined(_MSC_VER) && (_MSC_VER < 1900)

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -71,7 +71,7 @@ TEST_F(DepsLogTest, WriteRead) {
   ASSERT_EQ("", err);
 
   ASSERT_EQ(log1.nodes().size(), log2.nodes().size());
-  for (int i = 0; i < (int)log1.nodes().size(); ++i) {
+  for (int i = 0; i < static_cast<int>(log1.nodes().size()); ++i) {
     Node* node1 = log1.nodes()[i];
     Node* node2 = log2.nodes()[i];
     ASSERT_EQ(i, node1->id());
@@ -139,7 +139,7 @@ TEST_F(DepsLogTest, DoubleEntry) {
 
     struct stat st;
     ASSERT_EQ(0, stat(kTestFilename, &st));
-    file_size = (int)st.st_size;
+    file_size = static_cast<int>(st.st_size);
     ASSERT_GT(file_size, 0);
   }
 
@@ -161,7 +161,7 @@ TEST_F(DepsLogTest, DoubleEntry) {
 
     struct stat st;
     ASSERT_EQ(0, stat(kTestFilename, &st));
-    int file_size_2 = (int)st.st_size;
+    int file_size_2 = static_cast<int>(st.st_size);
     ASSERT_EQ(file_size, file_size_2);
   }
 }
@@ -199,7 +199,7 @@ TEST_F(DepsLogTest, Recompact) {
 
     struct stat st;
     ASSERT_EQ(0, stat(kTestFilename, &st));
-    file_size = (int)st.st_size;
+    file_size = static_cast<int>(st.st_size);
     ASSERT_GT(file_size, 0);
   }
 
@@ -222,7 +222,7 @@ TEST_F(DepsLogTest, Recompact) {
 
     struct stat st;
     ASSERT_EQ(0, stat(kTestFilename, &st));
-    file_size_2 = (int)st.st_size;
+    file_size_2 = static_cast<int>(st.st_size);
     // The file should grow to record the new deps.
     ASSERT_GT(file_size_2, file_size);
   }
@@ -273,7 +273,7 @@ TEST_F(DepsLogTest, Recompact) {
     // The file should have shrunk a bit for the smaller deps.
     struct stat st;
     ASSERT_EQ(0, stat(kTestFilename, &st));
-    file_size_3 = (int)st.st_size;
+    file_size_3 = static_cast<int>(st.st_size);
     ASSERT_LT(file_size_3, file_size_2);
   }
 
@@ -317,7 +317,7 @@ TEST_F(DepsLogTest, Recompact) {
     // The file should have shrunk more.
     struct stat st;
     ASSERT_EQ(0, stat(kTestFilename, &st));
-    int file_size_4 = (int)st.st_size;
+    int file_size_4 = static_cast<int>(st.st_size);
     ASSERT_LT(file_size_4, file_size_3);
   }
 }
@@ -380,7 +380,7 @@ TEST_F(DepsLogTest, Truncated) {
   // smaller sizes.
   int node_count = 5;
   int deps_count = 2;
-  for (int size = (int)st.st_size; size > 0; --size) {
+  for (int size = static_cast<int>(st.st_size); size > 0; --size) {
     string err;
     ASSERT_TRUE(Truncate(kTestFilename, size, &err));
 

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -14,13 +14,13 @@
 
 #include "disk_interface.h"
 
-#include <algorithm>
-
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 
 #ifdef _WIN32
 #include <sstream>

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -208,7 +208,8 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
   return ((int64_t)st.st_mtimespec.tv_sec * 1000000000LL +
           st.st_mtimespec.tv_nsec);
 #elif defined(st_mtime) // A macro, so we're likely on modern POSIX.
-  return (int64_t)st.st_mtim.tv_sec * 1000000000LL + st.st_mtim.tv_nsec;
+  return static_cast<int64_t>(st.st_mtim.tv_sec) * 1000000000LL +
+         st.st_mtim.tv_nsec;
 #else
   return (int64_t)st.st_mtime * 1000000000LL + st.st_mtimensec;
 #endif

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -190,7 +190,7 @@ TEST_F(DiskInterfaceTest, ReadFile) {
 
 TEST_F(DiskInterfaceTest, MakeDirs) {
   string path = "path/with/double//slash/";
-  EXPECT_TRUE(disk_.MakeDirs(path.c_str()));
+  EXPECT_TRUE(disk_.MakeDirs(path));
   FILE* f = fopen((path + "a_file").c_str(), "w");
   EXPECT_TRUE(f);
   EXPECT_EQ(0, fclose(f));

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 #ifdef _WIN32
 #include <io.h>
 #include <windows.h>

--- a/src/dyndep.cc
+++ b/src/dyndep.cc
@@ -14,8 +14,8 @@
 
 #include "dyndep.h"
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 #include "debug_flags.h"
 #include "disk_interface.h"

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <assert.h>
-
 #include "eval_env.h"
+
+#include <cassert>
 
 string BindingEnv::LookupVariable(const string& var) {
   map<string, string>::iterator i = bindings_.find(var);

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -638,7 +638,7 @@ bool ImplicitDepLoader::LoadDepsFromLog(Edge* edge, string* err) {
 vector<Node*>::iterator ImplicitDepLoader::PreallocateSpace(Edge* edge,
                                                             int count) {
   edge->inputs_.insert(edge->inputs_.end() - edge->order_only_deps_,
-                       (size_t)count, 0);
+                       static_cast<size_t>(count), 0);
   edge->implicit_deps_ += count;
   return edge->inputs_.end() - edge->order_only_deps_ - count;
 }

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -514,7 +514,7 @@ bool ImplicitDepLoader::LoadDeps(Edge* edge, string* err) {
 }
 
 struct matches {
-  matches(std::vector<StringPiece>::iterator i) : i_(i) {}
+  explicit matches(std::vector<StringPiece>::iterator i) : i_(i) {}
 
   bool operator()(const Node* node) const {
     StringPiece opath = StringPiece(node->path());

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -349,7 +349,8 @@ string EdgeEnv::LookupVariable(const string& var) {
     return MakePathList(&edge_->inputs_[0], explicit_deps_count,
 #endif
                         var == "in" ? ' ' : '\n');
-  } else if (var == "out") {
+  }
+  if (var == "out") {
     int explicit_outs_count = edge_->outputs_.size() - edge_->implicit_outs_;
     return MakePathList(&edge_->outputs_[0], explicit_outs_count, ' ');
   }

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -15,8 +15,8 @@
 #include "graph.h"
 
 #include <algorithm>
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 #include "build_log.h"
 #include "debug_flags.h"

--- a/src/graphviz.cc
+++ b/src/graphviz.cc
@@ -14,8 +14,8 @@
 
 #include "graphviz.h"
 
-#include <stdio.h>
 #include <algorithm>
+#include <cstdio>
 
 #include "dyndep.h"
 #include "graph.h"

--- a/src/hash_collision_bench.cc
+++ b/src/hash_collision_bench.cc
@@ -17,8 +17,8 @@
 #include <algorithm>
 using namespace std;
 
-#include <stdlib.h>
-#include <time.h>
+#include <cstdlib>
+#include <ctime>
 
 int random(int low, int high) {
   return int(low + (rand() / double(RAND_MAX)) * (high - low) + 0.5);

--- a/src/hash_collision_bench.cc
+++ b/src/hash_collision_bench.cc
@@ -28,7 +28,7 @@ void RandomCommand(char** s) {
   int len = random(5, 100);
   *s = new char[len];
   for (int i = 0; i < len; ++i)
-    (*s)[i] = (char)random(32, 127);
+    (*s)[i] = static_cast<char>(random(32, 127));
 }
 
 int main() {
@@ -38,7 +38,7 @@ int main() {
   char** commands = new char*[N];
   pair<uint64_t, int>* hashes = new pair<uint64_t, int>[N];
 
-  srand((int)time(NULL));
+  srand(static_cast<int>(time(NULL)));
 
   for (int i = 0; i < N; ++i) {
     RandomCommand(&commands[i]);

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -14,8 +14,8 @@
 
 #include "line_printer.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #ifdef _WIN32
 #include <windows.h>
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -14,8 +14,8 @@
 
 #include "manifest_parser.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <vector>
 
 #include "graph.h"

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -327,16 +327,16 @@ bool ManifestParser::ParseEdge(string* err) {
         lexer_.Error("multiple rules generate " + path + " [-w dupbuild=err]",
                      err);
         return false;
-      } else {
-        if (!quiet_) {
-          Warning("multiple rules generate %s. "
-                  "builds involving this target will not be correct; "
-                  "continuing anyway [-w dupbuild=warn]",
-                  path.c_str());
-        }
-        if (e - i <= static_cast<size_t>(implicit_outs))
-          --implicit_outs;
       }
+      if (!quiet_) {
+        Warning(
+            "multiple rules generate %s. "
+            "builds involving this target will not be correct; "
+            "continuing anyway [-w dupbuild=warn]",
+            path.c_str());
+      }
+      if (e - i <= static_cast<size_t>(implicit_outs))
+        --implicit_outs;
     }
   }
   if (edge->outputs_.empty()) {

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -200,10 +200,7 @@ bool ManifestParser::ParseDefault(string* err) {
       return false;
   } while (!eval.empty());
 
-  if (!ExpectToken(Lexer::NEWLINE, err))
-    return false;
-
-  return true;
+  return ExpectToken(Lexer::NEWLINE, err);
 }
 
 bool ManifestParser::ParseEdge(string* err) {

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -15,12 +15,11 @@
 // Tests manifest parser performance.  Expects to be run in ninja's root
 // directory.
 
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <numeric>
-
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #ifdef _WIN32
 #include "getopt.h"

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -106,7 +106,7 @@ int main(int argc, char* argv[]) {
   for (int i = 0; i < kNumRepetitions; ++i) {
     int64_t start = GetTimeMillis();
     int optimization_guard = LoadManifests(measure_command_evaluation);
-    int delta = (int)(GetTimeMillis() - start);
+    int delta = static_cast<int>(GetTimeMillis() - start);
     printf("%dms (hash: %x)\n", delta, optimization_guard);
     times.push_back(delta);
   }

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -38,7 +38,7 @@ int64_t HighResTimer() {
   timeval tv;
   if (gettimeofday(&tv, NULL) < 0)
     Fatal("gettimeofday: %s", strerror(errno));
-  return (int64_t)tv.tv_sec * 1000*1000 + tv.tv_usec;
+  return static_cast<int64_t>(tv.tv_sec) * 1000 * 1000 + tv.tv_usec;
 }
 
 /// Convert a delta of HighResTimer() values to microseconds.
@@ -102,7 +102,7 @@ void Metrics::Report() {
   int width = 0;
   for (vector<Metric*>::iterator i = metrics_.begin();
        i != metrics_.end(); ++i) {
-    width = max((int)(*i)->name.size(), width);
+    width = max(static_cast<int>((*i)->name.size()), width);
   }
 
   printf("%-*s\t%-6s\t%-9s\t%s\n", width,
@@ -110,8 +110,8 @@ void Metrics::Report() {
   for (vector<Metric*>::iterator i = metrics_.begin();
        i != metrics_.end(); ++i) {
     Metric* metric = *i;
-    double total = metric->sum / (double)1000;
-    double avg = metric->sum / (double)metric->count;
+    double total = metric->sum / static_cast<double>(1000);
+    double avg = metric->sum / static_cast<double>(metric->count);
     printf("%-*s\t%-6d\t%-8.1f\t%.1f\n", width, metric->name.c_str(),
            metric->count, avg, total);
   }

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -14,9 +14,9 @@
 
 #include "metrics.h"
 
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 
 #ifndef _WIN32
 #include <sys/time.h>

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -369,7 +369,7 @@ int NinjaMain::ToolQuery(const Options* options, int argc, char* argv[]) {
         }
       }
       printf("  input: %s\n", edge->rule_->name().c_str());
-      for (int in = 0; in < (int)edge->inputs_.size(); in++) {
+      for (int in = 0; in < static_cast<int>(edge->inputs_.size()); in++) {
         const char* label = "";
         if (edge->is_implicit(in))
           label = "| ";
@@ -1182,10 +1182,10 @@ void NinjaMain::DumpMetrics() {
   g_metrics->Report();
 
   printf("\n");
-  int count = (int)state_.paths_.size();
-  int buckets = (int)state_.paths_.bucket_count();
+  int count = static_cast<int>(state_.paths_.size());
+  int buckets = static_cast<int>(state_.paths_.bucket_count());
   printf("path->node hash load %.2f (%d entries / %d buckets)\n",
-         count / (double) buckets, count, buckets);
+         count / static_cast<double>(buckets), count, buckets);
 }
 
 bool NinjaMain::EnsureBuildDirExists() {

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <errno.h>
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cerrno>
+#include <climits>
+#include <cstdio>
 #include <cstdlib>
+#include <cstring>
 
 #ifdef _WIN32
 #include "getopt.h"

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -297,21 +297,19 @@ Node* NinjaMain::CollectTarget(const char* cpath, string* err) {
       node = edge->outputs_[0];
     }
     return node;
-  } else {
-    *err =
-        "unknown target '" + Node::PathDecanonicalized(path, slash_bits) + "'";
-    if (path == "clean") {
-      *err += ", did you mean 'ninja -t clean'?";
-    } else if (path == "help") {
-      *err += ", did you mean 'ninja -h'?";
-    } else {
-      Node* suggestion = state_.SpellcheckNode(path);
-      if (suggestion) {
-        *err += ", did you mean '" + suggestion->path() + "'?";
-      }
-    }
-    return NULL;
   }
+  *err = "unknown target '" + Node::PathDecanonicalized(path, slash_bits) + "'";
+  if (path == "clean") {
+    *err += ", did you mean 'ninja -t clean'?";
+  } else if (path == "help") {
+    *err += ", did you mean 'ninja -h'?";
+  } else {
+    Node* suggestion = state_.SpellcheckNode(path);
+    if (suggestion) {
+      *err += ", did you mean '" + suggestion->path() + "'?";
+    }
+  }
+  return NULL;
 }
 
 bool NinjaMain::CollectTargetsFromArgs(int argc, char* argv[],
@@ -531,8 +529,7 @@ int NinjaMain::ToolTargets(const Options* options, int argc, char* argv[]) {
         rule = argv[1];
       if (rule.empty())
         return ToolTargetsSourceList(&state_);
-      else
-        return ToolTargetsList(&state_, rule);
+      return ToolTargetsList(&state_, rule);
     } else if (mode == "depth") {
       if (argc > 1)
         depth = atoi(argv[1]);
@@ -555,10 +552,9 @@ int NinjaMain::ToolTargets(const Options* options, int argc, char* argv[]) {
   vector<Node*> root_nodes = state_.RootNodes(&err);
   if (err.empty()) {
     return ToolTargetsList(root_nodes, depth, 0);
-  } else {
-    Error("%s", err.c_str());
-    return 1;
   }
+  Error("%s", err.c_str());
+  return 1;
 }
 
 int NinjaMain::ToolRules(const Options* options, int argc, char* argv[]) {
@@ -711,8 +707,7 @@ int NinjaMain::ToolClean(const Options* options, int argc, char* argv[]) {
   if (argc >= 1) {
     if (clean_rules)
       return cleaner.CleanRules(argc, argv);
-    else
-      return cleaner.CleanTargets(argc, argv);
+    return cleaner.CleanTargets(argc, argv);
   } else {
     return cleaner.CleanAll(generator);
   }
@@ -1020,34 +1015,43 @@ bool DebugEnable(const string& name) {
 #endif
 "multiple modes can be enabled via -d FOO -d BAR\n");
     return false;
-  } else if (name == "stats") {
+  }
+
+  if (name == "stats") {
     g_metrics = new Metrics;
     return true;
-  } else if (name == "explain") {
+  }
+
+  if (name == "explain") {
     g_explaining = true;
     return true;
-  } else if (name == "keepdepfile") {
+  }
+
+  if (name == "keepdepfile") {
     g_keep_depfile = true;
     return true;
-  } else if (name == "keeprsp") {
+  }
+
+  if (name == "keeprsp") {
     g_keep_rsp = true;
     return true;
-  } else if (name == "nostatcache") {
+  }
+
+  if (name == "nostatcache") {
     g_experimental_statcache = false;
     return true;
-  } else {
-    const char* suggestion =
-        SpellcheckString(name.c_str(),
-                         "stats", "explain", "keepdepfile", "keeprsp",
-                         "nostatcache", NULL);
-    if (suggestion) {
-      Error("unknown debug setting '%s', did you mean '%s'?",
-            name.c_str(), suggestion);
-    } else {
-      Error("unknown debug setting '%s'", name.c_str());
-    }
-    return false;
   }
+
+  const char* suggestion =
+      SpellcheckString(name.c_str(), "stats", "explain", "keepdepfile",
+                       "keeprsp", "nostatcache", NULL);
+  if (suggestion) {
+    Error("unknown debug setting '%s', did you mean '%s'?", name.c_str(),
+          suggestion);
+  } else {
+    Error("unknown debug setting '%s'", name.c_str());
+  }
+  return false;
 }
 
 /// Set a warning flag.  Returns false if Ninja should exit instead  of
@@ -1059,34 +1063,43 @@ bool WarningEnable(const string& name, Options* options) {
 "  phonycycle={err,warn}  phony build statement references itself\n"
     );
     return false;
-  } else if (name == "dupbuild=err") {
+  }
+
+  if (name == "dupbuild=err") {
     options->dupe_edges_should_err = true;
     return true;
-  } else if (name == "dupbuild=warn") {
+  }
+
+  if (name == "dupbuild=warn") {
     options->dupe_edges_should_err = false;
     return true;
-  } else if (name == "phonycycle=err") {
+  }
+
+  if (name == "phonycycle=err") {
     options->phony_cycle_should_err = true;
     return true;
-  } else if (name == "phonycycle=warn") {
+  }
+
+  if (name == "phonycycle=warn") {
     options->phony_cycle_should_err = false;
     return true;
-  } else if (name == "depfilemulti=err" ||
-             name == "depfilemulti=warn") {
+  }
+
+  if (name == "depfilemulti=err" || name == "depfilemulti=warn") {
     Warning("deprecated warning 'depfilemulti'");
     return true;
-  } else {
-    const char* suggestion =
-        SpellcheckString(name.c_str(), "dupbuild=err", "dupbuild=warn",
-                         "phonycycle=err", "phonycycle=warn", NULL);
-    if (suggestion) {
-      Error("unknown warning flag '%s', did you mean '%s'?",
-            name.c_str(), suggestion);
-    } else {
-      Error("unknown warning flag '%s'", name.c_str());
-    }
-    return false;
   }
+
+  const char* suggestion =
+      SpellcheckString(name.c_str(), "dupbuild=err", "dupbuild=warn",
+                       "phonycycle=err", "phonycycle=warn", NULL);
+  if (suggestion) {
+    Error("unknown warning flag '%s', did you mean '%s'?", name.c_str(),
+          suggestion);
+  } else {
+    Error("unknown warning flag '%s'", name.c_str());
+  }
+  return false;
 }
 
 bool NinjaMain::OpenBuildLog(bool recompact_only) {
@@ -1203,10 +1216,9 @@ int NinjaMain::RunBuild(int argc, char** argv) {
       if (!err.empty()) {
         Error("%s", err.c_str());
         return 1;
-      } else {
-        // Added a target that is already up-to-date; not really
-        // an error.
       }
+      // Added a target that is already up-to-date; not really
+      // an error.
     }
   }
 
@@ -1416,7 +1428,9 @@ NORETURN void real_main(int argc, char** argv) {
         exit(0);
       // Start the build over with the new manifest.
       continue;
-    } else if (!err.empty()) {
+    }
+
+    if (!err.empty()) {
       Error("rebuilding '%s': %s", options.input_file, err.c_str());
       exit(1);
     }

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
 
 #ifdef _WIN32
 #include "getopt.h"

--- a/src/state.cc
+++ b/src/state.cc
@@ -14,8 +14,8 @@
 
 #include "state.h"
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 #include "edit_distance.h"
 #include "graph.h"

--- a/src/string_piece_util.cc
+++ b/src/string_piece_util.cc
@@ -39,7 +39,7 @@ vector<StringPiece> SplitStringPiece(StringPiece input, char sep) {
 }
 
 string JoinStringPiece(const vector<StringPiece>& list, char sep) {
-  if (list.size() == 0){
+  if (list.empty()) {
     return "";
   }
 

--- a/src/string_piece_util_test.cc
+++ b/src/string_piece_util_test.cc
@@ -29,7 +29,7 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
   }
 
   {
-    string empty("");
+    string empty;
     vector<StringPiece> list = SplitStringPiece(empty, ':');
 
     EXPECT_EQ(list.size(), 1);
@@ -80,7 +80,7 @@ TEST(StringPieceUtilTest, JoinStringPiece) {
   }
 
   {
-    string empty("");
+    string empty;
     vector<StringPiece> list = SplitStringPiece(empty, ':');
 
     EXPECT_EQ("", JoinStringPiece(list, ':'));

--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "subprocess.h"
-
-#include <sys/select.h>
-#include <assert.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/wait.h>
 #include <spawn.h>
+#include <sys/select.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
+#include "subprocess.h"
 
 extern char** environ;
 

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -18,10 +18,11 @@
 
 #ifndef _WIN32
 // SetWithLots need setrlimit.
-#include <stdio.h>
-#include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/time.h>
 #include <unistd.h>
+
+#include <cstdio>
 #endif
 
 namespace {

--- a/src/test.cc
+++ b/src/test.cc
@@ -188,9 +188,8 @@ int VirtualFileSystem::RemoveFile(const string& path) {
     files_.erase(i);
     files_removed_.insert(path);
     return 0;
-  } else {
-    return 1;
   }
+  return 1;
 }
 
 void ScopedTempDir::CreateAndEnter(const string& name) {

--- a/src/test.cc
+++ b/src/test.cc
@@ -16,12 +16,11 @@
 #include <direct.h>  // Has to be before util.h is included.
 #endif
 
-#include "test.h"
-
 #include <algorithm>
+#include <cerrno>
+#include <cstdlib>
 
-#include <errno.h>
-#include <stdlib.h>
+#include "test.h"
 #ifdef _WIN32
 #include <windows.h>
 #include <io.h>

--- a/src/util.cc
+++ b/src/util.cc
@@ -23,15 +23,16 @@
 #include <share.h>
 #endif
 
-#include <assert.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include <cassert>
+#include <cerrno>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #ifndef _WIN32
 #include <unistd.h>

--- a/src/util.cc
+++ b/src/util.cc
@@ -152,7 +152,9 @@ bool CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits,
         // '.' component; eliminate.
         src += 2;
         continue;
-      } else if (src[1] == '.' && (src + 2 == end || IsPathSeparator(src[2]))) {
+      }
+
+      if (src[1] == '.' && (src + 2 == end || IsPathSeparator(src[2]))) {
         // '..' component.  Back up if possible.
         if (component_count > 0) {
           dst = components[component_count - 1];

--- a/src/version.cc
+++ b/src/version.cc
@@ -14,7 +14,7 @@
 
 #include "version.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "util.h"
 


### PR DESCRIPTION
ran through several clang-tidy fixes.

I tried to keep C++98 compatibility. Locally, it builds fine with -DCMAKE_CXX_STANDARD=98

edit: also, every commit was ran with git clang-format.