### PR TITLE
[clang-tidy] check empty instead of size

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -1033,7 +1033,7 @@ bool Builder::FinishCommand(CommandRunner::Result* result, string* err) {
   }
 
   if (!deps_type.empty() && !config_.dry_run) {
-    assert(edge->outputs_.size() >= 1 && "should have been rejected by parser");
+    assert(!edge->outputs_.empty() && "should have been rejected by parser");
     for (std::vector<Node*>::const_iterator o = edge->outputs_.begin();
          o != edge->outputs_.end(); ++o) {
       TimeStamp deps_mtime = disk_interface_->Stat((*o)->path(), err);

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -672,7 +672,7 @@ bool FakeCommandRunner::WaitForCommand(Result* result) {
     bool verify_active_edge_found = false;
     for (vector<Edge*>::iterator i = active_edges_.begin();
          i != active_edges_.end(); ++i) {
-      if ((*i)->outputs_.size() >= 1 &&
+      if (!(*i)->outputs_.empty() &&
           (*i)->outputs_[0]->path() == verify_active_edge) {
         verify_active_edge_found = true;
       }

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -399,7 +399,7 @@ bool DepsLog::RecordId(Node* node) {
   if (fwrite(&size, 4, 1, file_) < 1)
     return false;
   if (fwrite(node->path().data(), path_size, 1, file_) < 1) {
-    assert(node->path().size() > 0);
+    assert(!node->path().empty());
     return false;
   }
   if (padding && fwrite("\0\0", padding, 1, file_) < 1)

--- a/src/string_piece_util.cc
+++ b/src/string_piece_util.cc
@@ -39,7 +39,7 @@ vector<StringPiece> SplitStringPiece(StringPiece input, char sep) {
 }
 
 string JoinStringPiece(const vector<StringPiece>& list, char sep) {
-  if (list.size() == 0){
+  if (list.empty()) {
     return "";
   }
 


### PR DESCRIPTION
Found with readability-container-size-empty

Signed-off-by: Rosen Penev <rosenp@gmail.com>