### PR TITLE
[clang-tidy] remove pointless c_str()

### DIFF
--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -190,7 +190,7 @@ TEST_F(DiskInterfaceTest, ReadFile) {
 
 TEST_F(DiskInterfaceTest, MakeDirs) {
   string path = "path/with/double//slash/";
-  EXPECT_TRUE(disk_.MakeDirs(path.c_str()));
+  EXPECT_TRUE(disk_.MakeDirs(path));
   FILE* f = fopen((path + "a_file").c_str(), "w");
   EXPECT_TRUE(f);
   EXPECT_EQ(0, fclose(f));


### PR DESCRIPTION
Found with readability-redundant-string-cstr

Signed-off-by: Rosen Penev <rosenp@gmail.com>