### PR TITLE
[clang-tidy] remove redundant member init

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -77,12 +77,9 @@ bool DryRunCommandRunner::WaitForCommand(Result* result) {
 }  // namespace
 
 BuildStatus::BuildStatus(const BuildConfig& config)
-    : config_(config),
-      start_time_millis_(GetTimeMillis()),
-      started_edges_(0), finished_edges_(0), total_edges_(0),
-      progress_status_format_(NULL),
-      overall_rate_(), current_rate_(config.parallelism) {
-
+    : config_(config), start_time_millis_(GetTimeMillis()), started_edges_(0),
+      finished_edges_(0), total_edges_(0), progress_status_format_(NULL),
+      current_rate_(config.parallelism) {
   // Don't do anything fancy in verbose mode.
   if (config_.verbosity != BuildConfig::NORMAL)
     printer_.set_smart_terminal(false);

--- a/src/clean.cc
+++ b/src/clean.cc
@@ -28,8 +28,6 @@ Cleaner::Cleaner(State* state,
   : state_(state),
     config_(config),
     dyndep_loader_(state, disk_interface),
-    removed_(),
-    cleaned_(),
     cleaned_files_count_(0),
     disk_interface_(disk_interface),
     status_(0) {


### PR DESCRIPTION
Found with readability-redundant-member-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>