### PR TITLE
[clang-tidy] remove pointless string init

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,9 +3,11 @@ Checks: '
   ,readability-avoid-const-params-in-decls,
   ,readability-non-const-parameter,
   ,readability-redundant-string-cstr,
+  ,readability-redundant-string-init,
 '
 WarningsAsErrors: '
   ,readability-avoid-const-params-in-decls,
   ,readability-non-const-parameter,
   ,readability-redundant-string-cstr,
+  ,readability-redundant-string-init,
 '

--- a/src/string_piece_util_test.cc
+++ b/src/string_piece_util_test.cc
@@ -31,7 +31,7 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
   }
 
   {
-    string empty("");
+    string empty;
     vector<StringPiece> list = SplitStringPiece(empty, ':');
 
     EXPECT_EQ(list.size(), 1);
@@ -82,7 +82,7 @@ TEST(StringPieceUtilTest, JoinStringPiece) {
   }
 
   {
-    string empty("");
+    string empty;
     vector<StringPiece> list = SplitStringPiece(empty, ':');
 
     EXPECT_EQ("", JoinStringPiece(list, ':'));


### PR DESCRIPTION
Found with readability-redundant-string-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>