### PR TITLE
[clang-tidy] do not use else after return

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -349,7 +349,8 @@ string EdgeEnv::LookupVariable(const string& var) {
     return MakePathList(&edge_->inputs_[0], explicit_deps_count,
 #endif
                         var == "in" ? ' ' : '\n');
-  } else if (var == "out") {
+  }
+  if (var == "out") {
     int explicit_outs_count = edge_->outputs_.size() - edge_->implicit_outs_;
     return MakePathList(&edge_->outputs_[0], explicit_outs_count, ' ');
   }

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -327,16 +327,16 @@ bool ManifestParser::ParseEdge(string* err) {
         lexer_.Error("multiple rules generate " + path + " [-w dupbuild=err]",
                      err);
         return false;
-      } else {
-        if (!quiet_) {
-          Warning("multiple rules generate %s. "
-                  "builds involving this target will not be correct; "
-                  "continuing anyway [-w dupbuild=warn]",
-                  path.c_str());
-        }
-        if (e - i <= static_cast<size_t>(implicit_outs))
-          --implicit_outs;
       }
+      if (!quiet_) {
+        Warning(
+            "multiple rules generate %s. "
+            "builds involving this target will not be correct; "
+            "continuing anyway [-w dupbuild=warn]",
+            path.c_str());
+      }
+      if (e - i <= static_cast<size_t>(implicit_outs))
+        --implicit_outs;
     }
   }
   if (edge->outputs_.empty()) {

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -297,21 +297,19 @@ Node* NinjaMain::CollectTarget(const char* cpath, string* err) {
       node = edge->outputs_[0];
     }
     return node;
-  } else {
-    *err =
-        "unknown target '" + Node::PathDecanonicalized(path, slash_bits) + "'";
-    if (path == "clean") {
-      *err += ", did you mean 'ninja -t clean'?";
-    } else if (path == "help") {
-      *err += ", did you mean 'ninja -h'?";
-    } else {
-      Node* suggestion = state_.SpellcheckNode(path);
-      if (suggestion) {
-        *err += ", did you mean '" + suggestion->path() + "'?";
-      }
-    }
-    return NULL;
   }
+  *err = "unknown target '" + Node::PathDecanonicalized(path, slash_bits) + "'";
+  if (path == "clean") {
+    *err += ", did you mean 'ninja -t clean'?";
+  } else if (path == "help") {
+    *err += ", did you mean 'ninja -h'?";
+  } else {
+    Node* suggestion = state_.SpellcheckNode(path);
+    if (suggestion) {
+      *err += ", did you mean '" + suggestion->path() + "'?";
+    }
+  }
+  return NULL;
 }
 
 bool NinjaMain::CollectTargetsFromArgs(int argc, char* argv[],
@@ -531,9 +529,10 @@ int NinjaMain::ToolTargets(const Options* options, int argc, char* argv[]) {
         rule = argv[1];
       if (rule.empty())
         return ToolTargetsSourceList(&state_);
-      else
-        return ToolTargetsList(&state_, rule);
-    } else if (mode == "depth") {
+      return ToolTargetsList(&state_, rule);
+    }
+
+    if (mode == "depth") {
       if (argc > 1)
         depth = atoi(argv[1]);
     } else if (mode == "all") {
@@ -555,10 +554,9 @@ int NinjaMain::ToolTargets(const Options* options, int argc, char* argv[]) {
   vector<Node*> root_nodes = state_.RootNodes(&err);
   if (err.empty()) {
     return ToolTargetsList(root_nodes, depth, 0);
-  } else {
-    Error("%s", err.c_str());
-    return 1;
   }
+  Error("%s", err.c_str());
+  return 1;
 }
 
 int NinjaMain::ToolRules(const Options* options, int argc, char* argv[]) {
@@ -711,11 +709,9 @@ int NinjaMain::ToolClean(const Options* options, int argc, char* argv[]) {
   if (argc >= 1) {
     if (clean_rules)
       return cleaner.CleanRules(argc, argv);
-    else
-      return cleaner.CleanTargets(argc, argv);
-  } else {
-    return cleaner.CleanAll(generator);
+    return cleaner.CleanTargets(argc, argv);
   }
+  return cleaner.CleanAll(generator);
 }
 
 int NinjaMain::ToolCleanDead(const Options* options, int argc, char* argv[]) {
@@ -1020,34 +1016,43 @@ bool DebugEnable(const string& name) {
 #endif
 "multiple modes can be enabled via -d FOO -d BAR\n");
     return false;
-  } else if (name == "stats") {
+  }
+
+  if (name == "stats") {
     g_metrics = new Metrics;
     return true;
-  } else if (name == "explain") {
+  }
+
+  if (name == "explain") {
     g_explaining = true;
     return true;
-  } else if (name == "keepdepfile") {
+  }
+
+  if (name == "keepdepfile") {
     g_keep_depfile = true;
     return true;
-  } else if (name == "keeprsp") {
+  }
+
+  if (name == "keeprsp") {
     g_keep_rsp = true;
     return true;
-  } else if (name == "nostatcache") {
+  }
+
+  if (name == "nostatcache") {
     g_experimental_statcache = false;
     return true;
-  } else {
-    const char* suggestion =
-        SpellcheckString(name.c_str(),
-                         "stats", "explain", "keepdepfile", "keeprsp",
-                         "nostatcache", NULL);
-    if (suggestion) {
-      Error("unknown debug setting '%s', did you mean '%s'?",
-            name.c_str(), suggestion);
-    } else {
-      Error("unknown debug setting '%s'", name.c_str());
-    }
-    return false;
   }
+
+  const char* suggestion =
+      SpellcheckString(name.c_str(), "stats", "explain", "keepdepfile",
+                       "keeprsp", "nostatcache", NULL);
+  if (suggestion) {
+    Error("unknown debug setting '%s', did you mean '%s'?", name.c_str(),
+          suggestion);
+  } else {
+    Error("unknown debug setting '%s'", name.c_str());
+  }
+  return false;
 }
 
 /// Set a warning flag.  Returns false if Ninja should exit instead of
@@ -1059,34 +1064,43 @@ bool WarningEnable(const string& name, Options* options) {
 "  phonycycle={err,warn}  phony build statement references itself\n"
     );
     return false;
-  } else if (name == "dupbuild=err") {
+  }
+
+  if (name == "dupbuild=err") {
     options->dupe_edges_should_err = true;
     return true;
-  } else if (name == "dupbuild=warn") {
+  }
+
+  if (name == "dupbuild=warn") {
     options->dupe_edges_should_err = false;
     return true;
-  } else if (name == "phonycycle=err") {
+  }
+
+  if (name == "phonycycle=err") {
     options->phony_cycle_should_err = true;
     return true;
-  } else if (name == "phonycycle=warn") {
+  }
+
+  if (name == "phonycycle=warn") {
     options->phony_cycle_should_err = false;
     return true;
-  } else if (name == "depfilemulti=err" ||
-             name == "depfilemulti=warn") {
+  }
+
+  if (name == "depfilemulti=err" || name == "depfilemulti=warn") {
     Warning("deprecated warning 'depfilemulti'");
     return true;
-  } else {
-    const char* suggestion =
-        SpellcheckString(name.c_str(), "dupbuild=err", "dupbuild=warn",
-                         "phonycycle=err", "phonycycle=warn", NULL);
-    if (suggestion) {
-      Error("unknown warning flag '%s', did you mean '%s'?",
-            name.c_str(), suggestion);
-    } else {
-      Error("unknown warning flag '%s'", name.c_str());
-    }
-    return false;
   }
+
+  const char* suggestion =
+      SpellcheckString(name.c_str(), "dupbuild=err", "dupbuild=warn",
+                       "phonycycle=err", "phonycycle=warn", NULL);
+  if (suggestion) {
+    Error("unknown warning flag '%s', did you mean '%s'?", name.c_str(),
+          suggestion);
+  } else {
+    Error("unknown warning flag '%s'", name.c_str());
+  }
+  return false;
 }
 
 bool NinjaMain::OpenBuildLog(bool recompact_only) {
@@ -1203,10 +1217,9 @@ int NinjaMain::RunBuild(int argc, char** argv) {
       if (!err.empty()) {
         Error("%s", err.c_str());
         return 1;
-      } else {
-        // Added a target that is already up-to-date; not really
-        // an error.
       }
+      // Added a target that is already up-to-date; not really
+      // an error.
     }
   }
 
@@ -1416,7 +1429,9 @@ NORETURN void real_main(int argc, char** argv) {
         exit(0);
       // Start the build over with the new manifest.
       continue;
-    } else if (!err.empty()) {
+    }
+
+    if (!err.empty()) {
       Error("rebuilding '%s': %s", options.input_file, err.c_str());
       exit(1);
     }

--- a/src/test.cc
+++ b/src/test.cc
@@ -188,9 +188,8 @@ int VirtualFileSystem::RemoveFile(const string& path) {
     files_.erase(i);
     files_removed_.insert(path);
     return 0;
-  } else {
-    return 1;
   }
+  return 1;
 }
 
 void ScopedTempDir::CreateAndEnter(const string& name) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -152,7 +152,9 @@ bool CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits,
         // '.' component; eliminate.
         src += 2;
         continue;
-      } else if (src[1] == '.' && (src + 2 == end || IsPathSeparator(src[2]))) {
+      }
+
+      if (src[1] == '.' && (src + 2 == end || IsPathSeparator(src[2]))) {
         // '..' component.  Back up if possible.
         if (component_count > 0) {
           dst = components[component_count - 1];


### PR DESCRIPTION
Found with readability-else-after-return

Signed-off-by: Rosen Penev <rosenp@gmail.com>