### PR TITLE
[clang-tidy] fix small false positive

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -1067,8 +1067,7 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
       // complexity in IncludesNormalize::Relativize.
       deps_nodes->push_back(state_->GetNode(*i, ~0u));
     }
-  } else
-  if (deps_type == "gcc") {
+  } else if (deps_type == "gcc") {
     string depfile = result->edge->GetUnescapedDepfile();
     if (depfile.empty()) {
       *err = string("edge with deps=gcc but no depfile makes no sense");


### PR DESCRIPTION
else if has to be on the same line it seems.

Found with readability-misleading-indentation

Signed-off-by: Rosen Penev <rosenp@gmail.com>