### PR TITLE
[clang-tidy] simplify boolean expression

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,10 +4,12 @@ Checks: '
   ,readability-non-const-parameter,
   ,readability-redundant-string-cstr,
   ,readability-redundant-string-init,
+  ,readability-simplify-boolean-expr,
 '
 WarningsAsErrors: '
   ,readability-avoid-const-params-in-decls,
   ,readability-non-const-parameter,
   ,readability-redundant-string-cstr,
   ,readability-redundant-string-init,
+  ,readability-simplify-boolean-expr,
 '

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -202,10 +202,7 @@ bool ManifestParser::ParseDefault(string* err) {
       return false;
   } while (!eval.empty());
 
-  if (!ExpectToken(Lexer::NEWLINE, err))
-    return false;
-
-  return true;
+  return ExpectToken(Lexer::NEWLINE, err);
 }
 
 bool ManifestParser::ParseEdge(string* err) {


### PR DESCRIPTION
Found with readability-simplify-boolean-expr

Signed-off-by: Rosen Penev <rosenp@gmail.com>