### PR TITLE
[clang-tidy] add explicit to single argument constructors

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -490,10 +490,9 @@ struct BuildTest : public StateTestWithBuiltinRules, public BuildLogUser {
                 status_(config_) {
   }
 
-  BuildTest(DepsLog* log) : config_(MakeConfig()), command_runner_(&fs_),
-                            builder_(&state_, config_, NULL, log, &fs_),
-                            status_(config_) {
-  }
+  explicit BuildTest(DepsLog* log)
+      : config_(MakeConfig()), command_runner_(&fs_),
+        builder_(&state_, config_, NULL, log, &fs_), status_(config_) {}
 
   virtual void SetUp() {
     StateTestWithBuiltinRules::SetUp();

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -515,7 +515,7 @@ bool ImplicitDepLoader::LoadDeps(Edge* edge, string* err) {
 }
 
 struct matches {
-  matches(std::vector<StringPiece>::iterator i) : i_(i) {}
+  explicit matches(std::vector<StringPiece>::iterator i) : i_(i) {}
 
   bool operator()(const Node* node) const {
     StringPiece opath = StringPiece(node->path());


### PR DESCRIPTION
Found with google-explicit-constructor

Signed-off-by: Rosen Penev <rosenp@gmail.com>