### PR TITLE
[clang-tidy] change string to reference

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -469,7 +469,7 @@ bool Edge::maybe_phonycycle_diagnostic() const {
 
 // static
 string Node::PathDecanonicalized(const string& path, uint64_t slash_bits) {
-  string result = path;
+  const string& result = path;
 #ifdef _WIN32
   uint64_t mask = 1;
   for (char* c = &result[0]; (c = strchr(c, '/')) != NULL;) {


### PR DESCRIPTION
Found with performance-unnecessary-copy-initialization

Signed-off-by: Rosen Penev <rosenp@gmail.com>