### PR TITLE
Include unistd.h in disk_interface.cc

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -26,6 +26,8 @@
 #include <sstream>
 #include <windows.h>
 #include <direct.h>  // _mkdir
+#else
+#include <unistd.h>
 #endif
 
 #include "metrics.h"


### PR DESCRIPTION
stat() needs unistd.h in addition to sys/stat.h and sys/types.h per POSIX.
At least one (hobby) OS does need unistd.h, so add an include for it.