### PR TITLE
Include sys/select.h in subprocess-posix.cc

### DIFF
--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -18,12 +18,17 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <poll.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/wait.h>
 #include <spawn.h>
+
+#if defined(USE_PPOLL)
+#include <poll.h>
+#else
+#include <sys/select.h>
+#endif
 
 extern char** environ;
 


### PR DESCRIPTION
pselect() is in sys/select.h in "newer" (2001) versions of posix, so add an include for it.

While here, only include poll.h if USE_PPOLL is defined.