### PR TITLE
Output exit code in FAILED message

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -147,7 +147,7 @@ struct CommandRunner {
     Edge* edge;
     ExitStatus status;
     string output;
-    bool success() const { return status == ExitSuccess; }
+    bool success() const { return status.result == ExitSuccess; }
   };
   /// Wait for a command to complete, or return false if interrupted.
   virtual bool WaitForCommand(Result* result) = 0;
@@ -241,7 +241,7 @@ struct BuildStatus {
   explicit BuildStatus(const BuildConfig& config);
   void PlanHasTotalEdges(int total);
   void BuildEdgeStarted(const Edge* edge);
-  void BuildEdgeFinished(Edge* edge, bool success, const string& output,
+  void BuildEdgeFinished(Edge* edge, const CommandRunner::Result* result,
                          int* start_time, int* end_time);
   void BuildLoadDyndeps();
   void BuildStarted();

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -637,15 +637,15 @@ bool FakeCommandRunner::WaitForCommand(Result* result) {
 
   if (edge->rule().name() == "interrupt" ||
       edge->rule().name() == "touch-interrupt") {
-    result->status = ExitInterrupted;
+    result->status = ExitStatus(ExitInterrupted, 2);
     return true;
   }
 
   if (edge->rule().name() == "console") {
     if (edge->use_console())
-      result->status = ExitSuccess;
+      result->status = ExitStatus(ExitSuccess, 0);
     else
-      result->status = ExitFailure;
+      result->status = ExitStatus(ExitFailure, 1);
     active_edges_.erase(edge_iter);
     return true;
   }
@@ -660,9 +660,9 @@ bool FakeCommandRunner::WaitForCommand(Result* result) {
 
   if (edge->rule().name() == "fail" ||
       (edge->rule().name() == "touch-fail-tick2" && fs_->now_ == 2))
-    result->status = ExitFailure;
+    result->status = ExitStatus(ExitFailure, 1);
   else
-    result->status = ExitSuccess;
+    result->status = ExitStatus(ExitSuccess, 0);
 
   // Provide a way for test cases to verify when an edge finishes that
   // some other edge is still active.  This is useful for test cases

--- a/src/exit_status.h
+++ b/src/exit_status.h
@@ -15,10 +15,19 @@
 #ifndef NINJA_EXIT_STATUS_H_
 #define NINJA_EXIT_STATUS_H_
 
-enum ExitStatus {
+enum ExitResult {
   ExitSuccess,
   ExitFailure,
   ExitInterrupted
 };
+
+struct ExitStatus {
+  ExitStatus(): result(ExitSuccess), exit_code(0) {}
+  ExitStatus(ExitResult result, int exit_code):
+    result(result), exit_code(exit_code) {}
+  ExitResult result;
+  int exit_code;
+};
+
 
 #endif  // NINJA_EXIT_STATUS_H_

--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -155,13 +155,15 @@ ExitStatus Subprocess::Finish() {
   if (WIFEXITED(status)) {
     int exit = WEXITSTATUS(status);
     if (exit == 0)
-      return ExitSuccess;
+      return ExitStatus(ExitSuccess, exit);
+    else
+      return ExitStatus(ExitFailure, exit);
   } else if (WIFSIGNALED(status)) {
     if (WTERMSIG(status) == SIGINT || WTERMSIG(status) == SIGTERM
         || WTERMSIG(status) == SIGHUP)
-      return ExitInterrupted;
+      return ExitStatus(ExitInterrupted, status);
   }
-  return ExitFailure;
+  return ExitStatus(ExitFailure, status);
 }
 
 bool Subprocess::Done() const {

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -185,7 +185,7 @@ void Subprocess::OnPipeReady() {
 
 ExitStatus Subprocess::Finish() {
   if (!child_)
-    return ExitFailure;
+    return ExitStatus(ExitFailure, INT32_MAX);
 
   // TODO: add error handling for all of these.
   WaitForSingleObject(child_, INFINITE);
@@ -196,9 +196,9 @@ ExitStatus Subprocess::Finish() {
   CloseHandle(child_);
   child_ = NULL;
 
-  return exit_code == 0              ? ExitSuccess :
-         exit_code == CONTROL_C_EXIT ? ExitInterrupted :
-                                       ExitFailure;
+  return exit_code == 0              ? ExitStatus(ExitSuccess, exit_code) :
+         exit_code == CONTROL_C_EXIT ? ExitStatus(ExitInterrupted, exit_code) :
+                                       ExitStatus(ExitFailure, exit_code);
 }
 
 bool Subprocess::Done() const {

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -43,8 +43,11 @@ using namespace std;
 struct Subprocess {
   ~Subprocess();
 
-  /// Returns ExitSuccess on successful process exit, ExitInterrupted if
-  /// the process was interrupted, ExitFailure if it otherwise failed.
+  /// Returns ExitStatus for the end of the process. The result field will be
+  /// populated with ExitSuccess on successful process exit, ExitInterrupted if
+  /// the process was interrupted, ExitFailure if it otherwise failed. The
+  /// exit_code field will contain the exit code (exit status, errorlevel) of
+  /// the process.
   ExitStatus Finish();
 
   bool Done() const;


### PR DESCRIPTION
This fixes #1507 

Outputs the exit code after "FAILED" for any process that did not
complete successfully.

Output looks like "FAILED (\<exitcode\>): \<outputs\>"