### PR TITLE
WIP: Allow running ninjas to share a job limit

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -544,6 +544,9 @@ else:
 if platform.is_aix() and not platform.is_os400_pase():
     libs.append('-lperfstat')
 
+if not platform.is_msvc():
+    libs.append('-lpthread')
+
 all_targets = []
 
 n.comment('Main executable is library plus main() function.')

--- a/src/build.cc
+++ b/src/build.cc
@@ -40,7 +40,57 @@
 #include "subprocess.h"
 #include "util.h"
 
+#ifndef _WIN32
+unsigned shared_ninja_jobs = 0;
+unsigned shared_ninja_local_jobs = 0;
+sem_t* shared_ninja_jobs_semaphore = nullptr;
+sem_t* shared_ninjas_semaphore = nullptr;
+char shared_ninja_jobs_semaphore_name[sizeof(SHARED_NINJA_JOBS_SEMAPHORE_PREFIX
+                                             "18446744073709551615")] =
+    "";  // UINT64_MAX
+char shared_ninjas_semaphore_name[sizeof(
+    SHARED_NINJAS_SEMAPHORE_PREFIX "18446744073709551615")] = "";  // UINT64_MAX
+#endif
+
 namespace {
+
+bool TryGlobalSpawnEnter() {
+#ifndef _WIN32
+  if (shared_ninja_jobs_semaphore == nullptr)
+    return true;
+
+  int current_ninjas;
+  if (sem_getvalue(shared_ninjas_semaphore, &current_ninjas) != 0)
+    Fatal("sem_getvalue: %s", strerror(errno));
+
+  // There is a technically race between getting the number of ninjas and
+  // waiting, so as a hack add one more phantom ninja just in case.
+  bool wait = shared_ninja_local_jobs <
+              (shared_ninja_jobs / unsigned(current_ninjas + 1));
+
+  if (wait) {
+    if (sem_wait(shared_ninja_jobs_semaphore) != 0)
+      Fatal("sem_wait: %s", strerror(errno));
+  } else if (sem_trywait(shared_ninja_jobs_semaphore) != 0) {
+    if (errno == EAGAIN)
+      return false;
+    Fatal("sem_trywait: %s", strerror(errno));
+  }
+  ++shared_ninja_local_jobs;
+#endif
+
+  return true;
+}
+
+void GlobalSpawnLeave() {
+#ifndef _WIN32
+  if (shared_ninja_jobs_semaphore == nullptr)
+    return;
+  --shared_ninja_local_jobs;
+  if (sem_post(shared_ninja_jobs_semaphore) != 0)
+    Fatal("sem_post: %s", strerror(errno));
+#endif
+}
 
 /// A CommandRunner that doesn't actually run the commands.
 struct DryRunCommandRunner : public CommandRunner {
@@ -828,25 +878,30 @@ bool Builder::Build(string* err) {
   while (plan_.more_to_do()) {
     // See if we can start any more commands.
     if (failures_allowed && command_runner_->CanRunMore()) {
-      if (Edge* edge = plan_.FindWork()) {
-        if (!StartEdge(edge, err)) {
-          Cleanup();
-          status_->BuildFinished();
-          return false;
-        }
-
-        if (edge->is_phony()) {
-          if (!plan_.EdgeFinished(edge, Plan::kEdgeSucceeded, err)) {
+      if (TryGlobalSpawnEnter()) {
+        if (Edge* edge = plan_.FindWork()) {
+          if (!StartEdge(edge, err)) {
             Cleanup();
             status_->BuildFinished();
             return false;
           }
-        } else {
-          ++pending_commands;
-        }
 
-        // We made some progress; go back to the main loop.
-        continue;
+          if (edge->is_phony()) {
+            GlobalSpawnLeave();
+            if (!plan_.EdgeFinished(edge, Plan::kEdgeSucceeded, err)) {
+              Cleanup();
+              status_->BuildFinished();
+              return false;
+            }
+          } else {
+            ++pending_commands;
+          }
+
+          // We made some progress; go back to the main loop.
+          continue;
+        } else {
+          GlobalSpawnLeave();
+        }
       }
     }
 
@@ -862,6 +917,7 @@ bool Builder::Build(string* err) {
       }
 
       --pending_commands;
+      GlobalSpawnLeave();
       if (!FinishCommand(&result, err)) {
         Cleanup();
         status_->BuildFinished();

--- a/src/util.cc
+++ b/src/util.cc
@@ -68,6 +68,10 @@ void Fatal(const char* msg, ...) {
   fflush(stdout);
   ExitProcess(1);
 #else
+  // If we have a fatal error, then the shared semaphores might be wrong.
+  // Just unlink them and let the next ninja instance recreate it.
+  sem_unlink(shared_ninja_jobs_semaphore_name);
+  sem_unlink(shared_ninjas_semaphore_name);
   exit(1);
 #endif
 }

--- a/src/util.h
+++ b/src/util.h
@@ -18,7 +18,30 @@
 #ifdef _WIN32
 #include "win32port.h"
 #else
+#include <fcntl.h>
+#include <semaphore.h>
 #include <stdint.h>
+#include <sys/stat.h>
+
+// The semaphores shared between all ninja processes.
+extern sem_t* shared_ninja_jobs_semaphore;  // Count down of shared job. Zero
+                                            // means no more CPUs.
+extern sem_t* shared_ninjas_semaphore;      // Count of running ninjas for
+                                            // calculating "fairness".
+
+// The shared number of jobs:
+extern unsigned shared_ninja_jobs;
+
+// The local contribution to the shared semaphore:
+extern unsigned shared_ninja_local_jobs;
+
+#define SHARED_NINJA_JOBS_SEMAPHORE_PREFIX "ninja-jobs-"
+extern char shared_ninja_jobs_semaphore_name[sizeof(
+    SHARED_NINJA_JOBS_SEMAPHORE_PREFIX "18446744073709551615")];  // UINT64_MAX
+
+#define SHARED_NINJAS_SEMAPHORE_PREFIX "ninjas-"
+extern char shared_ninjas_semaphore_name[sizeof(
+    SHARED_NINJAS_SEMAPHORE_PREFIX "18446744073709551615")];  // UINT64_MAX
 #endif
 
 #include <string>


### PR DESCRIPTION
Hello. I've been toying around with using POSIX semaphores to enable a process jobs limit across ninja invocations. This is only the first take and there is plenty of room for improvement (and robustness). That being said, it does work. Is this something that might be a candidate for upstreaming? High level feedback and style feedback is appreciated. The design of this patch will probably change considerably in order to recover from ninja crashing.