### PR TITLE
Provide a way to silence status update with empty string in NINJA_STA…

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -211,6 +211,8 @@ The default progress status is `"[%f/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status
 could be `"[%u/%r/%f] "`.
 
+If `NINJA_STATUS` is set to an empty string, no status updates are printed.
+
 Extra tools
 ~~~~~~~~~~~
 

--- a/src/build.cc
+++ b/src/build.cc
@@ -291,7 +291,8 @@ string BuildStatus::FormatProgressStatus(
 }
 
 void BuildStatus::PrintStatus(const Edge* edge, EdgeStatus status) {
-  if (config_.verbosity == BuildConfig::QUIET)
+  if (config_.verbosity == BuildConfig::QUIET
+      || strlen(progress_status_format_) == 0)
     return;
 
   bool force_full_command = config_.verbosity == BuildConfig::VERBOSE;


### PR DESCRIPTION
I typically run ninja inside emacs to compile and generate the compiler messages to step through. The 'terminal' emacs provides does not allow for in-place updates of the status update line, so it scrolls with non-relevant information between actual compiler errors or warnings.

```
ninja
[1/31] CXX build/build_log.o
[2/31] CXX build/clean.o
[3/31] INLINE build/browse_py.h
[4/31] RE2C src/depfile_parser.cc
[5/31] RE2C src/lexer.cc
[6/31] CXX build/build.o
[7/31] CXX build/clparser.o
<... more scrolling status updates ...>
```

So ideally, it was possible to silence the output if the user just chooses to, so that _only_ actual compiler outputs, but not the build rule invocations. So well adhering to the _"no news are good news"_ paradigm.

The presented solution in this pull request is the simplest: if the user sets the `NINJA_STATUS` formatting string to an empty string, this now is interpreted to not show any status. IMHO a good, no-surprise way to express that intent.

Downside of course is that this changes behavior: is some existing user set the environment variable to an empty string before, they got build rules, but no prefix; now this would not output anything. Question is how often this is used in this way ?

Potential alternatives:
  * Add a new `BuildConfig::NO_STATUS_UPDATE` and wire it up to a command line option and/or environment variable. More involved, but it would preserve the existing use-case of setting NINJA_STATUS to an empty string and still get non-prefixed output.
  * Do some second-guessing of the intent and don't print status updates if `getenv("TERM") == "dumb"` (which is what emacs sets when compiling). This might work well in practice but sounds a bit like too much 'magic' as there was no explicit user choice.