### PR TITLE
Use c++ instead of g++

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -269,7 +269,7 @@ if configure_env:
     n.variable('configure_env', config_str + '$ ')
 n.newline()
 
-CXX = configure_env.get('CXX', 'g++')
+CXX = configure_env.get('CXX', 'c++')
 objext = '.o'
 if platform.is_msvc():
     CXX = 'cl'


### PR DESCRIPTION
`configure.py` assumes `g++` is present on the system, which is not the case, e.g. for FreeBSD.
`c++` should be used insted, which should be a link to system c++ compiler. This will be `g++` for linux, but `clang++` for FreeBSD.