### PR TITLE
Close BuildLog while running generators, fix #1724

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -829,6 +829,10 @@ bool Builder::Build(string* err) {
     // See if we can start any more commands.
     if (failures_allowed && command_runner_->CanRunMore()) {
       if (Edge* edge = plan_.FindWork()) {
+        if (edge->GetBindingBool("generator")) {
+          scan_.build_log()->Close();
+        }
+
         if (!StartEdge(edge, err)) {
           Cleanup();
           status_->BuildFinished();

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -181,7 +181,7 @@ void BuildLog::Close() {
 }
 
 bool BuildLog::OpenForWriteIfNeeded() {
-  if (log_file_path_.empty()) {
+  if (log_file_ || log_file_path_.empty()) {
     return true;
   }
   log_file_ = fopen(log_file_path_.c_str(), "ab");
@@ -200,7 +200,6 @@ bool BuildLog::OpenForWriteIfNeeded() {
       return false;
     }
   }
-  log_file_path_.clear();
   return true;
 }
 


### PR DESCRIPTION
While #1780 delayed opening .ninja_log until the first write, this this didn't fully fix the issue on Windows: There might be build
statements which run before the generator resulting in an actual write to .ninja_log.

To fix this once and for all the BuildLog now gets closed before running the generator. `BuildLog::log_file_path_` won't be cleared so that it can be opened again after the generator finished.

See #1724. Not sure if the same needs to be done for .ninja_deps?