### PR TITLE
CMake: make test build optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ include(CheckIncludeFileCXX)
 
 project(ninja)
 
+option(NINJA_BUILD_TESTING "build optional self-tests" ON)
+
 # --- optional link-time optimization
 if(CMAKE_BUILD_TYPE MATCHES "Release")
 	include(CheckIPOSupported)
@@ -149,6 +151,7 @@ if(platform_supports_ninja_browse)
 	)
 endif()
 
+if(NINJA_BUILD_TESTING)
 # Tests all build into ninja_test executable.
 add_executable(ninja_test
 	src/build_log_test.cc
@@ -190,4 +193,14 @@ endforeach()
 enable_testing()
 add_test(NinjaTest ninja_test)
 
+endif(NINJA_BUILD_TESTING)
+
 install(TARGETS ninja DESTINATION bin)
+
+include(FeatureSummary)
+
+add_feature_info(selftest NINJA_BUILD_TESTING "Ninja self tests")
+add_feature_info(re2c RE2C "lexer generator")
+add_feature_info(LTO lto_supported "Link time / interprocess optimization  ${error}")
+
+feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ via CMake. For more details see
 
 ### Python
 
-```
+```sh
 ./configure.py --bootstrap
 ```
 
@@ -36,16 +36,25 @@ to build Ninja with itself.
 
 ### CMake
 
-```
+```sh
 cmake -Bbuild-cmake -H.
-cmake --build build-cmake
+cmake --build build-cmake --parallel
 ```
+
+The optional `--parallel` argument builds Ninja more quickly by parallel compilation.
 
 The `ninja` binary will now be inside the `build-cmake` directory (you can
 choose any other name you like).
 
 To run the unit tests:
 
-```
+```sh
 ./build-cmake/ninja_test
+```
+
+The Ninja build can be sped up by omitting the self tests:
+
+```sh
+cmake -Bbuild-cmake -DNINJA_BUILD_TESTING=off
+cmake --build build-cmake --parallel
 ```


### PR DESCRIPTION
For low-resource systems, it can be useful to greatly speed up the build
by not building the self-tests when they're not wanted. This also helps
avoid the Ninja build crashing since the self test build uses > 1GB RAM.