### PR TITLE
Add terse output mode

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -291,7 +291,8 @@ string BuildStatus::FormatProgressStatus(
 }
 
 void BuildStatus::PrintStatus(const Edge* edge, EdgeStatus status) {
-  if (config_.verbosity == BuildConfig::QUIET)
+  if (config_.verbosity == BuildConfig::QUIET
+      || config_.verbosity == BuildConfig::NO_STATUS_UPDATE)
     return;
 
   bool force_full_command = config_.verbosity == BuildConfig::VERBOSE;

--- a/src/build.cc
+++ b/src/build.cc
@@ -74,11 +74,14 @@ bool DryRunCommandRunner::WaitForCommand(Result* result) {
    return true;
 }
 
+const int64_t kTerseIntervalMillies = 15 * 1000;
+
 }  // namespace
 
 BuildStatus::BuildStatus(const BuildConfig& config)
     : config_(config),
       start_time_millis_(GetTimeMillis()),
+      terse_status_time_millis_(start_time_millis_ - kTerseIntervalMillies),
       started_edges_(0), finished_edges_(0), total_edges_(0),
       progress_status_format_(NULL),
       overall_rate_(), current_rate_(config.parallelism) {
@@ -96,7 +99,7 @@ void BuildStatus::PlanHasTotalEdges(int total) {
   total_edges_ = total;
 }
 
-void BuildStatus::BuildEdgeStarted(const Edge* edge) {
+void BuildStatus::BuildEdgeStarted(Edge* edge) {
   assert(running_edges_.find(edge) == running_edges_.end());
   int start_time = (int)(GetTimeMillis() - start_time_millis_);
   running_edges_.insert(make_pair(edge, start_time));
@@ -129,8 +132,10 @@ void BuildStatus::BuildEdgeFinished(Edge* edge,
   if (config_.verbosity == BuildConfig::QUIET)
     return;
 
-  if (!edge->use_console())
-    PrintStatus(edge, kEdgeFinished);
+  if (!success || !output.empty())
+    PrintStatus(edge, kEdgeFinishedWithOutput);
+  else if (!edge->use_console())
+    PrintStatus(edge, kEdgeFinishedWithoutOutput);
 
   // Print the command that is spewing before printing its output.
   if (!success) {
@@ -231,7 +236,7 @@ string BuildStatus::FormatProgressStatus(
       case 'r': {
         int running_edges = started_edges_ - finished_edges_;
         // count the edge that just finished as a running edge
-        if (status == kEdgeFinished)
+        if (status != kEdgeStarted)
           running_edges++;
         snprintf(buf, sizeof(buf), "%d", running_edges);
         out += buf;
@@ -290,10 +295,27 @@ string BuildStatus::FormatProgressStatus(
   return out;
 }
 
-void BuildStatus::PrintStatus(const Edge* edge, EdgeStatus status) {
+void BuildStatus::PrintStatus(Edge* edge, EdgeStatus status) {
   if (config_.verbosity == BuildConfig::QUIET
       || config_.verbosity == BuildConfig::NO_STATUS_UPDATE)
     return;
+
+  if (config_.verbosity == BuildConfig::TERSE) {
+    const int64_t now = GetTimeMillis();
+
+    if (status == kEdgeFinishedWithOutput) {
+      // already printed status line?
+      if (edge->status_printed_)
+        return;
+    } else if (now - terse_status_time_millis_ < kTerseIntervalMillies) {
+      // print periodic status?
+      return;
+    }
+
+    terse_status_time_millis_ = now;
+  }
+
+  edge->status_printed_ = true;
 
   bool force_full_command = config_.verbosity == BuildConfig::VERBOSE;
 

--- a/src/build.h
+++ b/src/build.h
@@ -162,8 +162,9 @@ struct BuildConfig {
                   failures_allowed(1), max_load_average(-0.0f) {}
 
   enum Verbosity {
-    NORMAL,
     QUIET,  // No output -- used when testing.
+    NO_STATUS_UPDATE,  // just regular output but suppress status update
+    NORMAL,  // regular output and status update
     VERBOSE
   };
   Verbosity verbosity;

--- a/src/build.h
+++ b/src/build.h
@@ -164,6 +164,7 @@ struct BuildConfig {
   enum Verbosity {
     QUIET,  // No output -- used when testing.
     NO_STATUS_UPDATE,  // just regular output but suppress status update
+    TERSE, // periodically print status update
     NORMAL,  // regular output and status update
     VERBOSE
   };
@@ -241,7 +242,7 @@ struct Builder {
 struct BuildStatus {
   explicit BuildStatus(const BuildConfig& config);
   void PlanHasTotalEdges(int total);
-  void BuildEdgeStarted(const Edge* edge);
+  void BuildEdgeStarted(Edge* edge);
   void BuildEdgeFinished(Edge* edge, bool success, const string& output,
                          int* start_time, int* end_time);
   void BuildLoadDyndeps();
@@ -250,7 +251,8 @@ struct BuildStatus {
 
   enum EdgeStatus {
     kEdgeStarted,
-    kEdgeFinished,
+    kEdgeFinishedWithoutOutput,
+    kEdgeFinishedWithOutput,
   };
 
   /// Format the progress status string by replacing the placeholders.
@@ -262,12 +264,15 @@ struct BuildStatus {
                               EdgeStatus status) const;
 
  private:
-  void PrintStatus(const Edge* edge, EdgeStatus status);
+  void PrintStatus(Edge* edge, EdgeStatus status);
 
   const BuildConfig& config_;
 
   /// Time the build started.
   int64_t start_time_millis_;
+
+  // Time the last terse update happened
+  int64_t terse_status_time_millis_;
 
   int started_edges_, finished_edges_, total_edges_;
 

--- a/src/graph.h
+++ b/src/graph.h
@@ -146,8 +146,9 @@ struct Edge {
 
   Edge() : rule_(NULL), pool_(NULL), dyndep_(NULL), env_(NULL),
            mark_(VisitNone), outputs_ready_(false), deps_loaded_(false),
-           deps_missing_(false), implicit_deps_(0), order_only_deps_(0),
-           implicit_outs_(0) {}
+           deps_missing_(false),
+           status_printed_(false), implicit_deps_(0),
+           order_only_deps_(0), implicit_outs_(0) {}
 
   /// Return true if all inputs' in-edges are ready.
   bool AllInputsReady() const;
@@ -180,6 +181,7 @@ struct Edge {
   bool outputs_ready_;
   bool deps_loaded_;
   bool deps_missing_;
+  bool status_printed_;
 
   const Rule& rule() const { return *rule_; }
   Pool* pool() const { return pool_; }

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -207,7 +207,7 @@ void Usage(const BuildConfig& config) {
 "options:\n"
 "  --version      print ninja version (\"%s\")\n"
 "  -v, --verbose  show all command lines while building\n"
-"  --quiet        don't show progress updates.\n"
+"  --quiet        don't show progress status, just command output\n"
 "\n"
 "  -C DIR   change to DIR before doing anything else\n"
 "  -f FILE  specify input build file [default=build.ninja]\n"

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -207,6 +207,7 @@ void Usage(const BuildConfig& config) {
 "options:\n"
 "  --version      print ninja version (\"%s\")\n"
 "  -v, --verbose  show all command lines while building\n"
+"  --quiet        don't show progress updates.\n"
 "\n"
 "  -C DIR   change to DIR before doing anything else\n"
 "  -f FILE  specify input build file [default=build.ninja]\n"
@@ -1258,11 +1259,12 @@ int ReadFlags(int* argc, char*** argv,
               Options* options, BuildConfig* config) {
   config->parallelism = GuessParallelism();
 
-  enum { OPT_VERSION = 1 };
+  enum { OPT_VERSION = 1, OPT_QUIET = 2 };
   const option kLongOptions[] = {
     { "help", no_argument, NULL, 'h' },
     { "version", no_argument, NULL, OPT_VERSION },
     { "verbose", no_argument, NULL, 'v' },
+    { "quiet", no_argument, NULL, OPT_QUIET },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1319,6 +1321,9 @@ int ReadFlags(int* argc, char*** argv,
         break;
       case 'v':
         config->verbosity = BuildConfig::VERBOSE;
+        break;
+      case OPT_QUIET:
+        config->verbosity = BuildConfig::NO_STATUS_UPDATE;
         break;
       case 'w':
         if (!WarningEnable(optarg, options))

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -208,6 +208,7 @@ void Usage(const BuildConfig& config) {
 "  --version      print ninja version (\"%s\")\n"
 "  -v, --verbose  show all command lines while building\n"
 "  --quiet        don't show progress status, just command output\n"
+"  --terse        periodically show progress status, and full command output\n"
 "\n"
 "  -C DIR   change to DIR before doing anything else\n"
 "  -f FILE  specify input build file [default=build.ninja]\n"
@@ -1259,9 +1260,10 @@ int ReadFlags(int* argc, char*** argv,
               Options* options, BuildConfig* config) {
   config->parallelism = GuessParallelism();
 
-  enum { OPT_VERSION = 1, OPT_QUIET = 2 };
+  enum { OPT_VERSION = 1, OPT_QUIET = 2, OPT_TERSE = 3 };
   const option kLongOptions[] = {
     { "help", no_argument, NULL, 'h' },
+    { "terse", no_argument, NULL, OPT_TERSE },
     { "version", no_argument, NULL, OPT_VERSION },
     { "verbose", no_argument, NULL, 'v' },
     { "quiet", no_argument, NULL, OPT_QUIET },
@@ -1321,6 +1323,9 @@ int ReadFlags(int* argc, char*** argv,
         break;
       case 'v':
         config->verbosity = BuildConfig::VERBOSE;
+        break;
+      case OPT_TERSE:
+        config->verbosity = BuildConfig::TERSE;
         break;
       case OPT_QUIET:
         config->verbosity = BuildConfig::NO_STATUS_UPDATE;


### PR DESCRIPTION
In contrast to the `--quiet` output mode, the `--terse` mode
periodically prints status information if none have been printed
during a certain time frame (right now 15 seconds).

Additionally the status is printed before any command output so
that the source of the output could be determined more easily.