### PR TITLE
Generate directory for depfile

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -908,6 +908,14 @@ bool Builder::StartEdge(Edge* edge, string* err) {
       return false;
   }
 
+  // Create the depfile directory
+  // XXX: this will block; do we care?
+  string depfile = edge->GetUnescapedDepfile();
+  if (!depfile.empty()) {
+    if (!disk_interface_->MakeDirs(depfile))
+      return false;
+  }
+
   // Create response file, if needed
   // XXX: this may also block; do we care?
   string rspfile = edge->GetUnescapedRspfile();


### PR DESCRIPTION
Ninja creates the directories for all output files, but not the
directory for a depfile. This works for most commands, as the depfile is
typically located in the same directory as the corresponding object file
or the command might generate the directory for it.  However, if it does
not, the command could fail due to directory not existing. This change
creates the directory for the depfile when creating the directories for
the output files.

Fixes #1848