### PR TITLE
Fix clang-analyze build, need to also run during configure

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build ninja
       shell: bash
       run: |
-        cmake -DCMAKE_BUILD_TYPE=Release -B build
+        scan-build -o scanlogs cmake -DCMAKE_BUILD_TYPE=Release -B build
         scan-build -o scanlogs cmake --build build --parallel --config Release
         strip build/ninja
 


### PR DESCRIPTION
I apologize for not including this fix in the recently merged PR. I had the change in my local workspace, but apparently forgot to push it.

The scan-build command needs to run on both the configure and build step. My understanding is that somehow CMake is detecting that scan-build was used and doing something with it.