### PR TITLE
Add debug build with sanitizers support, fix scan-build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,23 +22,36 @@ jobs:
         curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/p7zip-plugins-16.02-10.el7.x86_64.rpm
         rpm -U --quiet p7zip-16.02-10.el7.x86_64.rpm
         rpm -U --quiet p7zip-plugins-16.02-10.el7.x86_64.rpm
-        yum install -y make gcc-c++ clang-analyzer
+        yum install -y make gcc-c++ libasan clang-analyzer
 
-    - name: Build ninja
+    - name: Build debug ninja
+      shell: bash
+      env:
+        CFLAGS: -fstack-protector-all -fsanitize=address
+        CXXFLAGS: -fstack-protector-all -fsanitize=address
+      run: |
+        scan-build -o scanlogs cmake -DCMAKE_BUILD_TYPE=Debug -B debug-build
+        scan-build -o scanlogs cmake --build debug-build --parallel --config Debug
+
+    - name: Test debug ninja
+      run: ./ninja_test
+      working-directory: debug-build
+
+    - name: Build release ninja
       shell: bash
       run: |
-        cmake -DCMAKE_BUILD_TYPE=Release -B build
-        scan-build -o scanlogs cmake --build build --parallel --config Release
-        strip build/ninja
+        cmake -DCMAKE_BUILD_TYPE=Release -B release-build
+        cmake --build release-build --parallel --config Release
+        strip release-build/ninja
 
-    - name: Test ninja
+    - name: Test release ninja
       run: ./ninja_test
-      working-directory: build
+      working-directory: release-build
 
     - name: Create ninja archive
       run: |
         mkdir artifact
-        7z a artifact/ninja-linux.zip ./build/ninja
+        7z a artifact/ninja-linux.zip ./release-build/ninja
 
     # Upload ninja binary archive as an artifact
     - name: Upload artifact


### PR DESCRIPTION
This change adds a "debug" build where things that affect the binary for sake of analysis purposes can live.