### PR TITLE
build: Add IBM i compile/link flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,6 @@ endif()
 # PRId64 (and others) at compile time, and links to libutil for getopt_long
 if(CMAKE_SYSTEM_NAME STREQUAL "OS400")
 	string(APPEND CMAKE_CXX_FLAGS " -D__STDC_FORMAT_MACROS")
-	string(APPEND CMAKE_C_FLAGS " -D__STDC_FORMAT_MACROS")
 	string(APPEND CMAKE_EXE_LINKER_FLAGS " -lutil")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,14 @@ if(MINGW)
 target_compile_definitions(libninja PRIVATE _WIN32_WINNT=0x0601 __USE_MINGW_ANSI_STDIO=1)
 endif()
 
+# On IBM i (identified as "OS400" for compatibility reasons), this fixes missing
+# PRId64 (and others) at compile time, and links to libutil for getopt_long
+if(CMAKE_SYSTEM_NAME STREQUAL "OS400")
+	string(APPEND CMAKE_CXX_FLAGS " -D__STDC_FORMAT_MACROS")
+	string(APPEND CMAKE_C_FLAGS " -D__STDC_FORMAT_MACROS")
+	string(APPEND CMAKE_EXE_LINKER_FLAGS " -lutil")
+endif()
+
 # Main executable is library plus main() function.
 add_executable(ninja src/ninja.cc)
 target_link_libraries(ninja PRIVATE libninja libninja-re2c)


### PR DESCRIPTION
I did some work previously via PR #1630 to get ninja to build on the IBM i platform, but it still needs some compile/link flags to be set manually, or "out of the box" builds fail. 

```fortran
/home/JGORZINS/projects/ninja/src/graph.cc: In member function 'bool DependencyScan::RecomputeOutputDirty(const Edge*, const Node*, const string&, Node*)':
/home/JGORZINS/projects/ninja/src/graph.cc:267:78: error: expected ')' before 'PRId64'
       EXPLAIN("%soutput %s older than most recent input %s "
                                                                              ^
/home/JGORZINS/projects/ninja/src/graph.cc:292:86: error: expected ')' before 'PRId64'
         EXPLAIN("recorded mtime of %s older than most recent input %s (%" PRId64 " vs %" PRId64 ")",
                                                                                      ^~~~~~
/home/JGORZINS/projects/ninja/src/graph.cc: In member function 'void Node::Dump(const char*) const':
/home/JGORZINS/projects/ninja/src/graph.cc:488:34: error: expected ')' before 'PRId64'
   printf("%s <%s 0x%p> mtime: %" PRId64 "%s, (:%s), ",
                                  ^~~~~~
/home/JGORZINS/projects/ninja/src/graph.cc: In member function 'bool ImplicitDepLoader::LoadDepsFromLog(Edge*, std::__cxx11::string*)':
/home/JGORZINS/projects/ninja/src/graph.cc:623:67: error: expected ')' before 'PRId64'
     EXPLAIN("stored deps info out of date for '%s' (%" PRId64 " vs %" PRId64 ")",
```

With this PR, the build will automatically define `__STDC_FORMAT_MACROS` to fix this problem. It also adds linkage to the `util` library, which provides `getopt_long` on this platform. 

With these changes, `ninja` builds out of the box on IBM i by simply copy/pasting instructions from the README