### PR TITLE
Do not use /bin/sh for execution of built-in commands.

### DIFF
--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -117,7 +117,11 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
   if (err != 0)
     Fatal("posix_spawnattr_setflags: %s", strerror(err));
 
-  const char* spawned_args[] = { "/bin/sh", "-c", command.c_str(), NULL };
+  // Avoid shell builtin expansion, such as $$ and echo, this is
+  // not portable.
+  string exec_command = "exec " + command;
+
+  const char* spawned_args[] = { "/bin/sh", "-c", exec_command.c_str(), NULL };
   err = posix_spawn(&pid_, "/bin/sh", &action, &attr,
         const_cast<char**>(spawned_args), environ);
   if (err != 0)

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -75,7 +75,7 @@ TEST_F(SubprocessTest, NoSuchCommand) {
 #ifndef _WIN32
 
 TEST_F(SubprocessTest, InterruptChild) {
-  Subprocess* subproc = subprocs_.Add("kill -INT $$");
+  Subprocess* subproc = subprocs_.Add("/bin/sh -c 'kill -INT $$'");
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -86,7 +86,7 @@ TEST_F(SubprocessTest, InterruptChild) {
 }
 
 TEST_F(SubprocessTest, InterruptParent) {
-  Subprocess* subproc = subprocs_.Add("kill -INT $PPID ; sleep 1");
+  Subprocess* subproc = subprocs_.Add("/bin/sh -c 'kill -INT $PPID ; sleep 1'");
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -99,7 +99,7 @@ TEST_F(SubprocessTest, InterruptParent) {
 }
 
 TEST_F(SubprocessTest, InterruptChildWithSigTerm) {
-  Subprocess* subproc = subprocs_.Add("kill -TERM $$");
+  Subprocess* subproc = subprocs_.Add("/bin/sh -c 'kill -TERM $$'");
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -110,7 +110,7 @@ TEST_F(SubprocessTest, InterruptChildWithSigTerm) {
 }
 
 TEST_F(SubprocessTest, InterruptParentWithSigTerm) {
-  Subprocess* subproc = subprocs_.Add("kill -TERM $PPID ; sleep 1");
+  Subprocess* subproc = subprocs_.Add("/bin/sh -c 'kill -TERM $PPID ; sleep 1'");
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -123,7 +123,7 @@ TEST_F(SubprocessTest, InterruptParentWithSigTerm) {
 }
 
 TEST_F(SubprocessTest, InterruptChildWithSigHup) {
-  Subprocess* subproc = subprocs_.Add("kill -HUP $$");
+  Subprocess* subproc = subprocs_.Add("/bin/sh -c 'kill -HUP $$'");
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {
@@ -134,7 +134,7 @@ TEST_F(SubprocessTest, InterruptChildWithSigHup) {
 }
 
 TEST_F(SubprocessTest, InterruptParentWithSigHup) {
-  Subprocess* subproc = subprocs_.Add("kill -HUP $PPID ; sleep 1");
+  Subprocess* subproc = subprocs_.Add("/bin/sh -c 'kill -HUP $PPID ; sleep 1'");
   ASSERT_NE((Subprocess *) 0, subproc);
 
   while (!subproc->Done()) {


### PR DESCRIPTION
Portable shell programming is a challenge. /bin/sh defaults to bash
on most Linuxes, but not Debian and its descendants (where it points
to dash), which leads to different behaviour of shell builtins,
e.g. `echo`.

Autoconf's guide to portable shell programming calls this situation
a deadlock.

One way to ensure ninja behaviour is identical on all platforms is
require Bash (/bin/bash) in all cases..
Another is to avoid using the shell interpreter altogether.

This patch implements the second alternative.

Fixes #1871