### PR TITLE
Fix building on AIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,9 @@ if(WIN32)
 	endif()
 else()
 	target_sources(libninja PRIVATE src/subprocess-posix.cc)
+	if(CMAKE_SYSTEM_NAME STREQUAL "OS400" OR CMAKE_SYSTEM_NAME STREQUAL "AIX")
+		target_sources(libninja PRIVATE src/getopt.c)
+	endif()
 endif()
 
 #Fixes GetActiveProcessorCount on MinGW
@@ -119,11 +122,10 @@ if(MINGW)
 target_compile_definitions(libninja PRIVATE _WIN32_WINNT=0x0601 __USE_MINGW_ANSI_STDIO=1)
 endif()
 
-# On IBM i (identified as "OS400" for compatibility reasons), this fixes missing
-# PRId64 (and others) at compile time, and links to libutil for getopt_long
-if(CMAKE_SYSTEM_NAME STREQUAL "OS400")
+# On IBM i (identified as "OS400" for compatibility reasons) and AIX, this fixes missing
+# PRId64 (and others) at compile time in C++ sources
+if(CMAKE_SYSTEM_NAME STREQUAL "OS400" OR CMAKE_SYSTEM_NAME STREQUAL "AIX")
 	string(APPEND CMAKE_CXX_FLAGS " -D__STDC_FORMAT_MACROS")
-	string(APPEND CMAKE_EXE_LINKER_FLAGS " -lutil")
 endif()
 
 # Main executable is library plus main() function.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,11 @@ else()
 	if(CMAKE_SYSTEM_NAME STREQUAL "OS400" OR CMAKE_SYSTEM_NAME STREQUAL "AIX")
 		target_sources(libninja PRIVATE src/getopt.c)
 	endif()
+
+	# Needed for perfstat_cpu_total
+	if(CMAKE_SYSTEM_NAME STREQUAL "AIX")
+		target_link_libraries(libninja PUBLIC "-lperfstat")
+	endif()
 endif()
 
 #Fixes GetActiveProcessorCount on MinGW

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,12 @@ if(BUILD_TESTING)
     target_link_libraries(${perftest} PRIVATE libninja libninja-re2c)
   endforeach()
 
+  if(CMAKE_SYSTEM_NAME STREQUAL "AIX" AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+    # These tests require more memory than will fit in the standard AIX shared stack/heap (256M)
+    target_link_libraries(hash_collision_bench PRIVATE "-Wl,-bmaxdata:0x80000000")
+    target_link_libraries(manifest_parser_perftest PRIVATE "-Wl,-bmaxdata:0x80000000")
+  endif()
+
   add_test(NinjaTest ninja_test)
 endif()
 

--- a/configure.py
+++ b/configure.py
@@ -596,6 +596,11 @@ all_targets += ninja_test
 
 n.comment('Ancillary executables.')
 
+if platform.is_aix() and '-maix64' not in ldflags:
+    # Both hash_collision_bench and manifest_parser_perftest require more
+    # memory than will fit in the standard 32-bit AIX shared stack/heap (256M)
+    libs.append('-Wl,-bmaxdata:0x80000000')
+
 for name in ['build_log_perftest',
              'canon_perftest',
              'depfile_parser_perftest',

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -25,6 +25,9 @@
 #ifdef _WIN32
 #include "getopt.h"
 #include <direct.h>
+#elif defined(_AIX)
+#include "getopt.h"
+#include <unistd.h>
 #else
 #include <getopt.h>
 #include <unistd.h>


### PR DESCRIPTION
This PR synchronizes the configure.py and CMake builds as well as uses
the internal getopt implementation on AIX, since AIX getopt does not
support getopt_long. Previously, the IBM i configure.py build would
link with libutil for this, but as that's not a standard library, I've
switched to also use the internal getopt implementation.

Additionally, this fixes some crashes within the tests. A couple are
due to peculiarities of AIX's 32-bit memory model, while one is due to
a bug in the test causing an out of bounds read.

Fixes #1844