### PR TITLE
Fix buffer overread in hash_collision_benchmark.cc

### DIFF
--- a/src/hash_collision_bench.cc
+++ b/src/hash_collision_bench.cc
@@ -27,9 +27,10 @@ int random(int low, int high) {
 
 void RandomCommand(char** s) {
   int len = random(5, 100);
-  *s = new char[len];
+  *s = new char[len+1];
   for (int i = 0; i < len; ++i)
     (*s)[i] = (char)random(32, 127);
+  (*s)[len] = '\0';
 }
 
 int main() {


### PR DESCRIPTION
The randomly generated command strings are not null-terminated and
implicitly converted to StringPiece objects, which will use strlen to
determine how long the passed `char*` is. Without the null terminator,
this results in undefined behavior and regularly causes crashes on AIX.