### PR TITLE
clang-tidy: add const to several global variables

### DIFF
--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -76,9 +76,8 @@ int64_t TimerToMicros(int64_t dt) {
 
 }  // anonymous namespace
 
-
-ScopedMetric::ScopedMetric(Metric* metric) {
-  metric_ = metric;
+ScopedMetric::ScopedMetric(const Metric* metric) {
+  metric_ = const_cast<Metric*>(metric);
   if (!metric_)
     return;
   start_ = HighResTimer();

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -36,7 +36,7 @@ struct Metric {
 /// A scoped object for recording a metric across the body of a function.
 /// Used by the METRIC_RECORD macro.
 struct ScopedMetric {
-  explicit ScopedMetric(Metric* metric);
+  explicit ScopedMetric(const Metric* metric);
   ~ScopedMetric();
 
 private:
@@ -81,9 +81,9 @@ struct Stopwatch {
 
 /// The primary interface to metrics.  Use METRIC_RECORD("foobar") at the top
 /// of a function to get timing stats recorded for each call of the function.
-#define METRIC_RECORD(name)                                             \
-  static Metric* metrics_h_metric =                                     \
-      g_metrics ? g_metrics->NewMetric(name) : NULL;                    \
+#define METRIC_RECORD(name)                          \
+  static const Metric* const metrics_h_metric =      \
+      g_metrics ? g_metrics->NewMetric(name) : NULL; \
   ScopedMetric metrics_h_scoped(metrics_h_metric);
 
 extern Metrics* g_metrics;

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -29,9 +29,9 @@ using namespace std;
 namespace {
 
 #ifdef _WIN32
-const char* kSimpleCommand = "cmd /c dir \\";
+const char* const kSimpleCommand = "cmd /c dir \\";
 #else
-const char* kSimpleCommand = "ls /";
+const char* const kSimpleCommand = "ls /";
 #endif
 
 struct SubprocessTest : public testing::Test {

--- a/src/version.cc
+++ b/src/version.cc
@@ -20,7 +20,7 @@
 
 using namespace std;
 
-const char* kNinjaVersion = "1.10.2.git";
+const char* const kNinjaVersion = "1.10.2.git";
 
 void ParseVersion(const string& version, int* major, int* minor) {
   size_t end = version.find('.');

--- a/src/version.h
+++ b/src/version.h
@@ -19,7 +19,7 @@
 
 /// The version number of the current Ninja release.  This will always
 /// be "git" on trunk.
-extern const char* kNinjaVersion;
+extern const char* const kNinjaVersion;
 
 /// Parse the major/minor components of a version string.
 void ParseVersion(const std::string& version, int* major, int* minor);


### PR DESCRIPTION
Found with cppcoreguidelines-avoid-non-const-global-variables

Signed-off-by: Rosen Penev <rosenp@gmail.com>