### PR TITLE
cmake: Use modern add_test signature

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,7 +26,7 @@ jobs:
         cmake --build build --config Release
 
     - name: Test ninja
-      run: ctest -vv
+      run: ctest -C Release -vv
       working-directory: build
 
     - name: Create ninja archive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ if(BUILD_TESTING)
     target_link_libraries(manifest_parser_perftest PRIVATE "-Wl,-bmaxdata:0x80000000")
   endif()
 
-  add_test(NinjaTest ninja_test)
+  add_test(NAME NinjaTest COMMAND ninja_test)
 endif()
 
 install(TARGETS ninja DESTINATION bin)


### PR DESCRIPTION
Using this modern signature makes CMake/CTest use the effective
binary path and works also with multi-config generators which put
binaries in extra `Release` folders.