### PR TITLE
disk_interface: Improve the stat cache handling for case sensitive folders on Windows

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -180,12 +180,13 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
     dir = path;
   }
 
-  transform(dir.begin(), dir.end(), dir.begin(), ::tolower);
+  string dir_lowercase = dir;
+  transform(dir.begin(), dir.end(), dir_lowercase.begin(), ::tolower);
   transform(base.begin(), base.end(), base.begin(), ::tolower);
 
-  Cache::iterator ci = cache_.find(dir);
+  Cache::iterator ci = cache_.find(dir_lowercase);
   if (ci == cache_.end()) {
-    ci = cache_.insert(make_pair(dir, DirCache())).first;
+    ci = cache_.insert(make_pair(dir_lowercase, DirCache())).first;
     if (!StatAllFilesInDir(dir.empty() ? "." : dir, &ci->second, err)) {
       cache_.erase(ci);
       return -1;


### PR DESCRIPTION
disk_interface: Improve the stat cache handling for case sensitive folders on Windows

The path used as argument to FindFirstFileExA is no longer being converted to lowercase.
By not converting the path to lower case, case sensitive folders will now be handled correctly.
Case insensitive folders still works as expected because casing doesn't matter on those.
All entries in the stat cache remains lowercase to avoid potential cache misses.