### PR TITLE
Clarify purpose for implicit dependencies

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -949,8 +949,9 @@ source file of a compile command.
 +
 This is for expressing dependencies that don't show up on the
 command line of the command; for example, for a rule that runs a
-script, the script itself should be an implicit dependency, as
-changes to the script should cause the output to rebuild.
+script that reads a hardcoded file, the hardcoded file should 
+be an implicit dependency, as changes to the file should cause 
+the output to rebuild, even though it doesn't show up in the arguments.
 +
 Note that dependencies as loaded through depfiles have slightly different
 semantics, as described in the <<ref_rule,rule reference>>.


### PR DESCRIPTION
This confused me for a bit, so I've tried to clarify it.

In some cases the script would want to be in `$in`, eg
```ninja
rule runscript
  command = sh $in
```

However if the script reads a file, and which file it reads is encoded in the script itself, it's clear the file will never show up in the arguments. 

Another example would be something like
```ninja
build ninja: link $builddir/ninja.o | $builddir/libninja.a
  libs = -lninja
```
but that requires knowing how linker arguments work, which is probably more confusing.