### PR TITLE
Restore toleration of missing to-be-deleted files on Windows

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -272,9 +272,9 @@ int RealDiskInterface::RemoveFile(const string& path) {
     return 1;
   }
   if (attributes & FILE_ATTRIBUTE_READONLY) {
-    // On non-Windows systems remove will happily delete read-only files. On
-    // Windows Ninja should behave the same. See
-    // https://github.com/ninja-build/ninja/issues/1886
+    // On non-Windows systems, remove() will happily delete read-only files.
+    // On Windows Ninja should behave the same:
+    //   https://github.com/ninja-build/ninja/issues/1886
     SetFileAttributes(path.c_str(), attributes & ~FILE_ATTRIBUTE_READONLY);
   }
   if (!DeleteFile(path.c_str())) {

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -268,16 +268,23 @@ int RealDiskInterface::RemoveFile(const string& path) {
 #ifdef _WIN32
   DWORD attributes = GetFileAttributes(path.c_str());
   if (attributes == INVALID_FILE_ATTRIBUTES) {
-    if (GetLastError() == ERROR_FILE_NOT_FOUND) {
+    DWORD win_err = GetLastError();
+    if (win_err == ERROR_FILE_NOT_FOUND || win_err == ERROR_PATH_NOT_FOUND) {
       return 1;
     }
   } else if (attributes & FILE_ATTRIBUTE_READONLY) {
     // On non-Windows systems, remove() will happily delete read-only files.
     // On Windows Ninja should behave the same:
     //   https://github.com/ninja-build/ninja/issues/1886
+    // Skip error checking.  If this fails, accept whatever happens below.
     SetFileAttributes(path.c_str(), attributes & ~FILE_ATTRIBUTE_READONLY);
   }
   if (!DeleteFile(path.c_str())) {
+    DWORD win_err = GetLastError();
+    if (win_err == ERROR_FILE_NOT_FOUND || win_err == ERROR_PATH_NOT_FOUND) {
+      return 1;
+    }
+    // Report as remove(), not DeleteFile(), for cross-platform consistency.
     Error("remove(%s): %s", path.c_str(), GetLastErrorString().c_str());
     return -1;
   }

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -267,11 +267,11 @@ FileReader::Status RealDiskInterface::ReadFile(const string& path,
 int RealDiskInterface::RemoveFile(const string& path) {
 #ifdef _WIN32
   DWORD attributes = GetFileAttributes(path.c_str());
-  if (attributes == INVALID_FILE_ATTRIBUTES &&
-      GetLastError() == ERROR_FILE_NOT_FOUND) {
-    return 1;
-  }
-  if (attributes & FILE_ATTRIBUTE_READONLY) {
+  if (attributes == INVALID_FILE_ATTRIBUTES) {
+    if (GetLastError() == ERROR_FILE_NOT_FOUND) {
+      return 1;
+    }
+  } else if (attributes & FILE_ATTRIBUTE_READONLY) {
     // On non-Windows systems, remove() will happily delete read-only files.
     // On Windows Ninja should behave the same:
     //   https://github.com/ninja-build/ninja/issues/1886


### PR DESCRIPTION
Since #1892 we use `DeleteFile` without checking if it failed due to a path missing.  Fix the `GetFileAttributes` logic to check for multiple variants of "file not found" as we do in `StatSingleFile`.  ~~Then fall back to the original `remove()` logic that already checks for `ENOENT` on failure.~~  Add the check after `DeleteFile` too.

Issue: #1886