### PR TITLE
ninja_workdir: Add top-level binding to set working directory

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -828,6 +828,11 @@ Two variables are significant when declared in the outermost file scope.
   discussion of the build log>>.  (You can also store other build output
   in this directory.)
 
+`ninja_workdir`:: _(Available since Ninja 1.11.)_ If present, sets the
+  working directory in which the build will take place.  Otherwise, the
+  build will take place in the working directory in which `ninja` is
+  invoked, or that specified by `ninja -C`.
+
 `ninja_required_version`:: the minimum version of Ninja required to process
   the build correctly.  See <<ref_versioning,the discussion of versioning>>.
 

--- a/src/dyndep_parser.cc
+++ b/src/dyndep_parser.cc
@@ -30,6 +30,10 @@ DyndepParser::DyndepParser(State* state, FileReader* file_reader,
     , dyndep_file_(dyndep_file) {
 }
 
+bool DyndepParser::Load(const std::string& filename, std::string* err) {
+  return LoadFile(filename, err, NULL);
+}
+
 bool DyndepParser::Parse(const string& filename, const string& input,
                          string* err) {
   lexer_.Start(filename, input);

--- a/src/dyndep_parser.h
+++ b/src/dyndep_parser.h
@@ -26,6 +26,9 @@ struct DyndepParser: public Parser {
   DyndepParser(State* state, FileReader* file_reader,
                DyndepFile* dyndep_file);
 
+  /// Load and parse a dyndep file.
+  bool Load(const std::string& filename, std::string* err);
+
   /// Parse a text string of input.  Used by tests.
   bool ParseTest(const std::string& input, std::string* err) {
     return Parse("input", input, err);

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -32,6 +32,10 @@ ManifestParser::ManifestParser(State* state, FileReader* file_reader,
   env_ = &state->bindings_;
 }
 
+bool ManifestParser::Load(const std::string& filename, std::string* err) {
+  return LoadFile(filename, err, NULL);
+}
+
 bool ManifestParser::Parse(const string& filename, const string& input,
                            string* err) {
   lexer_.Start(filename, input);
@@ -411,7 +415,7 @@ bool ManifestParser::ParseFileInclude(bool new_scope, string* err) {
     subparser.env_ = env_;
   }
 
-  if (!subparser.Load(path, err, &lexer_))
+  if (!subparser.LoadFile(path, err, &lexer_))
     return false;
 
   if (!ExpectToken(Lexer::NEWLINE, err))

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -33,7 +33,9 @@ ManifestParser::ManifestParser(State* state, FileReader* file_reader,
 }
 
 bool ManifestParser::Load(const std::string& filename, std::string* err) {
-  return LoadFile(filename, err, NULL);
+  if (!LoadFile(filename, err, NULL))
+    return false;
+  return CheckTopLevelBindings(err);
 }
 
 bool ManifestParser::Parse(const string& filename, const string& input,
@@ -421,5 +423,10 @@ bool ManifestParser::ParseFileInclude(bool new_scope, string* err) {
   if (!ExpectToken(Lexer::NEWLINE, err))
     return false;
 
+  return true;
+}
+
+bool ManifestParser::CheckTopLevelBindings(std::string* err) {
+  static_cast<void>(err);
   return true;
 }

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -427,6 +427,21 @@ bool ManifestParser::ParseFileInclude(bool new_scope, string* err) {
 }
 
 bool ManifestParser::CheckTopLevelBindings(std::string* err) {
-  static_cast<void>(err);
+  std::string workdir = env_->LookupVariable("ninja_workdir");
+
+  if (!workdir.empty()) {
+    std::string path_err;
+    if (!NormalizeWorkDir(&workdir, &path_err)) {
+      *err = "invalid ninja_workdir: " + path_err;
+      return false;
+    }
+    if (!IsAbsolutePath(StringPiece(workdir))) {
+      *err = "invalid ninja_workdir: not an absolute path";
+      return false;
+    }
+  }
+
+  state_->workdir_ = workdir;
+
   return true;
 }

--- a/src/manifest_parser.h
+++ b/src/manifest_parser.h
@@ -49,7 +49,9 @@ struct ManifestParser : public Parser {
   /// Parse a text string of input.  Used by tests.
   bool ParseTest(const std::string& input, std::string* err) {
     quiet_ = true;
-    return Parse("input", input, err);
+    if (!Parse("input", input, err))
+      return false;
+    return CheckTopLevelBindings(err);
   }
 
 private:
@@ -66,6 +68,8 @@ private:
 
   /// Parse either a 'subninja' or 'include' line.
   bool ParseFileInclude(bool new_scope, std::string* err);
+
+  bool CheckTopLevelBindings(std::string* err);
 
   BindingEnv* env_;
   ManifestParserOptions options_;

--- a/src/manifest_parser.h
+++ b/src/manifest_parser.h
@@ -43,6 +43,9 @@ struct ManifestParser : public Parser {
   ManifestParser(State* state, FileReader* file_reader,
                  ManifestParserOptions options = ManifestParserOptions());
 
+  /// Load and parse a top-level manifest file.
+  bool Load(const std::string& filename, std::string* err);
+
   /// Parse a text string of input.  Used by tests.
   bool ParseTest(const std::string& input, std::string* err) {
     quiet_ = true;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -849,18 +849,10 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
   argc -= optind;
 
   bool first = true;
-  vector<char> cwd;
-  char* success = NULL;
+  std::string cwd;
 
-  do {
-    cwd.resize(cwd.size() + 1024);
-    errno = 0;
-    success = getcwd(&cwd[0], cwd.size());
-  } while (!success && errno == ERANGE);
-  if (!success) {
-    Error("cannot determine working directory: %s", strerror(errno));
+  if (!GetCWD(&cwd))
     return 1;
-  }
 
   putchar('[');
   for (vector<Edge*>::iterator e = state_.edges_.begin();

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -19,7 +19,7 @@
 
 using namespace std;
 
-bool Parser::Load(const string& filename, string* err, Lexer* parent) {
+bool Parser::LoadFile(const string& filename, string* err, Lexer* parent) {
   METRIC_RECORD(".ninja parse");
   string contents;
   string read_err;

--- a/src/parser.h
+++ b/src/parser.h
@@ -27,10 +27,10 @@ struct Parser {
   Parser(State* state, FileReader* file_reader)
       : state_(state), file_reader_(file_reader) {}
 
-  /// Load and parse a file.
-  bool Load(const std::string& filename, std::string* err, Lexer* parent = NULL);
-
 protected:
+  /// Load and parse a file.  Called by subclass Load methods.
+  bool LoadFile(const std::string& filename, std::string* err, Lexer* parent);
+
   /// If the next token is not \a expected, produce an error string
   /// saying "expected foo, got bar".
   bool ExpectToken(Lexer::Token expected, std::string* err);

--- a/src/state.h
+++ b/src/state.h
@@ -125,6 +125,11 @@ struct State {
   typedef ExternalStringHashMap<Node*>::Type Paths;
   Paths paths_;
 
+  /// Working directory in which to run commands, ending in a trailing slash.
+  /// This may be set by a 'ninja_workdir' top-level binding in the manifest.
+  /// Otherwise, this is computed from the process working directory.
+  std::string workdir_;
+
   /// All the pools used in the graph.
   std::map<std::string, Pool*> pools_;
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -21,6 +21,7 @@
 #include <windows.h>
 #include <io.h>
 #include <share.h>
+#include <direct.h>
 #endif
 
 #include <assert.h>
@@ -115,6 +116,22 @@ void Info(const char* msg, ...) {
   va_start(ap, msg);
   Info(msg, ap);
   va_end(ap);
+}
+
+bool GetCWD(std::string* result) {
+  vector<char> cwd;
+  char* success = NULL;
+  do {
+    cwd.resize(cwd.size() + 1024);
+    errno = 0;
+    success = getcwd(&cwd[0], cwd.size());
+  } while (!success && errno == ERANGE);
+  if (!success) {
+    Error("cannot determine working directory: %s", strerror(errno));
+    return false;
+  }
+  result->assign(success);
+  return true;
 }
 
 bool CanonicalizePath(string* path, uint64_t* slash_bits, string* err) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -134,6 +134,19 @@ bool GetCWD(std::string* result) {
   return true;
 }
 
+bool NormalizeWorkDir(std::string* workdir, std::string* err) {
+  // Ensure we have forward slashes.
+  uint64_t slash_bits;
+  if (!CanonicalizePath(workdir, &slash_bits, err))
+    return false;
+
+  // Add a trailing slash so we can simply append relative paths later.
+  if ((*workdir)[workdir->size() - 1] != '/')
+    *workdir += '/';
+
+  return true;
+}
+
 bool CanonicalizePath(string* path, uint64_t* slash_bits, string* err) {
   METRIC_RECORD("canonicalize str");
   size_t len = path->size();

--- a/src/util.cc
+++ b/src/util.cc
@@ -254,6 +254,22 @@ bool CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits,
   return true;
 }
 
+bool IsAbsolutePath(StringPiece path) {
+  if (path.len_ < 1)
+    return false;
+  if (path.str_[0] == '/')
+    return true; // NOLINT(readability-simplify-boolean-expr)
+#ifdef _WIN32
+  if (path.str_[0] == '\\')
+    return true;
+  if (path.len_ < 2)
+    return false;
+  if (path.str_[1] == ':')
+    return true;
+#endif
+  return false;
+}
+
 static inline bool IsKnownShellSafeCharacter(char ch) {
   if ('A' <= ch && ch <= 'Z') return true;
   if ('a' <= ch && ch <= 'z') return true;

--- a/src/util.h
+++ b/src/util.h
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+#include "string_piece.h"
+
 #ifdef _MSC_VER
 #define NORETURN __declspec(noreturn)
 #else
@@ -71,6 +73,10 @@ bool CanonicalizePath(std::string* path, uint64_t* slash_bits,
                       std::string* err);
 bool CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits,
                       std::string* err);
+
+/// Returns true if the given path is absolute
+/// (starts in '/', or 'x:' on Windows).
+bool IsAbsolutePath(StringPiece path);
 
 /// Appends |input| to |*result|, escaping according to the whims of either
 /// Bash, or Win32's CommandLineToArgvW().

--- a/src/util.h
+++ b/src/util.h
@@ -66,6 +66,9 @@ void Info(const char* msg, va_list ap);
 /// Get the current working directory of the process.
 bool GetCWD(std::string* result);
 
+/// Normalize a working directory string to end in a trailing slash.
+bool NormalizeWorkDir(std::string* workdir, std::string* err);
+
 /// Canonicalize a path like "foo/../bar.h" into just "bar.h".
 /// |slash_bits| has bits set starting from lowest for a backslash that was
 /// normalized to a forward slash. (only used on Windows)

--- a/src/util.h
+++ b/src/util.h
@@ -61,6 +61,9 @@ void Error(const char* msg, va_list ap);
 void Info(const char* msg, ...);
 void Info(const char* msg, va_list ap);
 
+/// Get the current working directory of the process.
+bool GetCWD(std::string* result);
+
 /// Canonicalize a path like "foo/../bar.h" into just "bar.h".
 /// |slash_bits| has bits set starting from lowest for a backslash that was
 /// normalized to a forward slash. (only used on Windows)

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -377,6 +377,27 @@ TEST(CanonicalizePath, NotNullTerminated) {
   EXPECT_EQ("file ./file bar/.", string(path));
 }
 
+TEST(IsAbsolutePath, Basic) {
+  string const empty_path;
+  string const relative_path = "foo/bar";
+  string const absolute_path_unix = "/path/to/foo/bar";
+  string const absolute_path_network = "//machine/share/path/to/foo/bar";
+  string const absolute_path_windows = "c:/path/to/foo/bar";
+  string const absolute_path_windows_backslash = "c:\\path\\to\\foo\\bar";
+
+  EXPECT_FALSE(IsAbsolutePath(empty_path));
+  EXPECT_FALSE(IsAbsolutePath(relative_path));
+  EXPECT_TRUE(IsAbsolutePath(absolute_path_unix));
+  EXPECT_TRUE(IsAbsolutePath(absolute_path_network));
+#ifdef _WIN32
+  EXPECT_TRUE(IsAbsolutePath(absolute_path_windows));
+  EXPECT_TRUE(IsAbsolutePath(absolute_path_windows_backslash));
+#else
+  EXPECT_FALSE(IsAbsolutePath(absolute_path_windows));
+  EXPECT_FALSE(IsAbsolutePath(absolute_path_windows_backslash));
+#endif
+}
+
 TEST(PathEscaping, TortureTest) {
   string result;
 

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -27,6 +27,13 @@ bool CanonicalizePath(string* path, string* err) {
 
 }  // namespace
 
+TEST(GetCWD, Basic) {
+  string cwd;
+
+  EXPECT_TRUE(GetCWD(&cwd));
+  EXPECT_TRUE(!cwd.empty());
+}
+
 TEST(CanonicalizePath, PathSamples) {
   string path;
   string err;


### PR DESCRIPTION
Add a binding that the build manifest generator can use to tell ninja the working directory to use for the build.  This allows a command like

```console
$ ninja -f /path/to/some/build.ninja
```

to work, regardless of the caller's working directory, if `build.ninja` has the binding.
