### PR TITLE
Add tool to print code page information on Windows

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -308,6 +308,18 @@ file. _Available since Ninja 1.10._
 if they have one).  It can be used to know which rule name to pass to
 +ninja -t targets rule _name_+ or +ninja -t compdb+.
 
+`wincodepage`:: available on Windows hosts.  Prints the ANSI code page
+used by `ninja`, whose encoding is expected in `build.ninja`.  Also prints
+the Console code page for reference.  The output has the form:
++
+----
+ANSI code page: %u
+Console code page: %u
+----
++
+where each `%u` is an integer code page identifier, expressed in decimal.
+_Available since Ninja 1.11._
+
 Writing your own Ninja files
 ----------------------------
 

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -287,12 +287,12 @@ target, show just the target's dependencies. _Available since Ninja 1.4._
 `missingdeps`:: given a list of targets, look for targets that depend on
 a generated file, but do not have a properly (possibly transitive) dependency
 on the generator.  Such targets may cause build flakiness on clean builds.
-
++
 The broken targets can be found assuming deps log / depfile dependency
 information is correct.  Any target that depends on a generated file (output
 of a generator-target) implicitly, but does not have an explicit or order-only
 dependency path to the generator-target, is considered broken.
-
++
 The tool's findings can be verified by trying to build the listed targets in
 a clean outdir without buidling any other targets.  The build should fail for
 each of them with a missing include error or equivalent pointing to the

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -133,6 +133,7 @@ struct NinjaMain : public BuildLogUser {
   int ToolRestat(const Options* options, int argc, char* argv[]);
   int ToolUrtle(const Options* options, int argc, char** argv);
   int ToolRules(const Options* options, int argc, char* argv[]);
+  int ToolWinCodePage(const Options* options, int argc, char* argv[]);
 
   /// Open the build log.
   /// @return LOAD_ERROR on error.
@@ -641,6 +642,18 @@ int NinjaMain::ToolRules(const Options* options, int argc, char* argv[]) {
   return 0;
 }
 
+#ifdef _WIN32
+int NinjaMain::ToolWinCodePage(const Options* options, int argc, char* argv[]) {
+  if (argc != 0) {
+    printf("usage: ninja -t wincodepage\n");
+    return 1;
+  }
+  printf("ANSI code page: %u\n", GetACP());
+  printf("Console code page: %u\n", GetConsoleOutputCP());
+  return 0;
+}
+#endif
+
 enum PrintCommandMode { PCM_Single, PCM_All };
 void PrintCommands(Edge* edge, EdgeSet* seen, PrintCommandMode mode) {
   if (!edge)
@@ -1009,6 +1022,10 @@ const Tool* ChooseTool(const string& tool_name) {
       Tool::RUN_AFTER_LOGS, &NinjaMain::ToolCleanDead },
     { "urtle", NULL,
       Tool::RUN_AFTER_FLAGS, &NinjaMain::ToolUrtle },
+#ifdef _WIN32
+    { "wincodepage", "print the Windows ANSI code page identifier",
+      Tool::RUN_AFTER_FLAGS, &NinjaMain::ToolWinCodePage },
+#endif
     { NULL, NULL, Tool::RUN_AFTER_FLAGS, NULL }
   };
 


### PR DESCRIPTION
Since #1915, `ninja` does not always expect `build.ninja` to be encoded in the system's ANSI code page.  The expected encoding now depends on how `ninja` is built and the version of Windows on which it is running.

Add a `-t wincodepage` tool that generators can use to ask `ninja` what encoding it expects.

Issue: #1195
