### PR TITLE
wincodepage: minimize to indicate UTF-8 or not

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -308,17 +308,21 @@ file. _Available since Ninja 1.10._
 if they have one).  It can be used to know which rule name to pass to
 +ninja -t targets rule _name_+ or +ninja -t compdb+.
 
-`wincodepage`:: available on Windows hosts.  Prints the ANSI code page
-used by `ninja`, whose encoding is expected in `build.ninja`.  Also prints
-the Console code page for reference.  The output has the form:
+`wincodepage`:: Available on Windows hosts (_since Ninja 1.11_).
+Prints the Windows code page whose encoding is expected in the build file.
+The output has the form:
 +
 ----
-ANSI code page: %u
-Console code page: %u
+Build file encoding: <codepage>
 ----
 +
-where each `%u` is an integer code page identifier, expressed in decimal.
-_Available since Ninja 1.11._
+Additional lines may be added in future versions of Ninja.
++
+The `<codepage>` is one of:
+
+`UTF-8`::: Encode as UTF-8.
+
+`ANSI`::: Encode to the system-wide ANSI code page.
 
 Writing your own Ninja files
 ----------------------------

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -648,8 +648,7 @@ int NinjaMain::ToolWinCodePage(const Options* options, int argc, char* argv[]) {
     printf("usage: ninja -t wincodepage\n");
     return 1;
   }
-  printf("ANSI code page: %u\n", GetACP());
-  printf("Console code page: %u\n", GetConsoleOutputCP());
+  printf("Build file encoding: %s\n", GetACP() == CP_UTF8? "UTF-8" : "ANSI");
   return 0;
 }
 #endif
@@ -1023,7 +1022,7 @@ const Tool* ChooseTool(const string& tool_name) {
     { "urtle", NULL,
       Tool::RUN_AFTER_FLAGS, &NinjaMain::ToolUrtle },
 #ifdef _WIN32
-    { "wincodepage", "print the Windows ANSI code page identifier",
+    { "wincodepage", "print the Windows code page used by ninja",
       Tool::RUN_AFTER_FLAGS, &NinjaMain::ToolWinCodePage },
 #endif
     { NULL, NULL, Tool::RUN_AFTER_FLAGS, NULL }


### PR DESCRIPTION
The ANSI code page identifier is more information than generator
programs actually need.  The encoding of `build.ninja` is always
either UTF-8 or the system-wide ANSI code page.  Reduce the output
to provide no more information than the generator programs need.

The Console code page can be obtained in other ways, so drop it.