### PR TITLE
depfile,dyndep: reconcile relative and absolute paths with build manifest

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -589,6 +589,13 @@ build edges such that it is not an error if the listed dependency is
 missing.  This allows you to delete a header file and rebuild without
 the build aborting due to a missing input.
 
+Paths emitted by the compiler may be either absolute or relative paths,
+depending on compiler behavior and the include directory flags given to it.
+Paths loaded from a depfile are matched to paths in build statements
+if they match exactly.  _Since Ninja 1.11_, paths are also matched if
+one of them is relative and matches the other when prefixed by the
+working directory.
+
 depfile
 ^^^^^^^
 
@@ -649,11 +656,6 @@ rule cc
   deps = msvc
   command = cl /showIncludes -c $in /Fo$out
 ----
-
-If the include directory directives are using absolute paths, your depfile
-may result in a mixture of relative and absolute paths. Paths used by other
-build rules need to match exactly. Therefore, it is recommended to use
-relative paths in these cases.
 
 [[ref_pool]]
 Pools
@@ -997,8 +999,11 @@ header file before starting a subsequent compilation step.  (Once the
 header is used in compilation, a generated dependency file will then
 express the implicit dependency.)
 
-File paths are compared as is, which means that an absolute path and a
-relative path, pointing to the same file, are considered different by Ninja.
+File paths in `build.ninja` are compared as is, which means that an
+absolute path and a relative path, pointing to the same file, are
+considered different by Ninja.
+See <<ref_headers, discussion of header dependencies>> for treatment
+of paths in a depfile.
 
 Variable expansion
 ~~~~~~~~~~~~~~~~~~

--- a/src/build.cc
+++ b/src/build.cc
@@ -846,7 +846,7 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
       // all backslashes (as some of the slashes will certainly be backslashes
       // anyway). This could be fixed if necessary with some additional
       // complexity in IncludesNormalize::Relativize.
-      deps_nodes->push_back(state_->GetNode(*i, ~0u));
+      deps_nodes->push_back(state_->GetNodeForDepfile(*i, ~0u));
     }
   } else if (deps_type == "gcc") {
     string depfile = result->edge->GetUnescapedDepfile();
@@ -881,7 +881,7 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
       if (!CanonicalizePath(const_cast<char*>(i->str_), &i->len_, &slash_bits,
                             err))
         return false;
-      deps_nodes->push_back(state_->GetNode(*i, slash_bits));
+      deps_nodes->push_back(state_->GetNodeForDepfile(*i, slash_bits));
     }
 
     if (!g_keep_depfile) {

--- a/src/dyndep_parser.cc
+++ b/src/dyndep_parser.cc
@@ -119,7 +119,7 @@ bool DyndepParser::ParseEdge(string* err) {
     uint64_t slash_bits;
     if (!CanonicalizePath(&path, &slash_bits, &path_err))
       return lexer_.Error(path_err, err);
-    Node* node = state_->LookupNode(path);
+    Node* node = state_->LookupNodeForDepfile(path);
     if (!node || !node->in_edge())
       return lexer_.Error("no build statement exists for '" + path + "'", err);
     Edge* edge = node->in_edge();
@@ -206,7 +206,7 @@ bool DyndepParser::ParseEdge(string* err) {
     uint64_t slash_bits;
     if (!CanonicalizePath(&path, &slash_bits, &path_err))
       return lexer_.Error(path_err, err);
-    Node* n = state_->GetNode(path, slash_bits);
+    Node* n = state_->GetNodeForDepfile(path, slash_bits);
     dyndeps->implicit_inputs_.push_back(n);
   }
 
@@ -217,7 +217,7 @@ bool DyndepParser::ParseEdge(string* err) {
     uint64_t slash_bits;
     if (!CanonicalizePath(&path, &slash_bits, &path_err))
       return lexer_.Error(path_err, err);
-    Node* n = state_->GetNode(path, slash_bits);
+    Node* n = state_->GetNodeForDepfile(path, slash_bits);
     dyndeps->implicit_outputs_.push_back(n);
   }
 

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -605,7 +605,7 @@ bool ImplicitDepLoader::ProcessDepfileDeps(
                           err))
       return false;
 
-    Node* node = state_->GetNode(*i, slash_bits);
+    Node* node = state_->GetNodeForDepfile(*i, slash_bits);
     *implicit_dep = node;
     node->AddOutEdge(edge);
     CreatePhonyInEdge(node);

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -511,6 +511,37 @@ TEST_F(GraphTest, DyndepLoadTrivial) {
   EXPECT_FALSE(edge->GetBindingBool("restat"));
 }
 
+TEST_F(GraphTest, DyndepLoadImplicit) {
+  AssertParse(&state_,
+"rule r\n"
+"  command = unused\n"
+"build out1: r in || dd\n"
+"  dyndep = dd\n"
+"build out2: r in\n"
+  );
+  fs_.Create("dd",
+"ninja_dyndep_version = 1\n"
+"build out1: dyndep | out2\n"
+  );
+
+  string err;
+  ASSERT_TRUE(GetNode("dd")->dyndep_pending());
+  EXPECT_TRUE(scan_.LoadDyndeps(GetNode("dd"), &err));
+  EXPECT_EQ("", err);
+  EXPECT_FALSE(GetNode("dd")->dyndep_pending());
+
+  Edge* edge = GetNode("out1")->in_edge();
+  ASSERT_EQ(1u, edge->outputs_.size());
+  EXPECT_EQ("out1", edge->outputs_[0]->path());
+  ASSERT_EQ(3u, edge->inputs_.size());
+  EXPECT_EQ("in", edge->inputs_[0]->path());
+  EXPECT_EQ("out2", edge->inputs_[1]->path());
+  EXPECT_EQ("dd", edge->inputs_[2]->path());
+  EXPECT_EQ(1u, edge->implicit_deps_);
+  EXPECT_EQ(1u, edge->order_only_deps_);
+  EXPECT_FALSE(edge->GetBindingBool("restat"));
+}
+
 TEST_F(GraphTest, DyndepLoadMissingFile) {
   AssertParse(&state_,
 "rule r\n"

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -558,16 +558,19 @@ TEST_F(GraphTest, DyndepLoadTrivial) {
 }
 
 TEST_F(GraphTest, DyndepLoadImplicit) {
+  state_.workdir_ = "/path/to/";
   AssertParse(&state_,
 "rule r\n"
 "  command = unused\n"
 "build out1: r in || dd\n"
 "  dyndep = dd\n"
 "build out2: r in\n"
+"build out3: r in\n"
+"build /path/to/out4: r in\n"
   );
   fs_.Create("dd",
 "ninja_dyndep_version = 1\n"
-"build out1: dyndep | out2\n"
+"build /path/to/out1: dyndep | out2 /path/to/out3 out4\n"
   );
 
   string err;
@@ -579,11 +582,13 @@ TEST_F(GraphTest, DyndepLoadImplicit) {
   Edge* edge = GetNode("out1")->in_edge();
   ASSERT_EQ(1u, edge->outputs_.size());
   EXPECT_EQ("out1", edge->outputs_[0]->path());
-  ASSERT_EQ(3u, edge->inputs_.size());
+  ASSERT_EQ(5u, edge->inputs_.size());
   EXPECT_EQ("in", edge->inputs_[0]->path());
   EXPECT_EQ("out2", edge->inputs_[1]->path());
-  EXPECT_EQ("dd", edge->inputs_[2]->path());
-  EXPECT_EQ(1u, edge->implicit_deps_);
+  EXPECT_EQ("out3", edge->inputs_[2]->path());
+  EXPECT_EQ("/path/to/out4", edge->inputs_[3]->path());
+  EXPECT_EQ("dd", edge->inputs_[4]->path());
+  EXPECT_EQ(3u, edge->implicit_deps_);
   EXPECT_EQ(1u, edge->order_only_deps_);
   EXPECT_FALSE(edge->GetBindingBool("restat"));
 }

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -247,6 +247,52 @@ TEST_F(GraphTest, DepfileWithCanonicalizablePath) {
   EXPECT_FALSE(GetNode("out.o")->dirty());
 }
 
+TEST_F(GraphTest, DepfileWithAbsolutePathToRelativeNode) {
+  state_.workdir_ = "/path/to/";
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule catdep\n"
+"  depfile = $out.d\n"
+"  command = cat $in > $out\n"
+"build ./out.o: catdep ./foo.cc\n"));
+  fs_.Create("foo.cc", "");
+  fs_.Create("out.o.d", "out.o: /path/to/foo.cc\n");
+  fs_.Create("out.o", "");
+
+  Edge* edge = GetNode("out.o")->in_edge();
+  string err;
+  EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out.o"), &err));
+  ASSERT_EQ("", err);
+
+  EXPECT_EQ(1, edge->implicit_deps_);
+  ASSERT_EQ(2, edge->inputs_.size());
+  EXPECT_EQ("foo.cc", edge->inputs_[1]->path());
+
+  EXPECT_FALSE(GetNode("out.o")->dirty());
+}
+
+TEST_F(GraphTest, DepfileWithRelativePathToAbsoluteNode) {
+  state_.workdir_ = "/path/to/";
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule catdep\n"
+"  depfile = $out.d\n"
+"  command = cat $in > $out\n"
+"build ./out.o: catdep /path/to/foo.cc\n"));
+  fs_.Create("/path/to/foo.cc", "");
+  fs_.Create("out.o.d", "out.o: foo.cc\n");
+  fs_.Create("out.o", "");
+
+  string err;
+  EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out.o"), &err));
+  ASSERT_EQ("", err);
+
+  Edge* edge = GetNode("out.o")->in_edge();
+  EXPECT_EQ(1, edge->implicit_deps_);
+  ASSERT_EQ(2, edge->inputs_.size());
+  EXPECT_EQ("/path/to/foo.cc", edge->inputs_[1]->path());
+
+  EXPECT_FALSE(GetNode("out.o")->dirty());
+}
+
 // Regression test for https://github.com/ninja-build/ninja/issues/404
 TEST_F(GraphTest, DepfileRemoved) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -849,18 +849,10 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
   argc -= optind;
 
   bool first = true;
-  vector<char> cwd;
-  char* success = NULL;
+  std::string cwd;
 
-  do {
-    cwd.resize(cwd.size() + 1024);
-    errno = 0;
-    success = getcwd(&cwd[0], cwd.size());
-  } while (!success && errno == ERANGE);
-  if (!success) {
-    Error("cannot determine working directory: %s", strerror(errno));
+  if (!GetCWD(&cwd))
     return 1;
-  }
 
   putchar('[');
   for (vector<Edge*>::iterator e = state_.edges_.begin();

--- a/src/state.cc
+++ b/src/state.cc
@@ -94,13 +94,17 @@ Edge* State::AddEdge(const Rule* rule) {
   return edge;
 }
 
+Node* State::AddNode(StringPiece path, uint64_t slash_bits) {
+  Node* node = new Node(path.AsString(), slash_bits);
+  paths_[node->path()] = node;
+  return node;
+}
+
 Node* State::GetNode(StringPiece path, uint64_t slash_bits) {
   Node* node = LookupNode(path);
   if (node)
     return node;
-  node = new Node(path.AsString(), slash_bits);
-  paths_[node->path()] = node;
-  return node;
+  return AddNode(path, slash_bits);
 }
 
 Node* State::LookupNode(StringPiece path) const {

--- a/src/state.h
+++ b/src/state.h
@@ -125,6 +125,10 @@ struct State {
   typedef ExternalStringHashMap<Node*>::Type Paths;
   Paths paths_;
 
+  /// The working directory in which commands run, ending in a trailing slash.
+  /// This is computed from the process working directory, or set by tests.
+  std::string workdir_;
+
   /// All the pools used in the graph.
   std::map<std::string, Pool*> pools_;
 

--- a/src/state.h
+++ b/src/state.h
@@ -137,6 +137,9 @@ struct State {
 
   BindingEnv bindings_;
   std::vector<Node*> defaults_;
+
+ private:
+  Node* AddNode(StringPiece path, uint64_t slash_bits);
 };
 
 #endif  // NINJA_STATE_H_

--- a/src/state.h
+++ b/src/state.h
@@ -102,7 +102,9 @@ struct State {
   Edge* AddEdge(const Rule* rule);
 
   Node* GetNode(StringPiece path, uint64_t slash_bits);
+  Node* GetNodeForDepfile(StringPiece path, uint64_t slash_bits);
   Node* LookupNode(StringPiece path) const;
+  Node* LookupNodeForDepfile(StringPiece path) const;
   Node* SpellcheckNode(const std::string& path);
 
   void AddIn(Edge* edge, StringPiece path, uint64_t slash_bits);

--- a/src/util.cc
+++ b/src/util.cc
@@ -21,6 +21,7 @@
 #include <windows.h>
 #include <io.h>
 #include <share.h>
+#include <direct.h>
 #endif
 
 #include <assert.h>
@@ -115,6 +116,22 @@ void Info(const char* msg, ...) {
   va_start(ap, msg);
   Info(msg, ap);
   va_end(ap);
+}
+
+bool GetCWD(std::string* result) {
+  vector<char> cwd;
+  char* success = NULL;
+  do {
+    cwd.resize(cwd.size() + 1024);
+    errno = 0;
+    success = getcwd(&cwd[0], cwd.size());
+  } while (!success && errno == ERANGE);
+  if (!success) {
+    Error("cannot determine working directory: %s", strerror(errno));
+    return false;
+  }
+  result->assign(success);
+  return true;
 }
 
 bool CanonicalizePath(string* path, uint64_t* slash_bits, string* err) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -134,6 +134,19 @@ bool GetCWD(std::string* result) {
   return true;
 }
 
+bool NormalizeWorkDir(std::string* workdir, std::string* err) {
+  // Ensure we have forward slashes.
+  uint64_t slash_bits;
+  if (!CanonicalizePath(workdir, &slash_bits, err))
+    return false;
+
+  // Add a trailing slash so we can simply append relative paths later.
+  if ((*workdir)[workdir->size() - 1] != '/')
+    *workdir += '/';
+
+  return true;
+}
+
 bool CanonicalizePath(string* path, uint64_t* slash_bits, string* err) {
   METRIC_RECORD("canonicalize str");
   size_t len = path->size();

--- a/src/util.cc
+++ b/src/util.cc
@@ -254,6 +254,22 @@ bool CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits,
   return true;
 }
 
+bool IsAbsolutePath(StringPiece path) {
+  if (path.len_ < 1)
+    return false;
+  if (path.str_[0] == '/')
+    return true; // NOLINT(readability-simplify-boolean-expr)
+#ifdef _WIN32
+  if (path.str_[0] == '\\')
+    return true;
+  if (path.len_ < 2)
+    return false;
+  if (path.str_[1] == ':')
+    return true;
+#endif
+  return false;
+}
+
 static inline bool IsKnownShellSafeCharacter(char ch) {
   if ('A' <= ch && ch <= 'Z') return true;
   if ('a' <= ch && ch <= 'z') return true;

--- a/src/util.h
+++ b/src/util.h
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+#include "string_piece.h"
+
 #ifdef _MSC_VER
 #define NORETURN __declspec(noreturn)
 #else
@@ -71,6 +73,10 @@ bool CanonicalizePath(std::string* path, uint64_t* slash_bits,
                       std::string* err);
 bool CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits,
                       std::string* err);
+
+/// Returns true if the given path is absolute
+/// (starts in '/', or 'x:' on Windows).
+bool IsAbsolutePath(StringPiece path);
 
 /// Appends |input| to |*result|, escaping according to the whims of either
 /// Bash, or Win32's CommandLineToArgvW().

--- a/src/util.h
+++ b/src/util.h
@@ -66,6 +66,9 @@ void Info(const char* msg, va_list ap);
 /// Get the current working directory of the process.
 bool GetCWD(std::string* result);
 
+/// Normalize a working directory string to end in a trailing slash.
+bool NormalizeWorkDir(std::string* workdir, std::string* err);
+
 /// Canonicalize a path like "foo/../bar.h" into just "bar.h".
 /// |slash_bits| has bits set starting from lowest for a backslash that was
 /// normalized to a forward slash. (only used on Windows)

--- a/src/util.h
+++ b/src/util.h
@@ -61,6 +61,9 @@ void Error(const char* msg, va_list ap);
 void Info(const char* msg, ...);
 void Info(const char* msg, va_list ap);
 
+/// Get the current working directory of the process.
+bool GetCWD(std::string* result);
+
 /// Canonicalize a path like "foo/../bar.h" into just "bar.h".
 /// |slash_bits| has bits set starting from lowest for a backslash that was
 /// normalized to a forward slash. (only used on Windows)

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -377,6 +377,27 @@ TEST(CanonicalizePath, NotNullTerminated) {
   EXPECT_EQ("file ./file bar/.", string(path));
 }
 
+TEST(IsAbsolutePath, Basic) {
+  string const empty_path;
+  string const relative_path = "foo/bar";
+  string const absolute_path_unix = "/path/to/foo/bar";
+  string const absolute_path_network = "//machine/share/path/to/foo/bar";
+  string const absolute_path_windows = "c:/path/to/foo/bar";
+  string const absolute_path_windows_backslash = "c:\\path\\to\\foo\\bar";
+
+  EXPECT_FALSE(IsAbsolutePath(empty_path));
+  EXPECT_FALSE(IsAbsolutePath(relative_path));
+  EXPECT_TRUE(IsAbsolutePath(absolute_path_unix));
+  EXPECT_TRUE(IsAbsolutePath(absolute_path_network));
+#ifdef _WIN32
+  EXPECT_TRUE(IsAbsolutePath(absolute_path_windows));
+  EXPECT_TRUE(IsAbsolutePath(absolute_path_windows_backslash));
+#else
+  EXPECT_FALSE(IsAbsolutePath(absolute_path_windows));
+  EXPECT_FALSE(IsAbsolutePath(absolute_path_windows_backslash));
+#endif
+}
+
 TEST(PathEscaping, TortureTest) {
   string result;
 

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -27,6 +27,13 @@ bool CanonicalizePath(string* path, string* err) {
 
 }  // namespace
 
+TEST(GetCWD, Basic) {
+  string cwd;
+
+  EXPECT_TRUE(GetCWD(&cwd));
+  EXPECT_TRUE(!cwd.empty());
+}
+
 TEST(CanonicalizePath, PathSamples) {
   string path;
   string err;


### PR DESCRIPTION
A depfile (or dyndep file) may contain relative and/or absolute paths based on compiler
behavior and the include directory flags given. It is not always
possible to make these exactly match corresponding paths in the build
manifest. If Ninja does not find an exact match for a depfile path, try
converting it to the opposite kind of path (absolute or relative) and
look again. If neither matches, add a node with the path as-is.

Fixes: #1251