### PR TITLE
Follow up fixes to #1753

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1288,6 +1288,24 @@ struct BuildWithLogTest : public BuildTest {
   BuildLog build_log_;
 };
 
+TEST_F(BuildWithLogTest, ImplicitGeneratedOutOfDate) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule generator\n"
+"  command = touch out.imp\n"
+"  generator = 1\n"
+"build out.imp:  generator | in\n"));
+  fs_.Create("out.imp", "");
+  fs_.Tick();
+  fs_.Create("in", "");
+
+  string err;
+
+  EXPECT_TRUE(builder_.AddTarget("out.imp", &err));
+  EXPECT_FALSE(builder_.AlreadyUpToDate());
+
+  EXPECT_TRUE(GetNode("out.imp")->dirty());
+}
+
 TEST_F(BuildWithLogTest, NotInLogButOnDisk) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule cc\n"


### PR DESCRIPTION
These are followup fixes for #1753 and fixes #1932.

- Check the output file's mtime against the most recent input time before checking the build log
- For outputs created by generator rules, record the restat'd output's mtime in the build log
- Always include depfile mtime in build log mtime if special deps binding isn't specified
- Fix performance regression (change `Stat()` to `StatIfNecessary()` in `StartEdge()`)