### PR TITLE
Attempt reading depfiles in GraphViz

### DIFF
--- a/src/graphviz.cc
+++ b/src/graphviz.cc
@@ -50,6 +50,15 @@ void GraphViz::AddTarget(Node* node) {
     }
   }
 
+  {
+    // Load discovered deps.
+    std::string err;
+    if (!dep_loader_.LoadDeps(edge, &err)) {
+      if (!err.empty())
+        Warning("%s\n", err.c_str());
+    }
+  }
+
   if (edge->inputs_.size() == 1 && edge->outputs_.size() == 1) {
     // Can draw simply.
     // Note extra space before label text -- this is cosmetic and feels

--- a/src/graphviz.h
+++ b/src/graphviz.h
@@ -27,13 +27,16 @@ struct State;
 
 /// Runs the process of creating GraphViz .dot file output.
 struct GraphViz {
-  GraphViz(State* state, DiskInterface* disk_interface)
-      : dyndep_loader_(state, disk_interface) {}
+  GraphViz(State* state, DepsLog* deps_log, DiskInterface* disk_interface, DepfileParserOptions const* depfile_parser_options)
+      : dyndep_loader_(state, disk_interface),
+        dep_loader_(state, deps_log, disk_interface, depfile_parser_options) {}
+
   void Start();
   void AddTarget(Node* node);
   void Finish();
 
   DyndepLoader dyndep_loader_;
+  ImplicitDepLoader dep_loader_;
   std::set<Node*> visited_nodes_;
   EdgeSet visited_edges_;
 };

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -350,7 +350,7 @@ int NinjaMain::ToolGraph(const Options* options, int argc, char* argv[]) {
     return 1;
   }
 
-  GraphViz graph(&state_, &disk_interface_);
+  GraphViz graph(&state_, &deps_log_, &disk_interface_, &config_.depfile_parser_options);
   graph.Start();
   for (vector<Node*>::const_iterator n = nodes.begin(); n != nodes.end(); ++n)
     graph.AddTarget(*n);


### PR DESCRIPTION
Attempts to address #78. Some problems with it currently:

- Only works after you run the build process as .d files haven't been created otherwise, not sure how to generate these yet
- See a phony rule for earch file at the start, not sure how to get rid of these

Here's the example from https://github.com/ninja-build/ninja/issues/78#issuecomment-583098597
![x](https://user-images.githubusercontent.com/206854/112201141-dcae4400-8c07-11eb-919a-f71ea08bff72.png)

(closes #78)