### PR TITLE
Revert #1753 and add additional tests to expose previously untested behavior

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -116,9 +116,9 @@ BuildLog::LogEntry::LogEntry(const string& output)
   : output(output) {}
 
 BuildLog::LogEntry::LogEntry(const string& output, uint64_t command_hash,
-  int start_time, int end_time, TimeStamp mtime)
+  int start_time, int end_time, TimeStamp restat_mtime)
   : output(output), command_hash(command_hash),
-    start_time(start_time), end_time(end_time), mtime(mtime)
+    start_time(start_time), end_time(end_time), mtime(restat_mtime)
 {}
 
 BuildLog::BuildLog()
@@ -303,7 +303,7 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
     *end = 0;
 
     int start_time = 0, end_time = 0;
-    TimeStamp mtime = 0;
+    TimeStamp restat_mtime = 0;
 
     start_time = atoi(start);
     start = end + 1;
@@ -319,7 +319,7 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
     if (!end)
       continue;
     *end = 0;
-    mtime = strtoll(start, NULL, 10);
+    restat_mtime = strtoll(start, NULL, 10);
     start = end + 1;
 
     end = (char*)memchr(start, kFieldSeparator, line_end - start);
@@ -343,7 +343,7 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
 
     entry->start_time = start_time;
     entry->end_time = end_time;
-    entry->mtime = mtime;
+    entry->mtime = restat_mtime;
     if (log_version >= 5) {
       char c = *end; *end = '\0';
       entry->command_hash = (uint64_t)strtoull(start, NULL, 16);

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -73,7 +73,7 @@ struct BuildLog {
 
     explicit LogEntry(const std::string& output);
     LogEntry(const std::string& output, uint64_t command_hash,
-             int start_time, int end_time, TimeStamp mtime);
+             int start_time, int end_time, TimeStamp restat_mtime);
   };
 
   /// Lookup a previously-run command by its output path.

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -609,15 +609,6 @@ bool FakeCommandRunner::StartCommand(Edge* edge) {
     if (fs_->ReadFile(edge->inputs_[0]->path(), &content, &err) ==
         DiskInterface::Okay)
       fs_->WriteFile(edge->outputs_[0]->path(), content);
-  } else if (edge->rule().name() == "long-cc" ||
-             edge->rule().name() == "long-cc2") {
-    for (vector<Node*>::iterator out = edge->outputs_.begin();
-        out != edge->outputs_.end(); ++out) {
-      fs_->Tick();
-      fs_->Tick();
-      fs_->Tick();
-      fs_->Create((*out)->path(), "");
-    }
   } else {
     printf("unknown command\n");
     return false;
@@ -672,15 +663,6 @@ bool FakeCommandRunner::WaitForCommand(Result* result) {
     result->status = ExitFailure;
   else
     result->status = ExitSuccess;
-
-  // These rules simulate an external process modifying files while the build command
-  // runs. See TestInputMtimeRaceCondition and TestInputMtimeRaceConditionWithDepFile.
-  // Note: only the "first" time the rule is run per test is the file modified, so the
-  // test can verify that subsequent runs without the race have no work to do.
-  if (edge->rule().name() == "long-cc" && fs_->now_ == 4)
-    fs_->files_["in1"].mtime = 3;
-  if (edge->rule().name() == "long-cc2" && fs_->now_ == 4)
-    fs_->files_["header.h"].mtime = 3;
 
   // Provide a way for test cases to verify when an edge finishes that
   // some other edge is still active.  This is useful for test cases
@@ -2282,148 +2264,6 @@ TEST_F(BuildWithDepsLogTest, DepsIgnoredInDryRun) {
   ASSERT_EQ(1u, command_runner_.commands_ran_.size());
 
   builder.command_runner_.release();
-}
-
-TEST_F(BuildWithDepsLogTest, TestInputMtimeRaceCondition) {
-  string err;
-  const char* manifest =
-      "rule long-cc\n"
-      "  command = long-cc\n"
-      "build out: long-cc in1\n";
-
-  State state;
-  ASSERT_NO_FATAL_FAILURE(AddCatRule(&state));
-  ASSERT_NO_FATAL_FAILURE(AssertParse(&state, manifest));
-
-  BuildLog build_log;
-  ASSERT_TRUE(build_log.Load("build_log", &err));
-  ASSERT_TRUE(build_log.OpenForWrite("build_log", *this, &err));
-
-  DepsLog deps_log;
-  ASSERT_TRUE(deps_log.Load("ninja_deps", &state, &err));
-  ASSERT_TRUE(deps_log.OpenForWrite("ninja_deps", &err));
-
-  BuildLog::LogEntry* log_entry = NULL;
-  {
-    Builder builder(&state, config_, &build_log, &deps_log, &fs_, &status_, 0);
-    builder.command_runner_.reset(&command_runner_);
-    command_runner_.commands_ran_.clear();
-
-    // Run the build, out gets built, dep file is created
-    EXPECT_TRUE(builder.AddTarget("out", &err));
-    ASSERT_EQ("", err);
-    EXPECT_TRUE(builder.Build(&err));
-    ASSERT_EQ(1u, command_runner_.commands_ran_.size());
-
-    // See that an entry in the logfile is created. the input_mtime is 1 since that was
-    // the mtime of in1 when the command was started
-    log_entry = build_log.LookupByOutput("out");
-    ASSERT_TRUE(NULL != log_entry);
-    ASSERT_EQ(1u, log_entry->mtime);
-
-    builder.command_runner_.release();
-  }
-
-  {
-    Builder builder(&state, config_, &build_log, &deps_log, &fs_, &status_, 0);
-    builder.command_runner_.reset(&command_runner_);
-    command_runner_.commands_ran_.clear();
-
-    // Trigger the build again - "out" should rebuild despite having a newer mtime than
-    // "in1", since "in1" was touched during the build of out (simulated by changing its
-    // mtime in the the test builder's WaitForCommand() which runs before FinishCommand()
-    command_runner_.commands_ran_.clear();
-    state.Reset();
-    EXPECT_TRUE(builder.AddTarget("out", &err));
-    ASSERT_EQ("", err);
-    EXPECT_TRUE(builder.Build(&err));
-    ASSERT_EQ(1u, command_runner_.commands_ran_.size());
-
-    // Check that the logfile entry is still correct
-    log_entry = build_log.LookupByOutput("out");
-    ASSERT_TRUE(NULL != log_entry);
-    ASSERT_EQ(fs_.files_["in1"].mtime, log_entry->mtime);
-    builder.command_runner_.release();
-  }
-
-  {
-    Builder builder(&state, config_, &build_log, &deps_log, &fs_, &status_, 0);
-    builder.command_runner_.reset(&command_runner_);
-    command_runner_.commands_ran_.clear();
-
-    // And a subsequent run should not have any work to do
-    command_runner_.commands_ran_.clear();
-    state.Reset();
-    EXPECT_TRUE(builder.AddTarget("out", &err));
-    ASSERT_EQ("", err);
-    EXPECT_TRUE(builder.AlreadyUpToDate());
-
-    builder.command_runner_.release();
-  }
-}
-
-TEST_F(BuildWithDepsLogTest, TestInputMtimeRaceConditionWithDepFile) {
-  string err;
-  const char* manifest =
-      "rule long-cc2\n"
-      "  command = long-cc2\n"
-      "build out: long-cc2 in1\n"
-      "  deps = gcc\n"
-      "  depfile = in1.d\n";
-
-  fs_.Create("header.h", "");
-  fs_.Create("in1.d", "out: header.h");
-
-  State state;
-  ASSERT_NO_FATAL_FAILURE(AddCatRule(&state));
-  ASSERT_NO_FATAL_FAILURE(AssertParse(&state, manifest));
-
-  BuildLog build_log;
-  ASSERT_TRUE(build_log.Load("build_log", &err));
-  ASSERT_TRUE(build_log.OpenForWrite("build_log", *this, &err));
-
-  DepsLog deps_log;
-  ASSERT_TRUE(deps_log.Load("ninja_deps", &state, &err));
-  ASSERT_TRUE(deps_log.OpenForWrite("ninja_deps", &err));
-
-  {
-    Builder builder(&state, config_, &build_log, &deps_log, &fs_, &status_, 0);
-    builder.command_runner_.reset(&command_runner_);
-    command_runner_.commands_ran_.clear();
-
-    // Run the build, out gets built, dep file is created
-    EXPECT_TRUE(builder.AddTarget("out", &err));
-    ASSERT_EQ("", err);
-    EXPECT_TRUE(builder.Build(&err));
-    ASSERT_EQ(1u, command_runner_.commands_ran_.size());
-
-    // See that an entry in the logfile is created. the mtime is 3 due to header.h being
-    // updated during the build of out (simulated by changing its mtime in the the test
-    // builder's WaitForCommand() which runs before FinishCommand()
-    BuildLog::LogEntry* log_entry = build_log.LookupByOutput("out");
-    ASSERT_TRUE(NULL != log_entry);
-    ASSERT_EQ(3u, log_entry->mtime);
-
-    builder.command_runner_.release();
-  }
-
-  {
-    // Trigger the build again - "out" won't rebuild since its newest mtime (header.h)
-    // wasn't known when out was originally built and was only discovered via the deps file
-    // when the command completed. Subsequent runs will see out's recorded mtime equal to
-    // the actual most recent mtime.
-    Builder builder(&state, config_, &build_log, &deps_log, &fs_, &status_, 0);
-    builder.command_runner_.reset(&command_runner_);
-    command_runner_.commands_ran_.clear();
-
-    command_runner_.commands_ran_.clear();
-    state.Reset();
-    EXPECT_TRUE(builder.AddTarget("out", &err));
-    ASSERT_EQ("", err);
-    EXPECT_TRUE(builder.AlreadyUpToDate());
-
-    builder.command_runner_.release();
-  }
 }
 
 /// Check that a restat rule generating a header cancels compilations correctly.

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -143,12 +143,10 @@ bool DependencyScan::RecomputeDirty(Node* node, vector<Node*>* stack,
     }
   }
 
-  edge->most_recent_input_ = most_recent_input;
-
   // We may also be dirty due to output state: missing outputs, out of
   // date outputs, etc.  Visit all outputs and determine whether they're dirty.
   if (!dirty)
-    if (!RecomputeOutputsDirty(edge, &dirty, err))
+    if (!RecomputeOutputsDirty(edge, most_recent_input, &dirty, err))
       return false;
 
   // Finally, visit each output and update their dirty state if necessary.
@@ -214,11 +212,12 @@ bool DependencyScan::VerifyDAG(Node* node, vector<Node*>* stack, string* err) {
   return false;
 }
 
-bool DependencyScan::RecomputeOutputsDirty(Edge* edge, bool* outputs_dirty, string* err) {
+bool DependencyScan::RecomputeOutputsDirty(Edge* edge, Node* most_recent_input,
+                                           bool* outputs_dirty, string* err) {
   string command = edge->EvaluateCommand(/*incl_rsp_file=*/true);
   for (vector<Node*>::iterator o = edge->outputs_.begin();
        o != edge->outputs_.end(); ++o) {
-    if (RecomputeOutputDirty(edge, command, *o)) {
+    if (RecomputeOutputDirty(edge, most_recent_input, command, *o)) {
       *outputs_dirty = true;
       return true;
     }
@@ -227,6 +226,7 @@ bool DependencyScan::RecomputeOutputsDirty(Edge* edge, bool* outputs_dirty, stri
 }
 
 bool DependencyScan::RecomputeOutputDirty(const Edge* edge,
+                                          const Node* most_recent_input,
                                           const string& command,
                                           Node* output) {
   if (edge->is_phony()) {
@@ -248,7 +248,30 @@ bool DependencyScan::RecomputeOutputDirty(const Edge* edge,
     return true;
   }
 
-  const Node* most_recent_input = edge->most_recent_input_;
+  // Dirty if the output is older than the input.
+  if (most_recent_input && output->mtime() < most_recent_input->mtime()) {
+    TimeStamp output_mtime = output->mtime();
+
+    // If this is a restat rule, we may have cleaned the output with a restat
+    // rule in a previous run and stored the most recent input mtime in the
+    // build log.  Use that mtime instead, so that the file will only be
+    // considered dirty if an input was modified since the previous run.
+    bool used_restat = false;
+    if (edge->GetBindingBool("restat") && build_log() &&
+        (entry = build_log()->LookupByOutput(output->path()))) {
+      output_mtime = entry->mtime;
+      used_restat = true;
+    }
+
+    if (output_mtime < most_recent_input->mtime()) {
+      EXPLAIN("%soutput %s older than most recent input %s "
+              "(%" PRId64 " vs %" PRId64 ")",
+              used_restat ? "restat of " : "", output->path().c_str(),
+              most_recent_input->path().c_str(),
+              output_mtime, most_recent_input->mtime());
+      return true;
+    }
+  }
 
   if (build_log()) {
     bool generator = edge->GetBindingBool("generator");
@@ -276,14 +299,6 @@ bool DependencyScan::RecomputeOutputDirty(const Edge* edge,
       EXPLAIN("command line not found in log for %s", output->path().c_str());
       return true;
     }
-  } else if (most_recent_input &&
-             output->mtime() < most_recent_input->mtime()) {
-      EXPLAIN(
-          "output %s older than most recent input %s "
-          "(%" PRId64 " vs %" PRId64 ")",
-          output->path().c_str(), most_recent_input->path().c_str(),
-          output->mtime(), most_recent_input->mtime());
-    return true;
   }
 
   return false;

--- a/src/graph.h
+++ b/src/graph.h
@@ -146,7 +146,6 @@ struct Edge {
 
   Edge()
       : rule_(NULL), pool_(NULL), dyndep_(NULL), env_(NULL), mark_(VisitNone),
-        most_recent_input_(NULL), most_recent_input_mtime_(0),
         id_(0), outputs_ready_(false), deps_loaded_(false),
         deps_missing_(false), implicit_deps_(0), order_only_deps_(0),
         implicit_outs_(0) {}
@@ -179,8 +178,6 @@ struct Edge {
   Node* dyndep_;
   BindingEnv* env_;
   VisitMark mark_;
-  Node* most_recent_input_;
-  TimeStamp most_recent_input_mtime_;
   size_t id_;
   bool outputs_ready_;
   bool deps_loaded_;
@@ -301,7 +298,8 @@ struct DependencyScan {
 
   /// Recompute whether any output of the edge is dirty, if so sets |*dirty|.
   /// Returns false on failure.
-  bool RecomputeOutputsDirty(Edge* edge, bool* dirty, std::string* err);
+  bool RecomputeOutputsDirty(Edge* edge, Node* most_recent_input,
+                             bool* dirty, std::string* err);
 
   BuildLog* build_log() const {
     return build_log_;
@@ -327,8 +325,8 @@ struct DependencyScan {
 
   /// Recompute whether a given single output should be marked dirty.
   /// Returns true if so.
-  bool RecomputeOutputDirty(const Edge* edge, const std::string& command,
-                            Node* output);
+  bool RecomputeOutputDirty(const Edge* edge, const Node* most_recent_input,
+                            const std::string& command, Node* output);
 
   BuildLog* build_log_;
   DiskInterface* disk_interface_;


### PR DESCRIPTION
This reverts #1753 with the intention of re-landing the change with the fixes from #1933.

Additional tests are included that recreate some CMake test suite tests (see #1932). These regression tests are useful since they expose some edge-casey behavior.

Fixes #1932.