### PR TITLE
CI: macOS: Unfix Xcode version to use the latest stable one

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,6 @@ jobs:
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.12
       run: |
-        sudo xcode-select -s /Applications/Xcode_12.2.app
         cmake -Bbuild -GXcode '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'
         cmake --build build --config Release
 


### PR DESCRIPTION
Removes the selection of a fixed Xcode version added in 242b7dd which assured Xcode version 12.2 was used when the default was still 12.1. The GitHub default is now 12.4 and newer versions will be made the default a few weeks after the stable release. This commit ensures an up to date Xcode version is used in the CI.