### PR TITLE
Make outputs modified outside of the build system considered dirty

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -504,7 +504,8 @@ Builder::Builder(State* state, const BuildConfig& config,
     : state_(state), config_(config), plan_(this), status_(status),
       start_time_millis_(start_time_millis), disk_interface_(disk_interface),
       scan_(state, build_log, deps_log, disk_interface,
-            &config_.depfile_parser_options) {
+            &config_.depfile_parser_options,
+            config.modified_output_is_dirty) {
 }
 
 Builder::~Builder() {

--- a/src/build.h
+++ b/src/build.h
@@ -155,8 +155,8 @@ struct CommandRunner {
 
 /// Options (e.g. verbosity, parallelism) passed to a build.
 struct BuildConfig {
-  BuildConfig() : verbosity(NORMAL), dry_run(false), parallelism(1),
-                  failures_allowed(1), max_load_average(-0.0f) {}
+  BuildConfig() : verbosity(NORMAL), dry_run(false), modified_output_is_dirty(false), 
+                  parallelism(1), failures_allowed(1), max_load_average(-0.0f) {}
 
   enum Verbosity {
     NORMAL,
@@ -165,6 +165,7 @@ struct BuildConfig {
   };
   Verbosity verbosity;
   bool dry_run;
+  bool modified_output_is_dirty;
   int parallelism;
   int failures_allowed;
   /// The maximum load average we must not exceed. A negative value

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -221,7 +221,7 @@ TEST_F(DiskInterfaceTest, RemoveFile) {
 
 struct StatTest : public StateTestWithBuiltinRules,
                   public DiskInterface {
-  StatTest() : scan_(&state_, NULL, NULL, this, NULL) {}
+  StatTest() : scan_(&state_, NULL, NULL, this, NULL, false) {}
 
   // DiskInterface implementation.
   virtual TimeStamp Stat(const string& path, string* err) const;

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -276,7 +276,7 @@ bool DependencyScan::RecomputeOutputDirty(const Edge* edge,
   if (build_log()) {
     bool generator = edge->GetBindingBool("generator");
     if (entry || (entry = build_log()->LookupByOutput(output->path()))) {
-      if (output->mtime() > entry->mtime) {
+      if (modified_output_is_dirty_ && output->mtime() > entry->mtime) {
         // May also be dirty due to the mtime in the log being older from the
         // actual mtime of the output. This can occur if the output has been
         // modified from a process unrelated to the build system. In that case the

--- a/src/graph.h
+++ b/src/graph.h
@@ -284,11 +284,13 @@ struct ImplicitDepLoader {
 struct DependencyScan {
   DependencyScan(State* state, BuildLog* build_log, DepsLog* deps_log,
                  DiskInterface* disk_interface,
-                 DepfileParserOptions const* depfile_parser_options)
+                 DepfileParserOptions const* depfile_parser_options,
+                 bool modified_output_is_dirty)
       : build_log_(build_log),
         disk_interface_(disk_interface),
         dep_loader_(state, deps_log, disk_interface, depfile_parser_options),
-        dyndep_loader_(state, disk_interface) {}
+        dyndep_loader_(state, disk_interface), 
+        modified_output_is_dirty_(modified_output_is_dirty) {}
 
   /// Update the |dirty_| state of the given node by inspecting its input edge.
   /// Examine inputs, outputs, and command lines to judge whether an edge
@@ -333,6 +335,7 @@ struct DependencyScan {
   DiskInterface* disk_interface_;
   ImplicitDepLoader dep_loader_;
   DyndepLoader dyndep_loader_;
+  bool modified_output_is_dirty_;
 };
 
 #endif  // NINJA_GRAPH_H_

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -20,7 +20,7 @@
 using namespace std;
 
 struct GraphTest : public StateTestWithBuiltinRules {
-  GraphTest() : scan_(&state_, NULL, NULL, &fs_, NULL) {}
+  GraphTest() : scan_(&state_, NULL, NULL, &fs_, NULL, false) {}
 
   VirtualFileSystem fs_;
   DependencyScan scan_;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -224,6 +224,7 @@ void Usage(const BuildConfig& config) {
 "  -j N     run N jobs in parallel (0 means infinity) [default=%d on this system]\n"
 "  -k N     keep going until N jobs fail (0 means infinity) [default=1]\n"
 "  -l N     do not start new jobs if the load average is greater than N\n"
+"  -m       considered modified output as dirty\n"
 "  -n       dry run (don't run commands but act like they succeeded)\n"
 "\n"
 "  -d MODE  enable debugging (use '-d list' to list modes)\n"
@@ -1356,6 +1357,10 @@ int ReadFlags(int* argc, char*** argv,
         if (end == optarg)
           Fatal("-l parameter not numeric: did you mean -l 0.0?");
         config->max_load_average = value;
+        break;
+      }
+      case 'm': {
+        config->modified_output_is_dirty = true;
         break;
       }
       case 'n':


### PR DESCRIPTION
This pull request is a fix for #1946.

Today if an output of the build is modified from outside of the build system (manually or by another process) ninja will not consider it to be dirty.

I think if an output state is different from the state it would have if the rule command was executed again, then it should be considered dirty. (Edit: Since in some scenario like when you consciously modified outputs for quick testing you may not want ninja to override your change, my implementation makes it optional. For backward compatibility default ninja keep the same behavior, but if run with -m flag, it will considered modified outputs as dirty).

Situation where it is a problem: 
- You have an action registered as order-only dependency which generate some C++ header. 
- You include one of generated file for the time to one of your .cpp, so ninja does not consider it yet as implicit dependency. 
- You open the generated file with your favorite text editor, and by mistyping on your keyboard you modify the generated header to an invalid C++ state.
- As consequence, ninja will not try to re-generate the header, because it is not yet a dependency of the build, and ninja will fail the build because the header is not valid C++.

My modification considered an output is dirty if its mtime is more recent than the one in the build log. The mtime of the output can be older than the one on the build log in the case its build edge is mark with 'restat = 1'. In that case if the rule command did not modified the output, its build log entry will inherit the mtime of its most recent inputs or depfile.