### PR TITLE
Suppress progress output when NINJA_STATUS is empty.

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -211,6 +211,9 @@ The default progress status is `"[%f/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status
 could be `"[%u/%r/%f] "`.
 
+If `NINJA_STATUS` is set to an empty string then all progress status
+information will be suppressed.
+
 Extra tools
 ~~~~~~~~~~~
 

--- a/src/status.cc
+++ b/src/status.cc
@@ -237,6 +237,11 @@ void StatusPrinter::PrintStatus(const Edge* edge, int64_t time_millis) {
   if (to_print.empty() || force_full_command)
     to_print = edge->GetBinding("command");
 
+  // If the user supplies an empty value for NINJA_STATUS, print nothing.
+  size_t progress_status_format_len = strlen(progress_status_format_);
+  if (progress_status_format_len == 0 && !force_full_command)
+    return;
+
   to_print = FormatProgressStatus(progress_status_format_, time_millis)
       + to_print;
 


### PR DESCRIPTION
If log verbosity is set to fully verbose it overrides the NINJA_STATUS
environment variable. Otherwise, this allows users to suppress most
build output on very large builds.

Issue: https://github.com/ninja-build/ninja/issues/1954