### PR TITLE
Remove 'using namespace std', properly namespace all std symbols

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -326,7 +326,7 @@ if platform.is_msvc():
               # Disable size_t -> int truncation warning.
               # We never have strings or arrays larger than 2**31.
               '/wd4267',
-              '/DNOMINMAX', '/D_CRT_SECURE_NO_WARNINGS',
+              '/D_CRT_SECURE_NO_WARNINGS',
               '/D_HAS_EXCEPTIONS=0',
               '/DNINJA_PYTHON="%s"' % options.with_python]
     if platform.msvc_needs_fs():

--- a/src/browse.cc
+++ b/src/browse.cc
@@ -22,8 +22,6 @@
 
 #include "build/browse_py.h"
 
-using namespace std;
-
 void RunBrowsePython(State* state, const char* ninja_command,
                      const char* input_file, int argc, char* argv[]) {
   // Fork off a Python process and have it run our code via its stdin.

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -41,7 +41,6 @@
 #define strtoll _strtoi64
 #endif
 
-using namespace std;
 
 // Implementation details:
 // Each run's log appends to the log file.
@@ -112,10 +111,10 @@ uint64_t BuildLog::LogEntry::HashCommand(StringPiece command) {
   return MurmurHash64A(command.str_, command.len_);
 }
 
-BuildLog::LogEntry::LogEntry(const string& output)
+BuildLog::LogEntry::LogEntry(const std::string& output)
   : output(output) {}
 
-BuildLog::LogEntry::LogEntry(const string& output, uint64_t command_hash,
+BuildLog::LogEntry::LogEntry(const std::string& output, uint64_t command_hash,
   int start_time, int end_time, TimeStamp mtime)
   : output(output), command_hash(command_hash),
     start_time(start_time), end_time(end_time), mtime(mtime)
@@ -128,8 +127,8 @@ BuildLog::~BuildLog() {
   Close();
 }
 
-bool BuildLog::OpenForWrite(const string& path, const BuildLogUser& user,
-                            string* err) {
+bool BuildLog::OpenForWrite(const std::string& path, const BuildLogUser& user,
+                            std::string* err) {
   if (needs_recompaction_) {
     if (!Recompact(path, user, err))
       return false;
@@ -143,11 +142,11 @@ bool BuildLog::OpenForWrite(const string& path, const BuildLogUser& user,
 
 bool BuildLog::RecordCommand(Edge* edge, int start_time, int end_time,
                              TimeStamp mtime) {
-  string command = edge->EvaluateCommand(true);
+  std::string command = edge->EvaluateCommand(true);
   uint64_t command_hash = LogEntry::HashCommand(command);
-  for (vector<Node*>::iterator out = edge->outputs_.begin();
+  for (std::vector<Node*>::iterator out = edge->outputs_.begin();
        out != edge->outputs_.end(); ++out) {
-    const string& path = (*out)->path();
+    const std::string& path = (*out)->path();
     Entries::iterator i = entries_.find(path);
     LogEntry* log_entry;
     if (i != entries_.end()) {
@@ -258,7 +257,7 @@ struct LineReader {
   char* line_end_;
 };
 
-LoadStatus BuildLog::Load(const string& path, string* err) {
+LoadStatus BuildLog::Load(const std::string& path, std::string* err) {
   METRIC_RECORD(".ninja_log load");
   FILE* file = fopen(path.c_str(), "r");
   if (!file) {
@@ -325,7 +324,7 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
     end = (char*)memchr(start, kFieldSeparator, line_end - start);
     if (!end)
       continue;
-    string output = string(start, end - start);
+    std::string output = std::string(start, end - start);
 
     start = end + 1;
     end = line_end;
@@ -374,7 +373,7 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
   return LOAD_SUCCESS;
 }
 
-BuildLog::LogEntry* BuildLog::LookupByOutput(const string& path) {
+BuildLog::LogEntry* BuildLog::LookupByOutput(const std::string& path) {
   Entries::iterator i = entries_.find(path);
   if (i != entries_.end())
     return i->second;
@@ -387,12 +386,12 @@ bool BuildLog::WriteEntry(FILE* f, const LogEntry& entry) {
           entry.output.c_str(), entry.command_hash) > 0;
 }
 
-bool BuildLog::Recompact(const string& path, const BuildLogUser& user,
-                         string* err) {
+bool BuildLog::Recompact(const std::string& path, const BuildLogUser& user,
+                         std::string* err) {
   METRIC_RECORD(".ninja_log recompact");
 
   Close();
-  string temp_path = path + ".recompact";
+  std::string temp_path = path + ".recompact";
   FILE* f = fopen(temp_path.c_str(), "wb");
   if (!f) {
     *err = strerror(errno);
@@ -405,7 +404,7 @@ bool BuildLog::Recompact(const string& path, const BuildLogUser& user,
     return false;
   }
 
-  vector<StringPiece> dead_outputs;
+  std::vector<StringPiece> dead_outputs;
   for (Entries::iterator i = entries_.begin(); i != entries_.end(); ++i) {
     if (user.IsPathDead(i->first)) {
       dead_outputs.push_back(i->first);

--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -26,7 +26,6 @@
 #include <unistd.h>
 #endif
 
-using namespace std;
 
 const char kTestFilename[] = "BuildLogPerfTest-tempfile";
 
@@ -34,7 +33,7 @@ struct NoDeadPaths : public BuildLogUser {
   virtual bool IsPathDead(StringPiece) const { return false; }
 };
 
-bool WriteTestData(string* err) {
+bool WriteTestData(std::string* err) {
   BuildLog log;
 
   NoDeadPaths no_dead_paths;
@@ -64,7 +63,7 @@ bool WriteTestData(string* err) {
 
   // ManifestParser is the only object allowed to create Rules.
   const size_t kRuleSize = 4000;
-  string long_rule_command = "gcc ";
+  std::string long_rule_command = "gcc ";
   for (int i = 0; long_rule_command.size() < kRuleSize; ++i) {
     char buf[80];
     sprintf(buf, "-I../../and/arbitrary/but/fairly/long/path/suffixed/%d ", i);
@@ -80,7 +79,7 @@ bool WriteTestData(string* err) {
   // Create build edges. Using ManifestParser is as fast as using the State api
   // for edge creation, so just use that.
   const int kNumCommands = 30000;
-  string build_rules;
+  std::string build_rules;
   for (int i = 0; i < kNumCommands; ++i) {
     char buf[80];
     sprintf(buf, "build input%d.o: cxx input%d.cc\n", i, i);
@@ -101,8 +100,8 @@ bool WriteTestData(string* err) {
 }
 
 int main() {
-  vector<int> times;
-  string err;
+  std::vector<int> times;
+  std::string err;
 
   if (!WriteTestData(&err)) {
     fprintf(stderr, "Failed to write test data: %s\n", err.c_str());

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -27,7 +27,6 @@
 #endif
 #include <cassert>
 
-using namespace std;
 
 namespace {
 
@@ -50,7 +49,7 @@ TEST_F(BuildLogTest, WriteRead) {
 "build mid: cat in\n");
 
   BuildLog log1;
-  string err;
+  std::string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
   log1.RecordCommand(state_.edges_[0], 15, 18);
@@ -77,7 +76,7 @@ TEST_F(BuildLogTest, FirstWriteAddsSignature) {
   const size_t kVersionPos = strlen(kExpectedVersion) - 2;  // Points at 'X'.
 
   BuildLog log;
-  string contents, err;
+  std::string contents, err;
 
   EXPECT_TRUE(log.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
@@ -109,7 +108,7 @@ TEST_F(BuildLogTest, DoubleEntry) {
   fprintf(f, "3\t4\t5\tout\tcommand def\n");
   fclose(f);
 
-  string err;
+  std::string err;
   BuildLog log;
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
@@ -126,7 +125,7 @@ TEST_F(BuildLogTest, Truncate) {
 
   {
     BuildLog log1;
-    string err;
+    std::string err;
     EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
     ASSERT_EQ("", err);
     log1.RecordCommand(state_.edges_[0], 15, 18);
@@ -142,7 +141,7 @@ TEST_F(BuildLogTest, Truncate) {
   // crash when parsing.
   for (off_t size = statbuf.st_size; size > 0; --size) {
     BuildLog log2;
-    string err;
+    std::string err;
     EXPECT_TRUE(log2.OpenForWrite(kTestFilename, *this, &err));
     ASSERT_EQ("", err);
     log2.RecordCommand(state_.edges_[0], 15, 18);
@@ -163,10 +162,10 @@ TEST_F(BuildLogTest, ObsoleteOldVersion) {
   fprintf(f, "123 456 0 out command\n");
   fclose(f);
 
-  string err;
+  std::string err;
   BuildLog log;
   EXPECT_TRUE(log.Load(kTestFilename, &err));
-  ASSERT_NE(err.find("version"), string::npos);
+  ASSERT_NE(err.find("version"), std::string::npos);
 }
 
 TEST_F(BuildLogTest, SpacesInOutputV4) {
@@ -175,7 +174,7 @@ TEST_F(BuildLogTest, SpacesInOutputV4) {
   fprintf(f, "123\t456\t456\tout with space\tcommand\n");
   fclose(f);
 
-  string err;
+  std::string err;
   BuildLog log;
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
@@ -199,7 +198,7 @@ TEST_F(BuildLogTest, DuplicateVersionHeader) {
   fprintf(f, "456\t789\t789\tout2\tcommand2\n");
   fclose(f);
 
-  string err;
+  std::string err;
   BuildLog log;
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
@@ -220,22 +219,22 @@ TEST_F(BuildLogTest, DuplicateVersionHeader) {
 }
 
 struct TestDiskInterface : public DiskInterface {
-  virtual TimeStamp Stat(const string& path, string* err) const {
+  virtual TimeStamp Stat(const std::string& path, std::string* err) const {
     return 4;
   }
-  virtual bool WriteFile(const string& path, const string& contents) {
+  virtual bool WriteFile(const std::string& path, const std::string& contents) {
     assert(false);
     return true;
   }
-  virtual bool MakeDir(const string& path) {
+  virtual bool MakeDir(const std::string& path) {
     assert(false);
     return false;
   }
-  virtual Status ReadFile(const string& path, string* contents, string* err) {
+  virtual Status ReadFile(const std::string& path, std::string* contents, std::string* err) {
     assert(false);
     return NotFound;
   }
-  virtual int RemoveFile(const string& path) {
+  virtual int RemoveFile(const std::string& path) {
     assert(false);
     return 0;
   }
@@ -279,7 +278,7 @@ TEST_F(BuildLogTest, VeryLongInputLine) {
   fprintf(f, "456\t789\t789\tout2\tcommand2\n");
   fclose(f);
 
-  string err;
+  std::string err;
   BuildLog log;
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
@@ -325,7 +324,7 @@ TEST_F(BuildLogRecompactTest, Recompact) {
 "build out2: cat in\n");
 
   BuildLog log1;
-  string err;
+  std::string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
   // Record the same edge several times, to trigger recompaction

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -22,7 +22,6 @@
 #include "status.h"
 #include "test.h"
 
-using namespace std;
 
 struct CompareEdgesByOutput {
   static bool cmp(const Edge* a, const Edge* b) {
@@ -39,7 +38,7 @@ struct PlanTest : public StateTestWithBuiltinRules {
   /// Because FindWork does not return Edges in any sort of predictable order,
   // provide a means to get available Edges in order and in a format which is
   // easy to write tests around.
-  void FindWorkSorted(deque<Edge*>* ret, int count) {
+  void FindWorkSorted(std::deque<Edge*>* ret, int count) {
     for (int i = 0; i < count; ++i) {
       ASSERT_TRUE(plan_.more_to_do());
       Edge* edge = plan_.FindWork();
@@ -59,7 +58,7 @@ TEST_F(PlanTest, Basic) {
 "build mid: cat in\n"));
   GetNode("mid")->MarkDirty();
   GetNode("out")->MarkDirty();
-  string err;
+  std::string err;
   EXPECT_TRUE(plan_.AddTarget(GetNode("out"), &err));
   ASSERT_EQ("", err);
   ASSERT_TRUE(plan_.more_to_do());
@@ -96,7 +95,7 @@ TEST_F(PlanTest, DoubleOutputDirect) {
   GetNode("mid2")->MarkDirty();
   GetNode("out")->MarkDirty();
 
-  string err;
+  std::string err;
   EXPECT_TRUE(plan_.AddTarget(GetNode("out"), &err));
   ASSERT_EQ("", err);
   ASSERT_TRUE(plan_.more_to_do());
@@ -128,7 +127,7 @@ TEST_F(PlanTest, DoubleOutputIndirect) {
   GetNode("b1")->MarkDirty();
   GetNode("b2")->MarkDirty();
   GetNode("out")->MarkDirty();
-  string err;
+  std::string err;
   EXPECT_TRUE(plan_.AddTarget(GetNode("out"), &err));
   ASSERT_EQ("", err);
   ASSERT_TRUE(plan_.more_to_do());
@@ -170,7 +169,7 @@ TEST_F(PlanTest, DoubleDependent) {
   GetNode("a2")->MarkDirty();
   GetNode("out")->MarkDirty();
 
-  string err;
+  std::string err;
   EXPECT_TRUE(plan_.AddTarget(GetNode("out"), &err));
   ASSERT_EQ("", err);
   ASSERT_TRUE(plan_.more_to_do());
@@ -204,7 +203,7 @@ void PlanTest::TestPoolWithDepthOne(const char* test_case) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_, test_case));
   GetNode("out1")->MarkDirty();
   GetNode("out2")->MarkDirty();
-  string err;
+  std::string err;
   EXPECT_TRUE(plan_.AddTarget(GetNode("out1"), &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(plan_.AddTarget(GetNode("out2"), &err));
@@ -280,23 +279,23 @@ TEST_F(PlanTest, PoolsWithDepthTwo) {
 ));
   // Mark all the out* nodes dirty
   for (int i = 0; i < 3; ++i) {
-    GetNode("out" + string(1, '1' + static_cast<char>(i)))->MarkDirty();
-    GetNode("outb" + string(1, '1' + static_cast<char>(i)))->MarkDirty();
+    GetNode("out" + std::string(1, '1' + static_cast<char>(i)))->MarkDirty();
+    GetNode("outb" + std::string(1, '1' + static_cast<char>(i)))->MarkDirty();
   }
   GetNode("allTheThings")->MarkDirty();
 
-  string err;
+  std::string err;
   EXPECT_TRUE(plan_.AddTarget(GetNode("allTheThings"), &err));
   ASSERT_EQ("", err);
 
-  deque<Edge*> edges;
+  std::deque<Edge*> edges;
   FindWorkSorted(&edges, 5);
 
   for (int i = 0; i < 4; ++i) {
     Edge *edge = edges[i];
     ASSERT_EQ("in",  edge->inputs_[0]->path());
-    string base_name(i < 2 ? "out" : "outb");
-    ASSERT_EQ(base_name + string(1, '1' + (i % 2)), edge->outputs_[0]->path());
+    std::string base_name(i < 2 ? "out" : "outb");
+    ASSERT_EQ(base_name + std::string(1, '1' + (i % 2)), edge->outputs_[0]->path());
   }
 
   // outb3 is exempt because it has an empty pool
@@ -323,7 +322,7 @@ TEST_F(PlanTest, PoolsWithDepthTwo) {
 
   ASSERT_FALSE(plan_.FindWork());
 
-  for (deque<Edge*>::iterator it = edges.begin(); it != edges.end(); ++it) {
+  for (std::deque<Edge*>::iterator it = edges.begin(); it != edges.end(); ++it) {
     plan_.EdgeFinished(*it, Plan::kEdgeSucceeded, &err);
     ASSERT_EQ("", err);
   }
@@ -363,14 +362,14 @@ TEST_F(PlanTest, PoolWithRedundantEdges) {
   GetNode("bar.cpp.obj")->MarkDirty();
   GetNode("libfoo.a")->MarkDirty();
   GetNode("all")->MarkDirty();
-  string err;
+  std::string err;
   EXPECT_TRUE(plan_.AddTarget(GetNode("all"), &err));
   ASSERT_EQ("", err);
   ASSERT_TRUE(plan_.more_to_do());
 
   Edge* edge = NULL;
 
-  deque<Edge*> initial_edges;
+  std::deque<Edge*> initial_edges;
   FindWorkSorted(&initial_edges, 2);
 
   edge = initial_edges[1];  // Foo first
@@ -434,7 +433,7 @@ TEST_F(PlanTest, PoolWithFailingEdge) {
     "build out2: poolcat in\n"));
   GetNode("out1")->MarkDirty();
   GetNode("out2")->MarkDirty();
-  string err;
+  std::string err;
   EXPECT_TRUE(plan_.AddTarget(GetNode("out1"), &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(plan_.AddTarget(GetNode("out2"), &err));
@@ -476,11 +475,11 @@ struct FakeCommandRunner : public CommandRunner {
   virtual bool CanRunMore() const;
   virtual bool StartCommand(Edge* edge);
   virtual bool WaitForCommand(Result* result);
-  virtual vector<Edge*> GetActiveEdges();
+  virtual std::vector<Edge*> GetActiveEdges();
   virtual void Abort();
 
-  vector<string> commands_ran_;
-  vector<Edge*> active_edges_;
+  std::vector<std::string> commands_ran_;
+  std::vector<Edge*> active_edges_;
   size_t max_active_edges_;
   VirtualFileSystem* fs_;
 };
@@ -516,12 +515,12 @@ struct BuildTest : public StateTestWithBuiltinRules, public BuildLogUser {
   /// Rebuild target in the 'working tree' (fs_).
   /// State of command_runner_ and logs contents (if specified) ARE MODIFIED.
   /// Handy to check for NOOP builds, and higher-level rebuild tests.
-  void RebuildTarget(const string& target, const char* manifest,
+  void RebuildTarget(const std::string& target, const char* manifest,
                      const char* log_path = NULL, const char* deps_path = NULL,
                      State* state = NULL);
 
   // Mark a path dirty.
-  void Dirty(const string& path);
+  void Dirty(const std::string& path);
 
   BuildConfig MakeConfig() {
     BuildConfig config;
@@ -536,7 +535,7 @@ struct BuildTest : public StateTestWithBuiltinRules, public BuildLogUser {
   Builder builder_;
 };
 
-void BuildTest::RebuildTarget(const string& target, const char* manifest,
+void BuildTest::RebuildTarget(const std::string& target, const char* manifest,
                               const char* log_path, const char* deps_path,
                               State* state) {
   State local_state, *pstate = &local_state;
@@ -545,7 +544,7 @@ void BuildTest::RebuildTarget(const string& target, const char* manifest,
   ASSERT_NO_FATAL_FAILURE(AddCatRule(pstate));
   AssertParse(pstate, manifest);
 
-  string err;
+  std::string err;
   BuildLog build_log, *pbuild_log = NULL;
   if (log_path) {
     ASSERT_TRUE(build_log.Load(log_path, &err));
@@ -592,7 +591,7 @@ bool FakeCommandRunner::StartCommand(Edge* edge) {
       edge->rule().name() == "touch" ||
       edge->rule().name() == "touch-interrupt" ||
       edge->rule().name() == "touch-fail-tick2") {
-    for (vector<Node*>::iterator out = edge->outputs_.begin();
+    for (std::vector<Node*>::iterator out = edge->outputs_.begin();
          out != edge->outputs_.end(); ++out) {
       fs_->Create((*out)->path(), "");
     }
@@ -604,48 +603,48 @@ bool FakeCommandRunner::StartCommand(Edge* edge) {
   } else if (edge->rule().name() == "cp") {
     assert(!edge->inputs_.empty());
     assert(edge->outputs_.size() == 1);
-    string content;
-    string err;
+    std::string content;
+    std::string err;
     if (fs_->ReadFile(edge->inputs_[0]->path(), &content, &err) ==
         DiskInterface::Okay)
       fs_->WriteFile(edge->outputs_[0]->path(), content);
   } else if (edge->rule().name() == "touch-implicit-dep-out") {
-    string dep = edge->GetBinding("test_dependency");
+    std::string dep = edge->GetBinding("test_dependency");
     fs_->Tick();
     fs_->Create(dep, "");
     fs_->Tick();
-    for (vector<Node*>::iterator out = edge->outputs_.begin();
+    for (std::vector<Node*>::iterator out = edge->outputs_.begin();
          out != edge->outputs_.end(); ++out) {
       fs_->Create((*out)->path(), "");
     }
   } else if (edge->rule().name() == "touch-out-implicit-dep") {
-    string dep = edge->GetBinding("test_dependency");
-    for (vector<Node*>::iterator out = edge->outputs_.begin();
+    std::string dep = edge->GetBinding("test_dependency");
+    for (std::vector<Node*>::iterator out = edge->outputs_.begin();
          out != edge->outputs_.end(); ++out) {
       fs_->Create((*out)->path(), "");
     }
     fs_->Tick();
     fs_->Create(dep, "");
   } else if (edge->rule().name() == "generate-depfile") {
-    string dep = edge->GetBinding("test_dependency");
+    std::string dep = edge->GetBinding("test_dependency");
     bool touch_dep = edge->GetBindingBool("touch_dependency");
-    string depfile = edge->GetUnescapedDepfile();
+    std::string depfile = edge->GetUnescapedDepfile();
     if (touch_dep) {
       fs_->Tick();
       fs_->Create(dep, "");
     }
-    string contents;
-    for (vector<Node*>::iterator out = edge->outputs_.begin();
+    std::string contents;
+    for (std::vector<Node*>::iterator out = edge->outputs_.begin();
          out != edge->outputs_.end(); ++out) {
       contents += (*out)->path() + ": " + dep + "\n";
       fs_->Create((*out)->path(), "");
     }
     fs_->Create(depfile, contents);
   } else if (edge->rule().name() == "long-cc") {
-    string dep = edge->GetBinding("test_dependency");
-    string depfile = edge->GetUnescapedDepfile();
-    string contents;
-    for (vector<Node*>::iterator out = edge->outputs_.begin();
+    std::string dep = edge->GetBinding("test_dependency");
+    std::string depfile = edge->GetUnescapedDepfile();
+    std::string contents;
+    for (std::vector<Node*>::iterator out = edge->outputs_.begin();
         out != edge->outputs_.end(); ++out) {
       fs_->Tick();
       fs_->Tick();
@@ -676,7 +675,7 @@ bool FakeCommandRunner::WaitForCommand(Result* result) {
   // All active edges were already completed immediately when started,
   // so we can pick any edge here.  Pick the last edge.  Tests can
   // control the order of edges by the name of the first output.
-  vector<Edge*>::iterator edge_iter = active_edges_.end() - 1;
+  std::vector<Edge*>::iterator edge_iter = active_edges_.end() - 1;
 
   Edge* edge = *edge_iter;
   result->edge = edge;
@@ -715,7 +714,7 @@ bool FakeCommandRunner::WaitForCommand(Result* result) {
   // Note: only the first and third time the rule is run per test is the file modified, so
   // the test can verify that subsequent runs without the race have no work to do.
   if (edge->rule().name() == "long-cc") {
-    string dep = edge->GetBinding("test_dependency");
+    std::string dep = edge->GetBinding("test_dependency");
     if (fs_->now_ == 4)
       fs_->files_[dep].mtime = 3;
     if (fs_->now_ == 10)
@@ -725,10 +724,10 @@ bool FakeCommandRunner::WaitForCommand(Result* result) {
   // Provide a way for test cases to verify when an edge finishes that
   // some other edge is still active.  This is useful for test cases
   // covering behavior involving multiple active edges.
-  const string& verify_active_edge = edge->GetBinding("verify_active_edge");
+  const std::string& verify_active_edge = edge->GetBinding("verify_active_edge");
   if (!verify_active_edge.empty()) {
     bool verify_active_edge_found = false;
-    for (vector<Edge*>::iterator i = active_edges_.begin();
+    for (std::vector<Edge*>::iterator i = active_edges_.begin();
          i != active_edges_.end(); ++i) {
       if (!(*i)->outputs_.empty() &&
           (*i)->outputs_[0]->path() == verify_active_edge) {
@@ -742,7 +741,7 @@ bool FakeCommandRunner::WaitForCommand(Result* result) {
   return true;
 }
 
-vector<Edge*> FakeCommandRunner::GetActiveEdges() {
+std::vector<Edge*> FakeCommandRunner::GetActiveEdges() {
   return active_edges_;
 }
 
@@ -750,7 +749,7 @@ void FakeCommandRunner::Abort() {
   active_edges_.clear();
 }
 
-void BuildTest::Dirty(const string& path) {
+void BuildTest::Dirty(const std::string& path) {
   Node* node = GetNode(path);
   node->MarkDirty();
 
@@ -761,7 +760,7 @@ void BuildTest::Dirty(const string& path) {
 }
 
 TEST_F(BuildTest, NoWork) {
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AlreadyUpToDate());
 }
 
@@ -769,7 +768,7 @@ TEST_F(BuildTest, OneStep) {
   // Given a dirty target with one ready input,
   // we should rebuild the target.
   Dirty("cat1");
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("cat1", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -783,7 +782,7 @@ TEST_F(BuildTest, OneStep2) {
   // Given a target with one dirty input,
   // we should rebuild the target.
   Dirty("cat1");
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("cat1", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -794,7 +793,7 @@ TEST_F(BuildTest, OneStep2) {
 }
 
 TEST_F(BuildTest, TwoStep) {
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("cat12", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -832,7 +831,7 @@ TEST_F(BuildTest, TwoOutputs) {
 
   fs_.Create("in.txt", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out1", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -848,7 +847,7 @@ TEST_F(BuildTest, ImplicitOutput) {
 "build out | out.imp: touch in.txt\n"));
   fs_.Create("in.txt", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out.imp", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -870,7 +869,7 @@ TEST_F(BuildTest, MultiOutIn) {
   fs_.Tick();
   fs_.Create("in1", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -886,7 +885,7 @@ TEST_F(BuildTest, Chain) {
 
   fs_.Create("c1", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("c5", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -915,7 +914,7 @@ TEST_F(BuildTest, Chain) {
 
 TEST_F(BuildTest, MissingInput) {
   // Input is referenced by build file, but no rule for it.
-  string err;
+  std::string err;
   Dirty("in1");
   EXPECT_FALSE(builder_.AddTarget("cat1", &err));
   EXPECT_EQ("'in1', needed by 'cat1', missing and no known rule to make it",
@@ -924,21 +923,21 @@ TEST_F(BuildTest, MissingInput) {
 
 TEST_F(BuildTest, MissingTarget) {
   // Target is not referenced by build file.
-  string err;
+  std::string err;
   EXPECT_FALSE(builder_.AddTarget("meow", &err));
   EXPECT_EQ("unknown target: 'meow'", err);
 }
 
 TEST_F(BuildTest, MissingInputTarget) {
   // Target is a missing input file
-  string err;
+  std::string err;
   Dirty("in1");
   EXPECT_FALSE(builder_.AddTarget("in1", &err));
   EXPECT_EQ("'in1' missing and no known rule to make it", err);
 }
 
 TEST_F(BuildTest, MakeDirs) {
-  string err;
+  std::string err;
 
 #ifdef _WIN32
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
@@ -958,7 +957,7 @@ TEST_F(BuildTest, MakeDirs) {
 }
 
 TEST_F(BuildTest, DepFileMissing) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule cc\n  command = cc $in\n  depfile = $out.d\n"
 "build fo$ o.o: cc foo.c\n"));
@@ -971,7 +970,7 @@ TEST_F(BuildTest, DepFileMissing) {
 }
 
 TEST_F(BuildTest, DepFileOK) {
-  string err;
+  std::string err;
   int orig_edges = state_.edges_.size();
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule cc\n  command = cc $in\n  depfile = $out.d\n"
@@ -997,7 +996,7 @@ TEST_F(BuildTest, DepFileOK) {
 }
 
 TEST_F(BuildTest, DepFileParseError) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule cc\n  command = cc $in\n  depfile = $out.d\n"
 "build foo.o: cc foo.c\n"));
@@ -1008,7 +1007,7 @@ TEST_F(BuildTest, DepFileParseError) {
 }
 
 TEST_F(BuildTest, EncounterReadyTwice) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule touch\n"
 "  command = touch $out\n"
@@ -1016,7 +1015,7 @@ TEST_F(BuildTest, EncounterReadyTwice) {
 "build b: touch || c\n"
 "build a: touch | b || c\n"));
 
-  vector<Edge*> c_out = GetNode("c")->out_edges();
+  std::vector<Edge*> c_out = GetNode("c")->out_edges();
   ASSERT_EQ(2u, c_out.size());
   EXPECT_EQ("b", c_out[0]->outputs_[0]->path());
   EXPECT_EQ("a", c_out[1]->outputs_[0]->path());
@@ -1030,8 +1029,8 @@ TEST_F(BuildTest, EncounterReadyTwice) {
   ASSERT_EQ(2u, command_runner_.commands_ran_.size());
 }
 
-TEST_F(BuildTest, OrderOnlyDeps) {
-  string err;
+TEST_F(BuildTest, OrderOnlyDeps)
+{
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule cc\n  command = cc $in\n  depfile = $out.d\n"
 "build foo.o: cc foo.c || otherfile\n"));
@@ -1040,8 +1039,12 @@ TEST_F(BuildTest, OrderOnlyDeps) {
   fs_.Create("foo.c", "");
   fs_.Create("otherfile", "");
   fs_.Create("foo.o.d", "foo.o: blah.h bar.h\n");
-  EXPECT_TRUE(builder_.AddTarget("foo.o", &err));
-  ASSERT_EQ("", err);
+
+  {
+      std::string err;
+      EXPECT_TRUE(builder_.AddTarget("foo.o", &err));
+      ASSERT_EQ("", err);
+  }
 
   // One explicit, two implicit, one order only.
   ASSERT_EQ(4u, edge->inputs_.size());
@@ -1058,8 +1061,11 @@ TEST_F(BuildTest, OrderOnlyDeps) {
   ASSERT_EQ("cc foo.c", edge->EvaluateCommand());
 
   // explicit dep dirty, expect a rebuild.
-  EXPECT_TRUE(builder_.Build(&err));
-  ASSERT_EQ("", err);
+  {
+      std::string err;
+      EXPECT_TRUE(builder_.Build(&err));
+      ASSERT_EQ("", err);
+  }
   ASSERT_EQ(1u, command_runner_.commands_ran_.size());
 
   fs_.Tick();
@@ -1072,9 +1078,12 @@ TEST_F(BuildTest, OrderOnlyDeps) {
   fs_.Create("bar.h", "");
   command_runner_.commands_ran_.clear();
   state_.Reset();
-  EXPECT_TRUE(builder_.AddTarget("foo.o", &err));
-  EXPECT_TRUE(builder_.Build(&err));
-  ASSERT_EQ("", err);
+  {
+      std::string err;
+      EXPECT_TRUE(builder_.AddTarget("foo.o", &err));
+      EXPECT_TRUE(builder_.Build(&err));
+      ASSERT_EQ("", err);
+  }
   ASSERT_EQ(1u, command_runner_.commands_ran_.size());
 
   fs_.Tick();
@@ -1086,22 +1095,29 @@ TEST_F(BuildTest, OrderOnlyDeps) {
   fs_.Create("otherfile", "");
   command_runner_.commands_ran_.clear();
   state_.Reset();
-  EXPECT_TRUE(builder_.AddTarget("foo.o", &err));
-  EXPECT_EQ("", err);
+
+  {
+      std::string err;
+      EXPECT_TRUE(builder_.AddTarget("foo.o", &err));
+      EXPECT_EQ("", err);
+  }
   EXPECT_TRUE(builder_.AlreadyUpToDate());
 
   // implicit dep missing, expect rebuild.
   fs_.RemoveFile("bar.h");
   command_runner_.commands_ran_.clear();
   state_.Reset();
-  EXPECT_TRUE(builder_.AddTarget("foo.o", &err));
-  EXPECT_TRUE(builder_.Build(&err));
-  ASSERT_EQ("", err);
+  {
+      std::string err;
+      EXPECT_TRUE(builder_.AddTarget("foo.o", &err));
+      EXPECT_TRUE(builder_.Build(&err));
+      ASSERT_EQ("", err);
+  }
   ASSERT_EQ(1u, command_runner_.commands_ran_.size());
 }
 
 TEST_F(BuildTest, RebuildOrderOnlyDeps) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule cc\n  command = cc $in\n"
 "rule true\n  command = true\n"
@@ -1149,7 +1165,7 @@ TEST_F(BuildTest, RebuildOrderOnlyDeps) {
 
 #ifdef _WIN32
 TEST_F(BuildTest, DepFileCanonicalize) {
-  string err;
+  std::string err;
   int orig_edges = state_.edges_.size();
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule cc\n  command = cc $in\n  depfile = $out.d\n"
@@ -1180,7 +1196,7 @@ TEST_F(BuildTest, DepFileCanonicalize) {
 #endif
 
 TEST_F(BuildTest, Phony) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "build out: cat bar.cc\n"
 "build all: phony out\n"));
@@ -1197,7 +1213,7 @@ TEST_F(BuildTest, Phony) {
 }
 
 TEST_F(BuildTest, PhonyNoWork) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "build out: cat bar.cc\n"
 "build all: phony out\n"));
@@ -1213,7 +1229,7 @@ TEST_F(BuildTest, PhonyNoWork) {
 // ninja 1.7 and below tolerated and CMake 2.8.12.x and 3.0.x both
 // incorrectly produce it.  We tolerate it for compatibility.
 TEST_F(BuildTest, PhonySelfReference) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "build a: phony a\n"));
 
@@ -1248,7 +1264,7 @@ void TestPhonyUseCase(BuildTest* t, int i) {
   FakeCommandRunner& command_runner_ = t->command_runner_;
   VirtualFileSystem& fs_ = t->fs_;
 
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule touch\n"
 " command = touch $out\n"
@@ -1288,7 +1304,7 @@ void TestPhonyUseCase(BuildTest* t, int i) {
   EXPECT_TRUE(builder_.Build(&err));
   ASSERT_EQ("", err);
 
-  string ci;
+  std::string ci;
   ci += static_cast<char>('0' + i);
 
   // Tests 1, 3, 4, and 6 should rebuild when the input is updated.
@@ -1321,7 +1337,7 @@ void TestPhonyUseCase(BuildTest* t, int i) {
     EXPECT_TRUE(builder_.Build(&err));
     ASSERT_EQ("", err);
     ASSERT_EQ(1u, command_runner_.commands_ran_.size());
-    EXPECT_EQ(string("touch test") + ci, command_runner_.commands_ran_[0]);
+    EXPECT_EQ(std::string("touch test") + ci, command_runner_.commands_ran_[0]);
     EXPECT_TRUE(builder_.AlreadyUpToDate());
 
     TimeStamp inputTime = inputNode->mtime();
@@ -1374,7 +1390,7 @@ TEST_F(BuildTest, Fail) {
 "  command = fail\n"
 "build out1: fail\n"));
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out1", &err));
   ASSERT_EQ("", err);
 
@@ -1395,7 +1411,7 @@ TEST_F(BuildTest, SwallowFailures) {
   // Swallow two failures, die on the third.
   config_.failures_allowed = 3;
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("all", &err));
   ASSERT_EQ("", err);
 
@@ -1416,7 +1432,7 @@ TEST_F(BuildTest, SwallowFailuresLimit) {
   // Swallow ten failures; we should stop before building final.
   config_.failures_allowed = 11;
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("final", &err));
   ASSERT_EQ("", err);
 
@@ -1440,7 +1456,7 @@ TEST_F(BuildTest, SwallowFailuresPool) {
   // Swallow ten failures; we should stop before building final.
   config_.failures_allowed = 11;
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("final", &err));
   ASSERT_EQ("", err);
 
@@ -1492,7 +1508,7 @@ TEST_F(BuildWithLogTest, ImplicitGeneratedOutOfDate) {
   fs_.Tick();
   fs_.Create("in", "");
 
-  string err;
+  std::string err;
 
   EXPECT_TRUE(builder_.AddTarget("out.imp", &err));
   EXPECT_FALSE(builder_.AlreadyUpToDate());
@@ -1513,7 +1529,7 @@ TEST_F(BuildWithLogTest, ImplicitGeneratedOutOfDate2) {
   fs_.Create("inimp2", "");
   fs_.Tick();
 
-  string err;
+  std::string err;
 
   EXPECT_TRUE(builder_.AddTarget("out.imp", &err));
   EXPECT_FALSE(builder_.AlreadyUpToDate());
@@ -1564,7 +1580,7 @@ TEST_F(BuildWithLogTest, NotInLogButOnDisk) {
   // not considering the command line hash.
   fs_.Create("in", "");
   fs_.Create("out1", "");
-  string err;
+  std::string err;
 
   // Because it's not in the log, it should not be up-to-date until
   // we build again.
@@ -1585,7 +1601,7 @@ TEST_F(BuildWithLogTest, RebuildAfterFailure) {
 "  command = touch-fail-tick2\n"
 "build out1: touch-fail-tick2 in\n"));
 
-  string err;
+  std::string err;
 
   fs_.Create("in", "");
 
@@ -1631,7 +1647,7 @@ TEST_F(BuildWithLogTest, RebuildWithNoInputs) {
 "build out1: touch\n"
 "build out2: touch in\n"));
 
-  string err;
+  std::string err;
 
   fs_.Create("in", "");
 
@@ -1678,7 +1694,7 @@ TEST_F(BuildWithLogTest, RestatTest) {
   // Do a pre-build so that there's commands in the log for the outputs,
   // otherwise, the lack of an entry in the build log will cause out3 to rebuild
   // regardless of restat.
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out3", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -1740,7 +1756,7 @@ TEST_F(BuildWithLogTest, RestatMissingFile) {
   // Do a pre-build so that there's commands in the log for the outputs,
   // otherwise, the lack of an entry in the build log will cause out2 to rebuild
   // regardless of restat.
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out2", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -1776,7 +1792,7 @@ TEST_F(BuildWithLogTest, RestatSingleDependentOutputDirty) {
   // Create the necessary files
   fs_.Create("in", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out4", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -1825,7 +1841,7 @@ TEST_F(BuildWithLogTest, RestatMissingInput) {
   fs_.Create("restat.file", "");
 
   // Run the build, out1 and out2 get built
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out2", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -1869,7 +1885,7 @@ TEST_F(BuildWithLogTest, RestatInputChangesDueToRule) {
   // log should be the time the command completes, not the time the command started. One
   // of out1's discovered dependencies will have a newer mtime than when out1 started
   // running, due to its command touching the dependency itself.
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out1", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -1911,7 +1927,7 @@ TEST_F(BuildWithLogTest, GeneratedPlainDepfileMtime) {
   fs_.Create("inimp", "");
   fs_.Tick();
 
-  string err;
+  std::string err;
 
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_FALSE(builder_.AlreadyUpToDate());
@@ -1956,7 +1972,7 @@ TEST_F(BuildDryRun, AllCommandsShown) {
 
   // "cc" touches out1, so we should build out2.  But because "true" does not
   // touch out2, we should cancel the build of out3.
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out3", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -1991,7 +2007,7 @@ TEST_F(BuildTest, RspFileSuccess)
 
   fs_.Create("in", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out1", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.AddTarget("out2", &err));
@@ -2032,7 +2048,7 @@ TEST_F(BuildTest, RspFileFailure) {
   fs_.Tick();
   fs_.Create("in", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
 
@@ -2072,7 +2088,7 @@ TEST_F(BuildWithLogTest, RspFileCmdLineChange) {
   fs_.Tick();
   fs_.Create("in", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
 
@@ -2120,7 +2136,7 @@ TEST_F(BuildTest, InterruptCleanup) {
   fs_.Create("in2", "");
 
   // An untouched output of an interrupted command should be retained.
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out1", &err));
   EXPECT_EQ("", err);
   EXPECT_FALSE(builder_.Build(&err));
@@ -2139,7 +2155,7 @@ TEST_F(BuildTest, InterruptCleanup) {
 }
 
 TEST_F(BuildTest, StatFailureAbortsBuild) {
-  const string kTooLongToStat(400, 'i');
+  const std::string kTooLongToStat(400, 'i');
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 ("build " + kTooLongToStat + ": cat in\n").c_str()));
   fs_.Create("in", "");
@@ -2148,7 +2164,7 @@ TEST_F(BuildTest, StatFailureAbortsBuild) {
   fs_.files_[kTooLongToStat].mtime = -1;
   fs_.files_[kTooLongToStat].stat_error = "stat failed";
 
-  string err;
+  std::string err;
   EXPECT_FALSE(builder_.AddTarget(kTooLongToStat, &err));
   EXPECT_EQ("stat failed", err);
 }
@@ -2163,7 +2179,7 @@ TEST_F(BuildTest, PhonyWithNoInputs) {
 
   // out1 should be up to date even though its input is dirty, because its
   // order-only dependency has nothing to do.
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out1", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.AlreadyUpToDate());
@@ -2187,7 +2203,7 @@ TEST_F(BuildTest, DepsGccWithEmptyDepfileErrorsOut) {
 "build out: cc\n"));
   Dirty("out");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
   EXPECT_FALSE(builder_.AlreadyUpToDate());
@@ -2215,7 +2231,7 @@ TEST_F(BuildTest, FailedDepsParse) {
 "  deps = gcc\n"
 "  depfile = in1.d\n"));
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("bad_deps.o", &err));
   ASSERT_EQ("", err);
 
@@ -2460,7 +2476,7 @@ struct BuildWithDepsLogTest : public BuildTest {
 
 /// Run a straightforward build where the deps log is used.
 TEST_F(BuildWithDepsLogTest, Straightforward) {
-  string err;
+  std::string err;
   // Note: in1 was created by the superclass SetUp().
   const char* manifest =
       "build out: cat in1\n"
@@ -2527,7 +2543,7 @@ TEST_F(BuildWithDepsLogTest, Straightforward) {
 /// 2) Move input/output to time t+1 -- despite files in alignment,
 ///    should still need to rebuild due to deps at older time.
 TEST_F(BuildWithDepsLogTest, ObsoleteDeps) {
-  string err;
+  std::string err;
   // Note: in1 was created by the superclass SetUp().
   const char* manifest =
       "build out: cat in1\n"
@@ -2616,7 +2632,7 @@ TEST_F(BuildWithDepsLogTest, DepsIgnoredInDryRun) {
   builder.command_runner_.reset(&command_runner_);
   command_runner_.commands_ran_.clear();
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder.AddTarget("out", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder.Build(&err));
@@ -2626,7 +2642,7 @@ TEST_F(BuildWithDepsLogTest, DepsIgnoredInDryRun) {
 }
 
 TEST_F(BuildWithDepsLogTest, TestInputMtimeRaceCondition) {
-  string err;
+  std::string err;
   const char* manifest =
       "rule long-cc\n"
       "  command = long-cc\n"
@@ -2705,7 +2721,7 @@ TEST_F(BuildWithDepsLogTest, TestInputMtimeRaceCondition) {
 }
 
 TEST_F(BuildWithDepsLogTest, TestInputMtimeRaceConditionWithDepFile) {
-  string err;
+  std::string err;
   const char* manifest =
       "rule long-cc\n"
       "  command = long-cc\n"
@@ -2844,7 +2860,7 @@ TEST_F(BuildTest, RestatDepfileDependency) {
   fs_.Tick();
   fs_.Create("header.in", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -2854,7 +2870,7 @@ TEST_F(BuildTest, RestatDepfileDependency) {
 /// Check that a restat rule generating a header cancels compilations correctly,
 /// depslog case.
 TEST_F(BuildWithDepsLogTest, RestatDepfileDependencyDepsLog) {
-  string err;
+  std::string err;
   // Note: in1 was created by the superclass SetUp().
   const char* manifest =
       "rule true\n"
@@ -2917,7 +2933,7 @@ TEST_F(BuildWithDepsLogTest, RestatDepfileDependencyDepsLog) {
 }
 
 TEST_F(BuildWithDepsLogTest, DepFileOKDepsLog) {
-  string err;
+  std::string err;
   const char* manifest =
       "rule cc\n  command = cc $in\n  depfile = $out.d\n  deps = gcc\n"
       "build fo$ o.o: cc foo.c\n";
@@ -2978,7 +2994,7 @@ TEST_F(BuildWithDepsLogTest, DepFileOKDepsLog) {
 }
 
 TEST_F(BuildWithDepsLogTest, DiscoveredDepDuringBuildChanged) {
-  string err;
+  std::string err;
   const char* manifest =
     "rule touch-out-implicit-dep\n"
     "  command = touch $out ; sleep 1 ; touch $test_dependency\n"
@@ -3063,7 +3079,7 @@ TEST_F(BuildWithDepsLogTest, DiscoveredDepDuringBuildChanged) {
 
 #ifdef _WIN32
 TEST_F(BuildWithDepsLogTest, DepFileDepsLogCanonicalize) {
-  string err;
+  std::string err;
   const char* manifest =
       "rule cc\n  command = cc $in\n  depfile = $out.d\n  deps = gcc\n"
       "build a/b\\c\\d/e/fo$ o.o: cc x\\y/z\\foo.c\n";
@@ -3154,7 +3170,7 @@ const char* manifest =
 /// Check that a restat rule doesn't clear an edge if the deps are missing.
 /// https://github.com/ninja-build/ninja/issues/603
 TEST_F(BuildWithDepsLogTest, RestatMissingDepfileDepslog) {
-  string err;
+  std::string err;
   const char* manifest =
 "rule true\n"
 "  command = true\n"  // Would be "write if out-of-date" in reality.
@@ -3204,7 +3220,7 @@ TEST_F(BuildWithDepsLogTest, RestatMissingDepfileDepslog) {
 }
 
 TEST_F(BuildTest, WrongOutputInDepfileCausesRebuild) {
-  string err;
+  std::string err;
   const char* manifest =
 "rule cc\n"
 "  command = cc $in\n"
@@ -3229,7 +3245,7 @@ TEST_F(BuildTest, Console) {
 
   fs_.Create("in.txt", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("cons", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -3247,7 +3263,7 @@ TEST_F(BuildTest, DyndepMissingAndNoRule) {
 "  dyndep = dd\n"
 ));
 
-  string err;
+  std::string err;
   EXPECT_FALSE(builder_.AddTarget("out", &err));
   EXPECT_EQ("loading 'dd': No such file or directory", err);
 }
@@ -3270,7 +3286,7 @@ TEST_F(BuildTest, DyndepReadyImplicitConnection) {
 "build tmp | tmp.imp: dyndep\n"
 );
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -3293,7 +3309,7 @@ TEST_F(BuildTest, DyndepReadySyntaxError) {
 "build out: dyndep\n"
 );
 
-  string err;
+  std::string err;
   EXPECT_FALSE(builder_.AddTarget("out", &err));
   EXPECT_EQ("dd:1: expected 'ninja_dyndep_version = ...'\n", err);
 }
@@ -3314,7 +3330,7 @@ TEST_F(BuildTest, DyndepReadyCircular) {
   );
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_FALSE(builder_.AddTarget("out", &err));
   EXPECT_EQ("dependency cycle: circ -> in -> circ", err);
 }
@@ -3335,7 +3351,7 @@ TEST_F(BuildTest, DyndepBuild) {
 "build out: dyndep\n"
 );
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -3371,7 +3387,7 @@ TEST_F(BuildTest, DyndepBuildSyntaxError) {
 "build out: dyndep\n"
 );
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -3399,7 +3415,7 @@ TEST_F(BuildTest, DyndepBuildUnrelatedOutput) {
   fs_.Tick();
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -3431,7 +3447,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverNewOutput) {
   fs_.Tick();
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -3464,7 +3480,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverNewOutputWithMultipleRules1) {
   fs_.Create("out1", "");
   fs_.Create("out2", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out1", &err));
   EXPECT_TRUE(builder_.AddTarget("out2", &err));
   EXPECT_EQ("", err);
@@ -3504,7 +3520,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverNewOutputWithMultipleRules2) {
   fs_.Create("out1", "");
   fs_.Create("out2", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out1", &err));
   EXPECT_TRUE(builder_.AddTarget("out2", &err));
   EXPECT_EQ("", err);
@@ -3533,7 +3549,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverNewInput) {
   fs_.Tick();
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -3562,13 +3578,13 @@ TEST_F(BuildTest, DyndepBuildDiscoverNewInputWithValidation) {
 "build out: dyndep |@ validation\n"
 );
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
   EXPECT_FALSE(builder_.Build(&err));
 
-  string err_first_line = err.substr(0, err.find("\n"));
+  std::string err_first_line = err.substr(0, err.find("\n"));
   EXPECT_EQ("dd:2: expected newline, got '|@'", err_first_line);
 }
 
@@ -3593,7 +3609,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverNewInputWithTransitiveValidation) {
   fs_.Tick();
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -3627,7 +3643,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverImplicitConnection) {
 "build tmp | tmp.imp: dyndep\n"
 );
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -3659,7 +3675,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverOutputAndDepfileInput) {
 "build tmp | tmp.imp: dyndep\n"
 );
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
 
@@ -3702,7 +3718,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverNowWantEdge) {
 "build tmp | tmp.imp: dyndep\n"
 );
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -3733,7 +3749,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverNowWantEdgeAndDependent) {
 "build tmp | tmp.imp: dyndep\n"
 );
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -3767,7 +3783,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverCircular) {
   );
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -3804,7 +3820,7 @@ TEST_F(BuildWithLogTest, DyndepBuildDiscoverRestat) {
   // Do a pre-build so that there's commands in the log for the outputs,
   // otherwise, the lack of an entry in the build log will cause "out2" to
   // rebuild regardless of restat.
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out2", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -3860,7 +3876,7 @@ TEST_F(BuildTest, DyndepBuildDiscoverScheduledEdge) {
   // also produced by the active edge.  The builder should not
   // re-schedule the already-active edge.
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out1", &err));
   EXPECT_TRUE(builder_.AddTarget("out2", &err));
   ASSERT_EQ("", err);
@@ -3912,7 +3928,7 @@ TEST_F(BuildTest, DyndepTwoLevelDirect) {
   // on dd1 has been satisfied).  This test case verifies that each dyndep
   // file is loaded to update the build graph independently.
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out2", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -3957,7 +3973,7 @@ TEST_F(BuildTest, DyndepTwoLevelIndirect) {
   // recognize that out2 needs to be built even though it was originally
   // clean without dyndep info.
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out2", &err));
   ASSERT_EQ("", err);
   EXPECT_TRUE(builder_.Build(&err));
@@ -3996,7 +4012,7 @@ TEST_F(BuildTest, DyndepTwoLevelDiscoveredReady) {
   fs_.Tick();
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -4036,7 +4052,7 @@ TEST_F(BuildTest, DyndepTwoLevelDiscoveredDirty) {
   fs_.Tick();
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -4058,7 +4074,7 @@ TEST_F(BuildTest, Validation) {
   fs_.Create("in", "");
   fs_.Create("in2", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -4110,7 +4126,7 @@ TEST_F(BuildTest, ValidationDependsOnOutput) {
   fs_.Create("in", "");
   fs_.Create("in2", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -4160,7 +4176,7 @@ TEST_F(BuildWithDepsLogTest, ValidationThroughDepfile) {
       "  deps = gcc\n"
       "  depfile = out2.d\n";
 
-  string err;
+  std::string err;
 
   {
     fs_.Create("in", "");
@@ -4239,7 +4255,7 @@ TEST_F(BuildTest, ValidationCircular) {
   fs_.Create("in", "");
   fs_.Create("in2", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   EXPECT_EQ("", err);
 
@@ -4289,7 +4305,7 @@ TEST_F(BuildTest, ValidationWithCircularDependency) {
 
   fs_.Create("in", "");
 
-  string err;
+  std::string err;
   EXPECT_FALSE(builder_.AddTarget("out", &err));
   EXPECT_EQ("dependency cycle: validate -> validate_in -> validate", err);
 }

--- a/src/canon_perftest.cc
+++ b/src/canon_perftest.cc
@@ -18,14 +18,13 @@
 #include "util.h"
 #include "metrics.h"
 
-using namespace std;
 
 const char kPath[] =
     "../../third_party/WebKit/Source/WebCore/"
     "platform/leveldb/LevelDBWriteBatch.cpp";
 
 int main() {
-  vector<int> times;
+  std::vector<int> times;
 
   char buf[200];
   size_t len = strlen(kPath);

--- a/src/clean.cc
+++ b/src/clean.cc
@@ -22,7 +22,6 @@
 #include "state.h"
 #include "util.h"
 
-using namespace std;
 
 Cleaner::Cleaner(State* state,
                  const BuildConfig& config,
@@ -35,25 +34,25 @@ Cleaner::Cleaner(State* state,
     status_(0) {
 }
 
-int Cleaner::RemoveFile(const string& path) {
+int Cleaner::RemoveFile(const std::string& path) {
   return disk_interface_->RemoveFile(path);
 }
 
-bool Cleaner::FileExists(const string& path) {
-  string err;
+bool Cleaner::FileExists(const std::string& path) {
+  std::string err;
   TimeStamp mtime = disk_interface_->Stat(path, &err);
   if (mtime == -1)
     Error("%s", err.c_str());
   return mtime > 0;  // Treat Stat() errors as "file does not exist".
 }
 
-void Cleaner::Report(const string& path) {
+void Cleaner::Report(const std::string& path) {
   ++cleaned_files_count_;
   if (IsVerbose())
     printf("Remove %s\n", path.c_str());
 }
 
-void Cleaner::Remove(const string& path) {
+void Cleaner::Remove(const std::string& path) {
   if (!IsAlreadyRemoved(path)) {
     removed_.insert(path);
     if (config_.dry_run) {
@@ -69,17 +68,17 @@ void Cleaner::Remove(const string& path) {
   }
 }
 
-bool Cleaner::IsAlreadyRemoved(const string& path) {
-  set<string>::iterator i = removed_.find(path);
+bool Cleaner::IsAlreadyRemoved(const std::string& path) {
+  std::set<std::string>::iterator i = removed_.find(path);
   return (i != removed_.end());
 }
 
 void Cleaner::RemoveEdgeFiles(Edge* edge) {
-  string depfile = edge->GetUnescapedDepfile();
+  std::string depfile = edge->GetUnescapedDepfile();
   if (!depfile.empty())
     Remove(depfile);
 
-  string rspfile = edge->GetUnescapedRspfile();
+  std::string rspfile = edge->GetUnescapedRspfile();
   if (!rspfile.empty())
     Remove(rspfile);
 }
@@ -105,7 +104,7 @@ int Cleaner::CleanAll(bool generator) {
   Reset();
   PrintHeader();
   LoadDyndeps();
-  for (vector<Edge*>::iterator e = state_->edges_.begin();
+  for (std::vector<Edge*>::iterator e = state_->edges_.begin();
        e != state_->edges_.end(); ++e) {
     // Do not try to remove phony targets
     if ((*e)->is_phony())
@@ -113,7 +112,7 @@ int Cleaner::CleanAll(bool generator) {
     // Do not remove generator's files unless generator specified.
     if (!generator && (*e)->GetBindingBool("generator"))
       continue;
-    for (vector<Node*>::iterator out_node = (*e)->outputs_.begin();
+    for (std::vector<Node*>::iterator out_node = (*e)->outputs_.begin();
          out_node != (*e)->outputs_.end(); ++out_node) {
       Remove((*out_node)->path());
     }
@@ -153,7 +152,7 @@ void Cleaner::DoCleanTarget(Node* target) {
       Remove(target->path());
       RemoveEdgeFiles(e);
     }
-    for (vector<Node*>::iterator n = e->inputs_.begin(); n != e->inputs_.end();
+    for (std::vector<Node*>::iterator n = e->inputs_.begin(); n != e->inputs_.end();
          ++n) {
       Node* next = *n;
       // call DoCleanTarget recursively if this node has not been visited
@@ -197,7 +196,7 @@ int Cleaner::CleanTargets(int target_count, char* targets[]) {
   PrintHeader();
   LoadDyndeps();
   for (int i = 0; i < target_count; ++i) {
-    string target_name = targets[i];
+    std::string target_name = targets[i];
     if (target_name.empty()) {
       Error("failed to canonicalize '': empty path");
       status_ = 1;
@@ -222,10 +221,10 @@ int Cleaner::CleanTargets(int target_count, char* targets[]) {
 void Cleaner::DoCleanRule(const Rule* rule) {
   assert(rule);
 
-  for (vector<Edge*>::iterator e = state_->edges_.begin();
+  for (std::vector<Edge*>::iterator e = state_->edges_.begin();
        e != state_->edges_.end(); ++e) {
     if ((*e)->rule().name() == rule->name()) {
-      for (vector<Node*>::iterator out_node = (*e)->outputs_.begin();
+      for (std::vector<Node*>::iterator out_node = (*e)->outputs_.begin();
            out_node != (*e)->outputs_.end(); ++out_node) {
         Remove((*out_node)->path());
         RemoveEdgeFiles(*e);
@@ -290,7 +289,7 @@ void Cleaner::Reset() {
 
 void Cleaner::LoadDyndeps() {
   // Load dyndep files that exist, before they are cleaned.
-  for (vector<Edge*>::iterator e = state_->edges_.begin();
+  for (std::vector<Edge*>::iterator e = state_->edges_.begin();
        e != state_->edges_.end(); ++e) {
     if (Node* dyndep = (*e)->dyndep_) {
       // Capture and ignore errors loading the dyndep file.

--- a/src/clean_test.cc
+++ b/src/clean_test.cc
@@ -22,7 +22,6 @@
 #include <unistd.h>
 #endif
 
-using namespace std;
 
 namespace {
 
@@ -55,7 +54,7 @@ TEST_F(CleanTest, CleanAll) {
   EXPECT_EQ(4u, fs_.files_removed_.size());
 
   // Check they are removed.
-  string err;
+  std::string err;
   EXPECT_EQ(0, fs_.Stat("in1", &err));
   EXPECT_EQ(0, fs_.Stat("out1", &err));
   EXPECT_EQ(0, fs_.Stat("in2", &err));
@@ -87,7 +86,7 @@ TEST_F(CleanTest, CleanAllDryRun) {
   EXPECT_EQ(0u, fs_.files_removed_.size());
 
   // Check they are not removed.
-  string err;
+  std::string err;
   EXPECT_LT(0, fs_.Stat("in1", &err));
   EXPECT_LT(0, fs_.Stat("out1", &err));
   EXPECT_LT(0, fs_.Stat("in2", &err));
@@ -118,7 +117,7 @@ TEST_F(CleanTest, CleanTarget) {
   EXPECT_EQ(2u, fs_.files_removed_.size());
 
   // Check they are removed.
-  string err;
+  std::string err;
   EXPECT_EQ(0, fs_.Stat("in1", &err));
   EXPECT_EQ(0, fs_.Stat("out1", &err));
   EXPECT_LT(0, fs_.Stat("in2", &err));
@@ -150,7 +149,7 @@ TEST_F(CleanTest, CleanTargetDryRun) {
   EXPECT_EQ(0u, fs_.files_removed_.size());
 
   // Check they are not removed.
-  string err;
+  std::string err;
   EXPECT_LT(0, fs_.Stat("in1", &err));
   EXPECT_LT(0, fs_.Stat("out1", &err));
   EXPECT_LT(0, fs_.Stat("in2", &err));
@@ -183,7 +182,7 @@ TEST_F(CleanTest, CleanRule) {
   EXPECT_EQ(2u, fs_.files_removed_.size());
 
   // Check they are removed.
-  string err;
+  std::string err;
   EXPECT_EQ(0, fs_.Stat("in1", &err));
   EXPECT_LT(0, fs_.Stat("out1", &err));
   EXPECT_EQ(0, fs_.Stat("in2", &err));
@@ -217,7 +216,7 @@ TEST_F(CleanTest, CleanRuleDryRun) {
   EXPECT_EQ(0u, fs_.files_removed_.size());
 
   // Check they are not removed.
-  string err;
+  std::string err;
   EXPECT_LT(0, fs_.Stat("in1", &err));
   EXPECT_LT(0, fs_.Stat("out1", &err));
   EXPECT_LT(0, fs_.Stat("in2", &err));
@@ -318,7 +317,7 @@ TEST_F(CleanTest, CleanDyndep) {
   EXPECT_EQ(2, cleaner.cleaned_files_count());
   EXPECT_EQ(2u, fs_.files_removed_.size());
 
-  string err;
+  std::string err;
   EXPECT_EQ(0, fs_.Stat("out", &err));
   EXPECT_EQ(0, fs_.Stat("out.imp", &err));
 }
@@ -340,7 +339,7 @@ TEST_F(CleanTest, CleanDyndepMissing) {
   EXPECT_EQ(1, cleaner.cleaned_files_count());
   EXPECT_EQ(1u, fs_.files_removed_.size());
 
-  string err;
+  std::string err;
   EXPECT_EQ(0, fs_.Stat("out", &err));
   EXPECT_EQ(1, fs_.Stat("out.imp", &err));
 }
@@ -394,7 +393,7 @@ TEST_F(CleanTest, CleanRsp) {
   EXPECT_EQ(6u, fs_.files_removed_.size());
 
   // Check they are removed.
-  string err;
+  std::string err;
   EXPECT_EQ(0, fs_.Stat("in1", &err));
   EXPECT_EQ(0, fs_.Stat("out1", &err));
   EXPECT_EQ(0, fs_.Stat("in2", &err));
@@ -412,7 +411,7 @@ TEST_F(CleanTest, CleanFailure) {
 }
 
 TEST_F(CleanTest, CleanPhony) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "build phony: phony t1 t2\n"
 "build t1: cat\n"
@@ -459,7 +458,7 @@ TEST_F(CleanTest, CleanDepFileAndRspFileWithSpaces) {
   EXPECT_EQ(4, cleaner.cleaned_files_count());
   EXPECT_EQ(4u, fs_.files_removed_.size());
 
-  string err;
+  std::string err;
   EXPECT_EQ(0, fs_.Stat("out 1", &err));
   EXPECT_EQ(0, fs_.Stat("out 2", &err));
   EXPECT_EQ(0, fs_.Stat("out 1.d", &err));
@@ -494,7 +493,7 @@ TEST_F(CleanDeadTest, CleanDead) {
   fs_.Create("out2", "");
 
   BuildLog log1;
-  string err;
+  std::string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
   log1.RecordCommand(state.edges_[0], 15, 18);
@@ -557,7 +556,7 @@ TEST_F(CleanDeadTest, CleanDeadPreservesInputs) {
   fs_.Create("out2", "");
 
   BuildLog log1;
-  string err;
+  std::string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
   log1.RecordCommand(state.edges_[0], 15, 18);

--- a/src/clparser.cc
+++ b/src/clparser.cc
@@ -28,12 +28,11 @@
 #include "util.h"
 #endif
 
-using namespace std;
 
 namespace {
 
 /// Return true if \a input ends with \a needle.
-bool EndsWith(const string& input, const string& needle) {
+bool EndsWith(const std::string& input, const std::string& needle) {
   return (input.size() >= needle.size() &&
           input.substr(input.size() - needle.size()) == needle);
 }
@@ -41,12 +40,12 @@ bool EndsWith(const string& input, const string& needle) {
 }  // anonymous namespace
 
 // static
-string CLParser::FilterShowIncludes(const string& line,
-                                    const string& deps_prefix) {
-  const string kDepsPrefixEnglish = "Note: including file: ";
+std::string CLParser::FilterShowIncludes(const std::string& line,
+                                    const std::string& deps_prefix) {
+  const std::string kDepsPrefixEnglish = "Note: including file: ";
   const char* in = line.c_str();
   const char* end = in + line.size();
-  const string& prefix = deps_prefix.empty() ? kDepsPrefixEnglish : deps_prefix;
+  const std::string& prefix = deps_prefix.empty() ? kDepsPrefixEnglish : deps_prefix;
   if (end - in > (int)prefix.size() &&
       memcmp(in, prefix.c_str(), (int)prefix.size()) == 0) {
     in += prefix.size();
@@ -58,15 +57,15 @@ string CLParser::FilterShowIncludes(const string& line,
 }
 
 // static
-bool CLParser::IsSystemInclude(string path) {
+bool CLParser::IsSystemInclude(std::string path) {
   transform(path.begin(), path.end(), path.begin(), ToLowerASCII);
   // TODO: this is a heuristic, perhaps there's a better way?
-  return (path.find("program files") != string::npos ||
-          path.find("microsoft visual studio") != string::npos);
+  return (path.find("program files") != std::string::npos ||
+          path.find("microsoft visual studio") != std::string::npos);
 }
 
 // static
-bool CLParser::FilterInputFilename(string line) {
+bool CLParser::FilterInputFilename(std::string line) {
   transform(line.begin(), line.end(), line.begin(), ToLowerASCII);
   // TODO: other extensions, like .asm?
   return EndsWith(line, ".c") ||
@@ -77,8 +76,8 @@ bool CLParser::FilterInputFilename(string line) {
 }
 
 // static
-bool CLParser::Parse(const string& output, const string& deps_prefix,
-                     string* filtered_output, string* err) {
+bool CLParser::Parse(const std::string& output, const std::string& deps_prefix,
+                     std::string* filtered_output, std::string* err) {
   METRIC_RECORD("CLParser::Parse");
 
   // Loop over all lines in the output to process them.
@@ -91,14 +90,14 @@ bool CLParser::Parse(const string& output, const string& deps_prefix,
 
   while (start < output.size()) {
     size_t end = output.find_first_of("\r\n", start);
-    if (end == string::npos)
+    if (end == std::string::npos)
       end = output.size();
-    string line = output.substr(start, end - start);
+    std::string line = output.substr(start, end - start);
 
-    string include = FilterShowIncludes(line, deps_prefix);
+    std::string include = FilterShowIncludes(line, deps_prefix);
     if (!include.empty()) {
       seen_show_includes = true;
-      string normalized;
+      std::string normalized;
 #ifdef _WIN32
       if (!normalizer.Normalize(include, &normalized, err))
         return false;

--- a/src/clparser_perftest.cc
+++ b/src/clparser_perftest.cc
@@ -18,11 +18,10 @@
 #include "clparser.h"
 #include "metrics.h"
 
-using namespace std;
 
 int main(int argc, char* argv[]) {
   // Output of /showIncludes from #include <iostream>
-  string perf_testdata =
+  std::string perf_testdata =
       "Note: including file: C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE\\iostream\r\n"
       "Note: including file:  C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE\\istream\r\n"
       "Note: including file:   C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE\\ostream\r\n"
@@ -136,8 +135,8 @@ int main(int argc, char* argv[]) {
   for (int limit = 1 << 10; limit < (1<<20); limit *= 2) {
     int64_t start = GetTimeMillis();
     for (int rep = 0; rep < limit; ++rep) {
-      string output;
-      string err;
+      std::string output;
+      std::string err;
 
       CLParser parser;
       if (!parser.Parse(perf_testdata, "", &output, &err)) {

--- a/src/clparser_test.cc
+++ b/src/clparser_test.cc
@@ -17,7 +17,6 @@
 #include "test.h"
 #include "util.h"
 
-using namespace std;
 
 TEST(CLParserTest, ShowIncludes) {
   ASSERT_EQ("", CLParser::FilterShowIncludes("", ""));
@@ -48,7 +47,8 @@ TEST(CLParserTest, FilterInputFilename) {
 
 TEST(CLParserTest, ParseSimple) {
   CLParser parser;
-  string output, err;
+  std::string output;
+  std::string err;
   ASSERT_TRUE(parser.Parse(
       "foo\r\n"
       "Note: inc file prefix:  foo.h\r\n"
@@ -62,7 +62,8 @@ TEST(CLParserTest, ParseSimple) {
 
 TEST(CLParserTest, ParseFilenameFilter) {
   CLParser parser;
-  string output, err;
+  std::string output;
+  std::string err;
   ASSERT_TRUE(parser.Parse(
       "foo.cc\r\n"
       "cl: warning\r\n",
@@ -72,7 +73,7 @@ TEST(CLParserTest, ParseFilenameFilter) {
 
 TEST(CLParserTest, NoFilenameFilterAfterShowIncludes) {
   CLParser parser;
-  string output, err;
+  std::string output, err;
   ASSERT_TRUE(parser.Parse(
       "foo.cc\r\n"
       "Note: including file: foo.h\r\n"
@@ -83,7 +84,8 @@ TEST(CLParserTest, NoFilenameFilterAfterShowIncludes) {
 
 TEST(CLParserTest, ParseSystemInclude) {
   CLParser parser;
-  string output, err;
+  std::string output;
+  std::string err;
   ASSERT_TRUE(parser.Parse(
       "Note: including file: c:\\Program Files\\foo.h\r\n"
       "Note: including file: d:\\Microsoft Visual Studio\\bar.h\r\n"
@@ -98,7 +100,8 @@ TEST(CLParserTest, ParseSystemInclude) {
 
 TEST(CLParserTest, DuplicatedHeader) {
   CLParser parser;
-  string output, err;
+  std::string output;
+  std::string err;
   ASSERT_TRUE(parser.Parse(
       "Note: including file: foo.h\r\n"
       "Note: including file: bar.h\r\n"
@@ -111,7 +114,8 @@ TEST(CLParserTest, DuplicatedHeader) {
 
 TEST(CLParserTest, DuplicatedHeaderPathConverted) {
   CLParser parser;
-  string output, err;
+  std::string output;
+  std::string err;
 
   // This isn't inline in the Parse() call below because the #ifdef in
   // a macro expansion would confuse MSVC2013's preprocessor.

--- a/src/depfile_parser.cc
+++ b/src/depfile_parser.cc
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 
-using namespace std;
 
 DepfileParser::DepfileParser(DepfileParserOptions options)
   : options_(options)
@@ -45,7 +44,7 @@ DepfileParser::DepfileParser(DepfileParserOptions options)
 //
 // If anyone actually has depfiles that rely on the more complicated
 // behavior we can adjust this.
-bool DepfileParser::Parse(string* content, string* err) {
+bool DepfileParser::Parse(std::string* content, std::string* err) {
   // in: current parser input point.
   // end: end of input.
   // parsing_targets: whether we are parsing targets or dependencies.

--- a/src/depfile_parser.in.cc
+++ b/src/depfile_parser.in.cc
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 
-using namespace std;
 
 DepfileParser::DepfileParser(DepfileParserOptions options)
   : options_(options)
@@ -44,7 +43,7 @@ DepfileParser::DepfileParser(DepfileParserOptions options)
 //
 // If anyone actually has depfiles that rely on the more complicated
 // behavior we can adjust this.
-bool DepfileParser::Parse(string* content, string* err) {
+bool DepfileParser::Parse(std::string* content, std::string* err) {
   // in: current parser input point.
   // end: end of input.
   // parsing_targets: whether we are parsing targets or dependencies.

--- a/src/depfile_parser_perftest.cc
+++ b/src/depfile_parser_perftest.cc
@@ -19,7 +19,6 @@
 #include "util.h"
 #include "metrics.h"
 
-using namespace std;
 
 int main(int argc, char* argv[]) {
   if (argc < 2) {
@@ -27,15 +26,15 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  vector<float> times;
+  std::vector<float> times;
   for (int i = 1; i < argc; ++i) {
     const char* filename = argv[i];
 
     for (int limit = 1 << 10; limit < (1<<20); limit *= 2) {
       int64_t start = GetTimeMillis();
       for (int rep = 0; rep < limit; ++rep) {
-        string buf;
-        string err;
+        std::string buf;
+        std::string err;
         if (ReadFile(filename, &buf, &err) < 0) {
           printf("%s: %s\n", filename, err.c_str());
           return 1;

--- a/src/depfile_parser_test.cc
+++ b/src/depfile_parser_test.cc
@@ -16,22 +16,21 @@
 
 #include "test.h"
 
-using namespace std;
 
 struct DepfileParserTest : public testing::Test {
-  bool Parse(const char* input, string* err);
+  bool Parse(const char* input, std::string* err);
 
   DepfileParser parser_;
-  string input_;
+  std::string input_;
 };
 
-bool DepfileParserTest::Parse(const char* input, string* err) {
+bool DepfileParserTest::Parse(const char* input, std::string* err) {
   input_ = input;
   return parser_.Parse(&input_, err);
 }
 
 TEST_F(DepfileParserTest, Basic) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(
 "build/ninja.o: ninja.cc ninja.h eval_env.h manifest_parser.h\n",
       &err));
@@ -42,7 +41,7 @@ TEST_F(DepfileParserTest, Basic) {
 }
 
 TEST_F(DepfileParserTest, EarlyNewlineAndWhitespace) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(
 " \\\n"
 "  out: in\n",
@@ -51,7 +50,7 @@ TEST_F(DepfileParserTest, EarlyNewlineAndWhitespace) {
 }
 
 TEST_F(DepfileParserTest, Continuation) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(
 "foo.o: \\\n"
 "  bar.h baz.h\n",
@@ -63,7 +62,7 @@ TEST_F(DepfileParserTest, Continuation) {
 }
 
 TEST_F(DepfileParserTest, CarriageReturnContinuation) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(
 "foo.o: \\\r\n"
 "  bar.h baz.h\r\n",
@@ -75,7 +74,7 @@ TEST_F(DepfileParserTest, CarriageReturnContinuation) {
 }
 
 TEST_F(DepfileParserTest, BackSlashes) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(
 "Project\\Dir\\Build\\Release8\\Foo\\Foo.res : \\\n"
 "  Dir\\Library\\Foo.rc \\\n"
@@ -91,7 +90,7 @@ TEST_F(DepfileParserTest, BackSlashes) {
 }
 
 TEST_F(DepfileParserTest, Spaces) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(
 "a\\ bc\\ def:   a\\ b c d",
       &err));
@@ -113,7 +112,7 @@ TEST_F(DepfileParserTest, MultipleBackslashes) {
   // backslashes and the space. A single backslash before hash sign is removed.
   // Other backslashes remain untouched (including 2N backslashes followed by
   // space).
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(
 "a\\ b\\#c.h: \\\\\\\\\\  \\\\\\\\ \\\\share\\info\\\\#1",
       &err));
@@ -133,7 +132,7 @@ TEST_F(DepfileParserTest, MultipleBackslashes) {
 TEST_F(DepfileParserTest, Escapes) {
   // Put backslashes before a variety of characters, see which ones make
   // it through.
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(
 "\\!\\@\\#$$\\%\\^\\&\\[\\]\\\\:",
       &err));
@@ -182,7 +181,7 @@ TEST_F(DepfileParserTest, EscapedTargetColon)
 TEST_F(DepfileParserTest, SpecialChars) {
   // See filenames like istreambuf.iterator_op!= in
   // https://github.com/google/libcxx/tree/master/test/iterators/stream.iterators/istreambuf.iterator/
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(
 "C:/Program\\ Files\\ (x86)/Microsoft\\ crtdefs.h: \\\n"
 " en@quot.header~ t+t-x!=1 \\\n"
@@ -209,7 +208,7 @@ TEST_F(DepfileParserTest, SpecialChars) {
 
 TEST_F(DepfileParserTest, UnifyMultipleOutputs) {
   // check that multiple duplicate targets are properly unified
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse("foo foo: x y z", &err));
   ASSERT_EQ(1u, parser_.outs_.size());
   ASSERT_EQ("foo", parser_.outs_[0].AsString());
@@ -221,7 +220,7 @@ TEST_F(DepfileParserTest, UnifyMultipleOutputs) {
 
 TEST_F(DepfileParserTest, MultipleDifferentOutputs) {
   // check that multiple different outputs are accepted by the parser
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse("foo bar: x y z", &err));
   ASSERT_EQ(2u, parser_.outs_.size());
   ASSERT_EQ("foo", parser_.outs_[0].AsString());
@@ -233,7 +232,7 @@ TEST_F(DepfileParserTest, MultipleDifferentOutputs) {
 }
 
 TEST_F(DepfileParserTest, MultipleEmptyRules) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse("foo: x\n"
                     "foo: \n"
                     "foo:\n", &err));
@@ -244,7 +243,7 @@ TEST_F(DepfileParserTest, MultipleEmptyRules) {
 }
 
 TEST_F(DepfileParserTest, UnifyMultipleRulesLF) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse("foo: x\n"
                     "foo: y\n"
                     "foo \\\n"
@@ -258,7 +257,7 @@ TEST_F(DepfileParserTest, UnifyMultipleRulesLF) {
 }
 
 TEST_F(DepfileParserTest, UnifyMultipleRulesCRLF) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse("foo: x\r\n"
                     "foo: y\r\n"
                     "foo \\\r\n"
@@ -272,7 +271,7 @@ TEST_F(DepfileParserTest, UnifyMultipleRulesCRLF) {
 }
 
 TEST_F(DepfileParserTest, UnifyMixedRulesLF) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse("foo: x\\\n"
                     "     y\n"
                     "foo \\\n"
@@ -286,7 +285,7 @@ TEST_F(DepfileParserTest, UnifyMixedRulesLF) {
 }
 
 TEST_F(DepfileParserTest, UnifyMixedRulesCRLF) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse("foo: x\\\r\n"
                     "     y\r\n"
                     "foo \\\r\n"
@@ -300,7 +299,7 @@ TEST_F(DepfileParserTest, UnifyMixedRulesCRLF) {
 }
 
 TEST_F(DepfileParserTest, IndentedRulesLF) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(" foo: x\n"
                     " foo: y\n"
                     " foo: z\n", &err));
@@ -313,7 +312,7 @@ TEST_F(DepfileParserTest, IndentedRulesLF) {
 }
 
 TEST_F(DepfileParserTest, IndentedRulesCRLF) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse(" foo: x\r\n"
                     " foo: y\r\n"
                     " foo: z\r\n", &err));
@@ -326,7 +325,7 @@ TEST_F(DepfileParserTest, IndentedRulesCRLF) {
 }
 
 TEST_F(DepfileParserTest, TolerateMP) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse("foo: x y z\n"
                     "x:\n"
                     "y:\n"
@@ -340,7 +339,7 @@ TEST_F(DepfileParserTest, TolerateMP) {
 }
 
 TEST_F(DepfileParserTest, MultipleRulesTolerateMP) {
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse("foo: x\n"
                     "x:\n"
                     "foo: y\n"
@@ -358,7 +357,7 @@ TEST_F(DepfileParserTest, MultipleRulesTolerateMP) {
 TEST_F(DepfileParserTest, MultipleRulesDifferentOutputs) {
   // check that multiple different outputs are accepted by the parser
   // when spread across multiple rules
-  string err;
+  std::string err;
   EXPECT_TRUE(Parse("foo: x y\n"
                     "bar: y z\n", &err));
   ASSERT_EQ(2u, parser_.outs_.size());

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -30,7 +30,6 @@ typedef unsigned __int32 uint32_t;
 #include "state.h"
 #include "util.h"
 
-using namespace std;
 
 // The version is stored as 4 bytes after the signature and also serves as a
 // byte order mark. Signature and version combined are 16 bytes long.
@@ -45,7 +44,7 @@ DepsLog::~DepsLog() {
   Close();
 }
 
-bool DepsLog::OpenForWrite(const string& path, string* err) {
+bool DepsLog::OpenForWrite(const std::string& path, std::string* err) {
   if (needs_recompaction_) {
     if (!Recompact(path, err))
       return false;
@@ -58,7 +57,7 @@ bool DepsLog::OpenForWrite(const string& path, string* err) {
 }
 
 bool DepsLog::RecordDeps(Node* node, TimeStamp mtime,
-                         const vector<Node*>& nodes) {
+                         const std::vector<Node*>& nodes) {
   return RecordDeps(node, mtime, nodes.size(),
                     nodes.empty() ? NULL : (Node**)&nodes.front());
 }
@@ -149,7 +148,7 @@ void DepsLog::Close() {
   file_ = NULL;
 }
 
-LoadStatus DepsLog::Load(const string& path, State* state, string* err) {
+LoadStatus DepsLog::Load(const std::string& path, State* state, std::string* err) {
   METRIC_RECORD(".ninja_deps load");
   char buf[kMaxRecordSize + 1];
   FILE* f = fopen(path.c_str(), "rb");
@@ -308,11 +307,11 @@ Node* DepsLog::GetFirstReverseDepsNode(Node* node) {
   return NULL;
 }
 
-bool DepsLog::Recompact(const string& path, string* err) {
+bool DepsLog::Recompact(const std::string& path, std::string* err) {
   METRIC_RECORD(".ninja_deps recompact");
 
   Close();
-  string temp_path = path + ".recompact";
+  std::string temp_path = path + ".recompact";
 
   // OpenForWrite() opens for append.  Make sure it's not appending to a
   // left-over file from a previous recompaction attempt that crashed somehow.
@@ -324,7 +323,7 @@ bool DepsLog::Recompact(const string& path, string* err) {
 
   // Clear all known ids so that new ones can be reassigned.  The new indices
   // will refer to the ordering in new_log, not in the current log.
-  for (vector<Node*>::iterator i = nodes_.begin(); i != nodes_.end(); ++i)
+  for (std::vector<Node*>::iterator i = nodes_.begin(); i != nodes_.end(); ++i)
     (*i)->set_id(-1);
 
   // Write out all deps again.

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -23,7 +23,6 @@
 #include "util.h"
 #include "test.h"
 
-using namespace std;
 
 namespace {
 
@@ -42,12 +41,12 @@ struct DepsLogTest : public testing::Test {
 TEST_F(DepsLogTest, WriteRead) {
   State state1;
   DepsLog log1;
-  string err;
+  std::string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, &err));
   ASSERT_EQ("", err);
 
   {
-    vector<Node*> deps;
+    std::vector<Node*> deps;
     deps.push_back(state1.GetNode("foo.h", 0));
     deps.push_back(state1.GetNode("bar.h", 0));
     log1.RecordDeps(state1.GetNode("out.o", 0), 1, deps);
@@ -94,12 +93,12 @@ TEST_F(DepsLogTest, LotsOfDeps) {
 
   State state1;
   DepsLog log1;
-  string err;
+  std::string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, &err));
   ASSERT_EQ("", err);
 
   {
-    vector<Node*> deps;
+    std::vector<Node*> deps;
     for (int i = 0; i < kNumDeps; ++i) {
       char buf[32];
       sprintf(buf, "file%d.h", i);
@@ -129,11 +128,11 @@ TEST_F(DepsLogTest, DoubleEntry) {
   {
     State state;
     DepsLog log;
-    string err;
+    std::string err;
     EXPECT_TRUE(log.OpenForWrite(kTestFilename, &err));
     ASSERT_EQ("", err);
 
-    vector<Node*> deps;
+    std::vector<Node*> deps;
     deps.push_back(state.GetNode("foo.h", 0));
     deps.push_back(state.GetNode("bar.h", 0));
     log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
@@ -149,13 +148,13 @@ TEST_F(DepsLogTest, DoubleEntry) {
   {
     State state;
     DepsLog log;
-    string err;
+    std::string err;
     EXPECT_TRUE(log.Load(kTestFilename, &state, &err));
 
     EXPECT_TRUE(log.OpenForWrite(kTestFilename, &err));
     ASSERT_EQ("", err);
 
-    vector<Node*> deps;
+    std::vector<Node*> deps;
     deps.push_back(state.GetNode("foo.h", 0));
     deps.push_back(state.GetNode("bar.h", 0));
     log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
@@ -183,11 +182,11 @@ TEST_F(DepsLogTest, Recompact) {
     State state;
     ASSERT_NO_FATAL_FAILURE(AssertParse(&state, kManifest));
     DepsLog log;
-    string err;
+    std::string err;
     ASSERT_TRUE(log.OpenForWrite(kTestFilename, &err));
     ASSERT_EQ("", err);
 
-    vector<Node*> deps;
+    std::vector<Node*> deps;
     deps.push_back(state.GetNode("foo.h", 0));
     deps.push_back(state.GetNode("bar.h", 0));
     log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
@@ -211,13 +210,13 @@ TEST_F(DepsLogTest, Recompact) {
     State state;
     ASSERT_NO_FATAL_FAILURE(AssertParse(&state, kManifest));
     DepsLog log;
-    string err;
+    std::string err;
     ASSERT_TRUE(log.Load(kTestFilename, &state, &err));
 
     ASSERT_TRUE(log.OpenForWrite(kTestFilename, &err));
     ASSERT_EQ("", err);
 
-    vector<Node*> deps;
+    std::vector<Node*> deps;
     deps.push_back(state.GetNode("foo.h", 0));
     log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
     log.Close();
@@ -236,7 +235,7 @@ TEST_F(DepsLogTest, Recompact) {
     State state;
     ASSERT_NO_FATAL_FAILURE(AssertParse(&state, kManifest));
     DepsLog log;
-    string err;
+    std::string err;
     ASSERT_TRUE(log.Load(kTestFilename, &state, &err));
 
     Node* out = state.GetNode("out.o", 0);
@@ -285,7 +284,7 @@ TEST_F(DepsLogTest, Recompact) {
     State state;
     // Intentionally not parsing kManifest here.
     DepsLog log;
-    string err;
+    std::string err;
     ASSERT_TRUE(log.Load(kTestFilename, &state, &err));
 
     Node* out = state.GetNode("out.o", 0);
@@ -342,7 +341,7 @@ TEST_F(DepsLogTest, InvalidHeader) {
         fwrite(kInvalidHeaders[i], 1, strlen(kInvalidHeaders[i]), deps_log));
     ASSERT_EQ(0 ,fclose(deps_log));
 
-    string err;
+    std::string err;
     DepsLog log;
     State state;
     ASSERT_TRUE(log.Load(kTestFilename, &state, &err));
@@ -356,11 +355,11 @@ TEST_F(DepsLogTest, Truncated) {
   {
     State state;
     DepsLog log;
-    string err;
+    std::string err;
     EXPECT_TRUE(log.OpenForWrite(kTestFilename, &err));
     ASSERT_EQ("", err);
 
-    vector<Node*> deps;
+    std::vector<Node*> deps;
     deps.push_back(state.GetNode("foo.h", 0));
     deps.push_back(state.GetNode("bar.h", 0));
     log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
@@ -383,7 +382,7 @@ TEST_F(DepsLogTest, Truncated) {
   int node_count = 5;
   int deps_count = 2;
   for (int size = (int)st.st_size; size > 0; --size) {
-    string err;
+    std::string err;
     ASSERT_TRUE(Truncate(kTestFilename, size, &err));
 
     State state;
@@ -399,7 +398,7 @@ TEST_F(DepsLogTest, Truncated) {
 
     // Count how many non-NULL deps entries there are.
     int new_deps_count = 0;
-    for (vector<DepsLog::Deps*>::const_iterator i = log.deps().begin();
+    for (std::vector<DepsLog::Deps*>::const_iterator i = log.deps().begin();
          i != log.deps().end(); ++i) {
       if (*i)
         ++new_deps_count;
@@ -415,11 +414,11 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
   {
     State state;
     DepsLog log;
-    string err;
+    std::string err;
     EXPECT_TRUE(log.OpenForWrite(kTestFilename, &err));
     ASSERT_EQ("", err);
 
-    vector<Node*> deps;
+    std::vector<Node*> deps;
     deps.push_back(state.GetNode("foo.h", 0));
     deps.push_back(state.GetNode("bar.h", 0));
     log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
@@ -436,7 +435,7 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
   {
     struct stat st;
     ASSERT_EQ(0, stat(kTestFilename, &st));
-    string err;
+    std::string err;
     ASSERT_TRUE(Truncate(kTestFilename, st.st_size - 2, &err));
   }
 
@@ -444,7 +443,7 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
   {
     State state;
     DepsLog log;
-    string err;
+    std::string err;
     EXPECT_TRUE(log.Load(kTestFilename, &state, &err));
     ASSERT_EQ("premature end of file; recovering", err);
     err.clear();
@@ -456,7 +455,7 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
     ASSERT_EQ("", err);
 
     // Add a new entry.
-    vector<Node*> deps;
+    std::vector<Node*> deps;
     deps.push_back(state.GetNode("foo.h", 0));
     deps.push_back(state.GetNode("bar2.h", 0));
     log.RecordDeps(state.GetNode("out2.o", 0), 3, deps);
@@ -469,7 +468,7 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
   {
     State state;
     DepsLog log;
-    string err;
+    std::string err;
     EXPECT_TRUE(log.Load(kTestFilename, &state, &err));
 
     // The truncated entry should exist.
@@ -481,11 +480,11 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
 TEST_F(DepsLogTest, ReverseDepsNodes) {
   State state;
   DepsLog log;
-  string err;
+  std::string err;
   EXPECT_TRUE(log.OpenForWrite(kTestFilename, &err));
   ASSERT_EQ("", err);
 
-  vector<Node*> deps;
+  std::vector<Node*> deps;
   deps.push_back(state.GetNode("foo.h", 0));
   deps.push_back(state.GetNode("bar.h", 0));
   log.RecordDeps(state.GetNode("out.o", 0), 1, deps);

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -33,11 +33,10 @@
 #include "metrics.h"
 #include "util.h"
 
-using namespace std;
 
 namespace {
 
-string DirName(const string& path) {
+std::string DirName(const std::string& path) {
 #ifdef _WIN32
   static const char kPathSeparators[] = "\\/";
 #else
@@ -45,16 +44,16 @@ string DirName(const string& path) {
 #endif
   static const char* const kEnd = kPathSeparators + sizeof(kPathSeparators) - 1;
 
-  string::size_type slash_pos = path.find_last_of(kPathSeparators);
-  if (slash_pos == string::npos)
-    return string();  // Nothing to do.
+  std::string::size_type slash_pos = path.find_last_of(kPathSeparators);
+  if (slash_pos == std::string::npos)
+    return std::string();  // Nothing to do.
   while (slash_pos > 0 &&
          std::find(kPathSeparators, kEnd, path[slash_pos - 1]) != kEnd)
     --slash_pos;
   return path.substr(0, slash_pos);
 }
 
-int MakeDir(const string& path) {
+int MakeDir(const std::string& path) {
 #ifdef _WIN32
   return _mkdir(path.c_str());
 #else
@@ -73,7 +72,7 @@ TimeStamp TimeStampFromFileTime(const FILETIME& filetime) {
   return (TimeStamp)mtime - 12622770400LL * (1000000000LL / 100);
 }
 
-TimeStamp StatSingleFile(const string& path, string* err) {
+TimeStamp StatSingleFile(const std::string& path, std::string* err) {
   WIN32_FILE_ATTRIBUTE_DATA attrs;
   if (!GetFileAttributesExA(path.c_str(), GetFileExInfoStandard, &attrs)) {
     DWORD win_err = GetLastError();
@@ -95,8 +94,8 @@ bool IsWindows7OrLater() {
       &version_info, VER_MAJORVERSION | VER_MINORVERSION, comparison);
 }
 
-bool StatAllFilesInDir(const string& dir, map<string, TimeStamp>* stamps,
-                       string* err) {
+bool StatAllFilesInDir(const std::string& dir, std::map<std::string, TimeStamp>* stamps,
+                       std::string* err) {
   // FindExInfoBasic is 30% faster than FindExInfoStandard.
   static bool can_use_basic_info = IsWindows7OrLater();
   // This is not in earlier SDKs.
@@ -116,13 +115,13 @@ bool StatAllFilesInDir(const string& dir, map<string, TimeStamp>* stamps,
     return false;
   }
   do {
-    string lowername = ffd.cFileName;
+    std::string lowername = ffd.cFileName;
     if (lowername == "..") {
       // Seems to just copy the timestamp for ".." from ".", which is wrong.
       // This is the case at least on NTFS under Windows 7.
       continue;
     }
-    transform(lowername.begin(), lowername.end(), lowername.begin(), ::tolower);
+    std::transform(lowername.begin(), lowername.end(), lowername.begin(), ::tolower);
     stamps->insert(make_pair(lowername,
                              TimeStampFromFileTime(ffd.ftLastWriteTime)));
   } while (FindNextFileA(find_handle, &ffd));
@@ -135,11 +134,11 @@ bool StatAllFilesInDir(const string& dir, map<string, TimeStamp>* stamps,
 
 // DiskInterface ---------------------------------------------------------------
 
-bool DiskInterface::MakeDirs(const string& path) {
-  string dir = DirName(path);
+bool DiskInterface::MakeDirs(const std::string& path) {
+  std::string dir = DirName(path);
   if (dir.empty())
     return true;  // Reached root; assume it's there.
-  string err;
+  std::string err;
   TimeStamp mtime = Stat(dir, &err);
   if (mtime < 0) {
     Error("%s", err.c_str());
@@ -157,13 +156,13 @@ bool DiskInterface::MakeDirs(const string& path) {
 
 // RealDiskInterface -----------------------------------------------------------
 
-TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
+TimeStamp RealDiskInterface::Stat(const std::string& path, std::string* err) const {
   METRIC_RECORD("node stat");
 #ifdef _WIN32
   // MSDN: "Naming Files, Paths, and Namespaces"
   // http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
   if (!path.empty() && path[0] != '\\' && path.size() > MAX_PATH) {
-    ostringstream err_stream;
+    std::ostringstream err_stream;
     err_stream << "Stat(" << path << "): Filename longer than " << MAX_PATH
                << " characters";
     *err = err_stream.str();
@@ -172,17 +171,17 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
   if (!use_cache_)
     return StatSingleFile(path, err);
 
-  string dir = DirName(path);
-  string base(path.substr(dir.size() ? dir.size() + 1 : 0));
+  std::string dir = DirName(path);
+  std::string base(path.substr(dir.size() ? dir.size() + 1 : 0));
   if (base == "..") {
     // StatAllFilesInDir does not report any information for base = "..".
     base = ".";
     dir = path;
   }
 
-  string dir_lowercase = dir;
-  transform(dir.begin(), dir.end(), dir_lowercase.begin(), ::tolower);
-  transform(base.begin(), base.end(), base.begin(), ::tolower);
+  std::string dir_lowercase = dir;
+  std::transform(dir.begin(), dir.end(), dir_lowercase.begin(), ::tolower);
+  std::transform(base.begin(), base.end(), base.begin(), ::tolower);
 
   Cache::iterator ci = cache_.find(dir_lowercase);
   if (ci == cache_.end()) {
@@ -220,7 +219,7 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
 #endif
 }
 
-bool RealDiskInterface::WriteFile(const string& path, const string& contents) {
+bool RealDiskInterface::WriteFile(const std::string& path, const std::string& contents) {
   FILE* fp = fopen(path.c_str(), "w");
   if (fp == NULL) {
     Error("WriteFile(%s): Unable to create file. %s",
@@ -244,7 +243,7 @@ bool RealDiskInterface::WriteFile(const string& path, const string& contents) {
   return true;
 }
 
-bool RealDiskInterface::MakeDir(const string& path) {
+bool RealDiskInterface::MakeDir(const std::string& path) {
   if (::MakeDir(path) < 0) {
     if (errno == EEXIST) {
       return true;
@@ -255,9 +254,9 @@ bool RealDiskInterface::MakeDir(const string& path) {
   return true;
 }
 
-FileReader::Status RealDiskInterface::ReadFile(const string& path,
-                                               string* contents,
-                                               string* err) {
+FileReader::Status RealDiskInterface::ReadFile(const std::string& path,
+                                               std::string* contents,
+                                               std::string* err) {
   switch (::ReadFile(path, contents, err)) {
   case 0:       return Okay;
   case -ENOENT: return NotFound;
@@ -265,7 +264,7 @@ FileReader::Status RealDiskInterface::ReadFile(const string& path,
   }
 }
 
-int RealDiskInterface::RemoveFile(const string& path) {
+int RealDiskInterface::RemoveFile(const std::string& path) {
 #ifdef _WIN32
   DWORD attributes = GetFileAttributesA(path.c_str());
   if (attributes == INVALID_FILE_ATTRIBUTES) {

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -23,7 +23,6 @@
 #include "graph.h"
 #include "test.h"
 
-using namespace std;
 
 namespace {
 
@@ -49,7 +48,7 @@ struct DiskInterfaceTest : public testing::Test {
 };
 
 TEST_F(DiskInterfaceTest, StatMissingFile) {
-  string err;
+  std::string err;
   EXPECT_EQ(0, disk_.Stat("nosuchfile", &err));
   EXPECT_EQ("", err);
 
@@ -66,27 +65,27 @@ TEST_F(DiskInterfaceTest, StatMissingFile) {
 }
 
 TEST_F(DiskInterfaceTest, StatBadPath) {
-  string err;
+  std::string err;
 #ifdef _WIN32
-  string bad_path("cc:\\foo");
+  std::string bad_path("cc:\\foo");
   EXPECT_EQ(-1, disk_.Stat(bad_path, &err));
   EXPECT_NE("", err);
 #else
-  string too_long_name(512, 'x');
+  std::string too_long_name(512, 'x');
   EXPECT_EQ(-1, disk_.Stat(too_long_name, &err));
   EXPECT_NE("", err);
 #endif
 }
 
 TEST_F(DiskInterfaceTest, StatExistingFile) {
-  string err;
+  std::string err;
   ASSERT_TRUE(Touch("file"));
   EXPECT_GT(disk_.Stat("file", &err), 1);
   EXPECT_EQ("", err);
 }
 
 TEST_F(DiskInterfaceTest, StatExistingDir) {
-  string err;
+  std::string err;
   ASSERT_TRUE(disk_.MakeDir("subdir"));
   ASSERT_TRUE(disk_.MakeDir("subdir/subsubdir"));
   EXPECT_GT(disk_.Stat("..", &err), 1);
@@ -108,7 +107,7 @@ TEST_F(DiskInterfaceTest, StatExistingDir) {
 
 #ifdef _WIN32
 TEST_F(DiskInterfaceTest, StatCache) {
-  string err;
+  std::string err;
 
   ASSERT_TRUE(Touch("file1"));
   ASSERT_TRUE(Touch("fiLE2"));
@@ -156,7 +155,7 @@ TEST_F(DiskInterfaceTest, StatCache) {
   EXPECT_EQ("", err);
 
   // Test error cases.
-  string bad_path("cc:\\foo");
+  std::string bad_path("cc:\\foo");
   EXPECT_EQ(-1, disk_.Stat(bad_path, &err));
   EXPECT_NE("", err); err.clear();
   EXPECT_EQ(-1, disk_.Stat(bad_path, &err));
@@ -169,7 +168,7 @@ TEST_F(DiskInterfaceTest, StatCache) {
 #endif
 
 TEST_F(DiskInterfaceTest, ReadFile) {
-  string err;
+  std::string err;
   std::string content;
   ASSERT_EQ(DiskInterface::NotFound,
             disk_.ReadFile("foobar", &content, &err));
@@ -191,13 +190,13 @@ TEST_F(DiskInterfaceTest, ReadFile) {
 }
 
 TEST_F(DiskInterfaceTest, MakeDirs) {
-  string path = "path/with/double//slash/";
+  std::string path = "path/with/double//slash/";
   EXPECT_TRUE(disk_.MakeDirs(path));
   FILE* f = fopen((path + "a_file").c_str(), "w");
   EXPECT_TRUE(f);
   EXPECT_EQ(0, fclose(f));
 #ifdef _WIN32
-  string path2 = "another\\with\\back\\\\slashes\\";
+  std::string path2 = "another\\with\\back\\\\slashes\\";
   EXPECT_TRUE(disk_.MakeDirs(path2));
   FILE* f2 = fopen((path2 + "a_file").c_str(), "w");
   EXPECT_TRUE(f2);
@@ -232,32 +231,32 @@ struct StatTest : public StateTestWithBuiltinRules,
   StatTest() : scan_(&state_, NULL, NULL, this, NULL) {}
 
   // DiskInterface implementation.
-  virtual TimeStamp Stat(const string& path, string* err) const;
-  virtual bool WriteFile(const string& path, const string& contents) {
+  virtual TimeStamp Stat(const std::string& path, std::string* err) const;
+  virtual bool WriteFile(const std::string& path, const std::string& contents) {
     assert(false);
     return true;
   }
-  virtual bool MakeDir(const string& path) {
+  virtual bool MakeDir(const std::string& path) {
     assert(false);
     return false;
   }
-  virtual Status ReadFile(const string& path, string* contents, string* err) {
+  virtual Status ReadFile(const std::string& path, std::string* contents, std::string* err) {
     assert(false);
     return NotFound;
   }
-  virtual int RemoveFile(const string& path) {
+  virtual int RemoveFile(const std::string& path) {
     assert(false);
     return 0;
   }
 
   DependencyScan scan_;
-  map<string, TimeStamp> mtimes_;
-  mutable vector<string> stats_;
+  std::map<std::string, TimeStamp> mtimes_;
+  mutable std::vector<std::string> stats_;
 };
 
-TimeStamp StatTest::Stat(const string& path, string* err) const {
+TimeStamp StatTest::Stat(const std::string& path, std::string* err) const {
   stats_.push_back(path);
-  map<string, TimeStamp>::const_iterator i = mtimes_.find(path);
+  std::map<std::string, TimeStamp>::const_iterator i = mtimes_.find(path);
   if (i == mtimes_.end())
     return 0;  // File not found.
   return i->second;
@@ -268,7 +267,7 @@ TEST_F(StatTest, Simple) {
 "build out: cat in\n"));
 
   Node* out = GetNode("out");
-  string err;
+  std::string err;
   EXPECT_TRUE(out->Stat(this, &err));
   EXPECT_EQ("", err);
   ASSERT_EQ(1u, stats_.size());
@@ -284,7 +283,7 @@ TEST_F(StatTest, TwoStep) {
 "build mid: cat in\n"));
 
   Node* out = GetNode("out");
-  string err;
+  std::string err;
   EXPECT_TRUE(out->Stat(this, &err));
   EXPECT_EQ("", err);
   ASSERT_EQ(1u, stats_.size());
@@ -304,7 +303,7 @@ TEST_F(StatTest, Tree) {
 "build mid2: cat in21 in22\n"));
 
   Node* out = GetNode("out");
-  string err;
+  std::string err;
   EXPECT_TRUE(out->Stat(this, &err));
   EXPECT_EQ("", err);
   ASSERT_EQ(1u, stats_.size());
@@ -325,7 +324,7 @@ TEST_F(StatTest, Middle) {
   mtimes_["out"] = 1;
 
   Node* out = GetNode("out");
-  string err;
+  std::string err;
   EXPECT_TRUE(out->Stat(this, &err));
   EXPECT_EQ("", err);
   ASSERT_EQ(1u, stats_.size());

--- a/src/dyndep.cc
+++ b/src/dyndep.cc
@@ -24,7 +24,6 @@
 #include "state.h"
 #include "util.h"
 
-using namespace std;
 
 bool DyndepLoader::LoadDyndeps(Node* node, std::string* err) const {
   DyndepFile ddf;

--- a/src/dyndep_parser.cc
+++ b/src/dyndep_parser.cc
@@ -22,7 +22,6 @@
 #include "util.h"
 #include "version.h"
 
-using namespace std;
 
 DyndepParser::DyndepParser(State* state, FileReader* file_reader,
                            DyndepFile* dyndep_file)
@@ -30,8 +29,8 @@ DyndepParser::DyndepParser(State* state, FileReader* file_reader,
     , dyndep_file_(dyndep_file) {
 }
 
-bool DyndepParser::Parse(const string& filename, const string& input,
-                         string* err) {
+bool DyndepParser::Parse(const std::string& filename, const std::string& input,
+                         std::string* err) {
   lexer_.Start(filename, input);
 
   // Require a supported ninja_dyndep_version value immediately so
@@ -51,7 +50,7 @@ bool DyndepParser::Parse(const string& filename, const string& input,
     case Lexer::IDENT: {
       lexer_.UnreadToken();
       if (haveDyndepVersion)
-        return lexer_.Error(string("unexpected ") + Lexer::TokenName(token),
+        return lexer_.Error(std::string("unexpected ") + Lexer::TokenName(token),
                             err);
       if (!ParseDyndepVersion(err))
         return false;
@@ -67,33 +66,33 @@ bool DyndepParser::Parse(const string& filename, const string& input,
     case Lexer::NEWLINE:
       break;
     default:
-      return lexer_.Error(string("unexpected ") + Lexer::TokenName(token),
+      return lexer_.Error(std::string("unexpected ") + Lexer::TokenName(token),
                           err);
     }
   }
   return false;  // not reached
 }
 
-bool DyndepParser::ParseDyndepVersion(string* err) {
-  string name;
+bool DyndepParser::ParseDyndepVersion(std::string* err) {
+  std::string name;
   EvalString let_value;
   if (!ParseLet(&name, &let_value, err))
     return false;
   if (name != "ninja_dyndep_version") {
     return lexer_.Error("expected 'ninja_dyndep_version = ...'", err);
   }
-  string version = let_value.Evaluate(&env_);
+  std::string version = let_value.Evaluate(&env_);
   int major, minor;
   ParseVersion(version, &major, &minor);
   if (major != 1 || minor != 0) {
     return lexer_.Error(
-      string("unsupported 'ninja_dyndep_version = ") + version + "'", err);
+      std::string("unsupported 'ninja_dyndep_version = ") + version + "'", err);
     return false;
   }
   return true;
 }
 
-bool DyndepParser::ParseLet(string* key, EvalString* value, string* err) {
+bool DyndepParser::ParseLet(std::string* key, EvalString* value, std::string* err) {
   if (!lexer_.ReadIdent(key))
     return lexer_.Error("expected variable name", err);
   if (!ExpectToken(Lexer::EQUALS, err))
@@ -103,7 +102,7 @@ bool DyndepParser::ParseLet(string* key, EvalString* value, string* err) {
   return true;
 }
 
-bool DyndepParser::ParseEdge(string* err) {
+bool DyndepParser::ParseEdge(std::string* err) {
   // Parse one explicit output.  We expect it to already have an edge.
   // We will record its dynamically-discovered dependency information.
   Dyndeps* dyndeps = NULL;
@@ -114,7 +113,7 @@ bool DyndepParser::ParseEdge(string* err) {
     if (out0.empty())
       return lexer_.Error("expected path", err);
 
-    string path = out0.Evaluate(&env_);
+    std::string path = out0.Evaluate(&env_);
     if (path.empty())
       return lexer_.Error("empty path", err);
     uint64_t slash_bits;
@@ -140,7 +139,7 @@ bool DyndepParser::ParseEdge(string* err) {
   }
 
   // Parse implicit outputs, if any.
-  vector<EvalString> outs;
+  std::vector<EvalString> outs;
   if (lexer_.PeekToken(Lexer::PIPE)) {
     for (;;) {
       EvalString out;
@@ -155,7 +154,7 @@ bool DyndepParser::ParseEdge(string* err) {
   if (!ExpectToken(Lexer::COLON, err))
     return false;
 
-  string rule_name;
+  std::string rule_name;
   if (!lexer_.ReadIdent(&rule_name) || rule_name != "dyndep")
     return lexer_.Error("expected build command name 'dyndep'", err);
 
@@ -169,7 +168,7 @@ bool DyndepParser::ParseEdge(string* err) {
   }
 
   // Parse implicit inputs, if any.
-  vector<EvalString> ins;
+  std::vector<EvalString> ins;
   if (lexer_.PeekToken(Lexer::PIPE)) {
     for (;;) {
       EvalString in;
@@ -189,19 +188,19 @@ bool DyndepParser::ParseEdge(string* err) {
     return false;
 
   if (lexer_.PeekToken(Lexer::INDENT)) {
-    string key;
+    std::string key;
     EvalString val;
     if (!ParseLet(&key, &val, err))
       return false;
     if (key != "restat")
       return lexer_.Error("binding is not 'restat'", err);
-    string value = val.Evaluate(&env_);
+    std::string value = val.Evaluate(&env_);
     dyndeps->restat_ = !value.empty();
   }
 
   dyndeps->implicit_inputs_.reserve(ins.size());
-  for (vector<EvalString>::iterator i = ins.begin(); i != ins.end(); ++i) {
-    string path = i->Evaluate(&env_);
+  for (std::vector<EvalString>::iterator i = ins.begin(); i != ins.end(); ++i) {
+    std::string path = i->Evaluate(&env_);
     if (path.empty())
       return lexer_.Error("empty path", err);
     uint64_t slash_bits;
@@ -211,11 +210,11 @@ bool DyndepParser::ParseEdge(string* err) {
   }
 
   dyndeps->implicit_outputs_.reserve(outs.size());
-  for (vector<EvalString>::iterator i = outs.begin(); i != outs.end(); ++i) {
-    string path = i->Evaluate(&env_);
+  for (std::vector<EvalString>::iterator i = outs.begin(); i != outs.end(); ++i) {
+    std::string path = i->Evaluate(&env_);
     if (path.empty())
       return lexer_.Error("empty path", err);
-    string path_err;
+    std::string path_err;
     uint64_t slash_bits;
     CanonicalizePath(&path, &slash_bits);
     Node* n = state_->GetNode(path, slash_bits);

--- a/src/dyndep_parser_test.cc
+++ b/src/dyndep_parser_test.cc
@@ -22,12 +22,11 @@
 #include "state.h"
 #include "test.h"
 
-using namespace std;
 
 struct DyndepParserTest : public testing::Test {
   void AssertParse(const char* input) {
     DyndepParser parser(&state_, &fs_, &dyndep_file_);
-    string err;
+    std::string err;
     EXPECT_TRUE(parser.ParseTest(input, &err));
     ASSERT_EQ("", err);
   }
@@ -48,7 +47,7 @@ TEST_F(DyndepParserTest, Empty) {
   const char kInput[] =
 "";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:1: expected 'ninja_dyndep_version = ...'\n", err);
 }
@@ -106,7 +105,7 @@ TEST_F(DyndepParserTest, VersionUnexpectedEOF) {
   const char kInput[] =
 "ninja_dyndep_version = 1.0";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:1: unexpected EOF\n"
             "ninja_dyndep_version = 1.0\n"
@@ -117,7 +116,7 @@ TEST_F(DyndepParserTest, UnsupportedVersion0) {
   const char kInput[] =
 "ninja_dyndep_version = 0\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:1: unsupported 'ninja_dyndep_version = 0'\n"
             "ninja_dyndep_version = 0\n"
@@ -128,7 +127,7 @@ TEST_F(DyndepParserTest, UnsupportedVersion1_1) {
   const char kInput[] =
 "ninja_dyndep_version = 1.1\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:1: unsupported 'ninja_dyndep_version = 1.1'\n"
             "ninja_dyndep_version = 1.1\n"
@@ -140,7 +139,7 @@ TEST_F(DyndepParserTest, DuplicateVersion) {
 "ninja_dyndep_version = 1\n"
 "ninja_dyndep_version = 1\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: unexpected identifier\n", err);
 }
@@ -149,7 +148,7 @@ TEST_F(DyndepParserTest, MissingVersionOtherVar) {
   const char kInput[] =
 "not_ninja_dyndep_version = 1\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:1: expected 'ninja_dyndep_version = ...'\n"
             "not_ninja_dyndep_version = 1\n"
@@ -160,7 +159,7 @@ TEST_F(DyndepParserTest, MissingVersionBuild) {
   const char kInput[] =
 "build out: dyndep\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:1: expected 'ninja_dyndep_version = ...'\n", err);
 }
@@ -169,7 +168,7 @@ TEST_F(DyndepParserTest, UnexpectedEqual) {
   const char kInput[] =
 "= 1\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:1: unexpected '='\n", err);
 }
@@ -178,7 +177,7 @@ TEST_F(DyndepParserTest, UnexpectedIndent) {
   const char kInput[] =
 " = 1\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:1: unexpected indent\n", err);
 }
@@ -189,7 +188,7 @@ TEST_F(DyndepParserTest, OutDuplicate) {
 "build out: dyndep\n"
 "build out: dyndep\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:3: multiple statements for 'out'\n"
             "build out: dyndep\n"
@@ -202,7 +201,7 @@ TEST_F(DyndepParserTest, OutDuplicateThroughOther) {
 "build out: dyndep\n"
 "build otherout: dyndep\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:3: multiple statements for 'otherout'\n"
             "build otherout: dyndep\n"
@@ -214,7 +213,7 @@ TEST_F(DyndepParserTest, NoOutEOF) {
 "ninja_dyndep_version = 1\n"
 "build";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: unexpected EOF\n"
             "build\n"
@@ -226,7 +225,7 @@ TEST_F(DyndepParserTest, NoOutColon) {
 "ninja_dyndep_version = 1\n"
 "build :\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: expected path\n"
             "build :\n"
@@ -238,7 +237,7 @@ TEST_F(DyndepParserTest, OutNoStatement) {
 "ninja_dyndep_version = 1\n"
 "build missing: dyndep\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: no build statement exists for 'missing'\n"
             "build missing: dyndep\n"
@@ -250,7 +249,7 @@ TEST_F(DyndepParserTest, OutEOF) {
 "ninja_dyndep_version = 1\n"
 "build out";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: unexpected EOF\n"
             "build out\n"
@@ -262,7 +261,7 @@ TEST_F(DyndepParserTest, OutNoRule) {
 "ninja_dyndep_version = 1\n"
 "build out:";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: expected build command name 'dyndep'\n"
             "build out:\n"
@@ -274,7 +273,7 @@ TEST_F(DyndepParserTest, OutBadRule) {
 "ninja_dyndep_version = 1\n"
 "build out: touch";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: expected build command name 'dyndep'\n"
             "build out: touch\n"
@@ -286,7 +285,7 @@ TEST_F(DyndepParserTest, BuildEOF) {
 "ninja_dyndep_version = 1\n"
 "build out: dyndep";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: unexpected EOF\n"
             "build out: dyndep\n"
@@ -298,7 +297,7 @@ TEST_F(DyndepParserTest, ExplicitOut) {
 "ninja_dyndep_version = 1\n"
 "build out exp: dyndep\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: explicit outputs not supported\n"
             "build out exp: dyndep\n"
@@ -310,7 +309,7 @@ TEST_F(DyndepParserTest, ExplicitIn) {
 "ninja_dyndep_version = 1\n"
 "build out: dyndep exp\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: explicit inputs not supported\n"
             "build out: dyndep exp\n"
@@ -322,7 +321,7 @@ TEST_F(DyndepParserTest, OrderOnlyIn) {
 "ninja_dyndep_version = 1\n"
 "build out: dyndep ||\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:2: order-only inputs not supported\n"
             "build out: dyndep ||\n"
@@ -335,7 +334,7 @@ TEST_F(DyndepParserTest, BadBinding) {
 "build out: dyndep\n"
 "  not_restat = 1\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:3: binding is not 'restat'\n"
             "  not_restat = 1\n"
@@ -349,7 +348,7 @@ TEST_F(DyndepParserTest, RestatTwice) {
 "  restat = 1\n"
 "  restat = 1\n";
   DyndepParser parser(&state_, &fs_, &dyndep_file_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:4: unexpected indent\n", err);
 }

--- a/src/edit_distance.cc
+++ b/src/edit_distance.cc
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <vector>
 
-using namespace std;
 
 int EditDistance(const StringPiece& s1,
                  const StringPiece& s2,
@@ -38,7 +37,7 @@ int EditDistance(const StringPiece& s1,
   int m = s1.len_;
   int n = s2.len_;
 
-  vector<int> row(n + 1);
+  std::vector<int> row(n + 1);
   for (int i = 1; i <= n; ++i)
     row[i] = i;
 
@@ -50,17 +49,17 @@ int EditDistance(const StringPiece& s1,
     for (int x = 1; x <= n; ++x) {
       int old_row = row[x];
       if (allow_replacements) {
-        row[x] = min(previous + (s1.str_[y - 1] == s2.str_[x - 1] ? 0 : 1),
-                     min(row[x - 1], row[x]) + 1);
+        row[x] = std::min(previous + (s1.str_[y - 1] == s2.str_[x - 1] ? 0 : 1),
+                     std::min(row[x - 1], row[x]) + 1);
       }
       else {
         if (s1.str_[y - 1] == s2.str_[x - 1])
           row[x] = previous;
         else
-          row[x] = min(row[x - 1], row[x]) + 1;
+          row[x] = std::min(row[x - 1], row[x]) + 1;
       }
       previous = old_row;
-      best_this_row = min(best_this_row, row[x]);
+      best_this_row = std::min(best_this_row, row[x]);
     }
 
     if (max_edit_distance && best_this_row > max_edit_distance)

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -16,10 +16,8 @@
 
 #include "eval_env.h"
 
-using namespace std;
-
-string BindingEnv::LookupVariable(const string& var) {
-  map<string, string>::iterator i = bindings_.find(var);
+std::string BindingEnv::LookupVariable(const std::string& var) {
+  std::map<std::string, std::string>::iterator i = bindings_.find(var);
   if (i != bindings_.end())
     return i->second;
   if (parent_)
@@ -27,7 +25,7 @@ string BindingEnv::LookupVariable(const string& var) {
   return "";
 }
 
-void BindingEnv::AddBinding(const string& key, const string& val) {
+void BindingEnv::AddBinding(const std::string& key, const std::string& val) {
   bindings_[key] = val;
 }
 
@@ -36,15 +34,15 @@ void BindingEnv::AddRule(const Rule* rule) {
   rules_[rule->name()] = rule;
 }
 
-const Rule* BindingEnv::LookupRuleCurrentScope(const string& rule_name) {
-  map<string, const Rule*>::iterator i = rules_.find(rule_name);
+const Rule* BindingEnv::LookupRuleCurrentScope(const std::string& rule_name) {
+  std::map<std::string, const Rule*>::iterator i = rules_.find(rule_name);
   if (i == rules_.end())
     return NULL;
   return i->second;
 }
 
-const Rule* BindingEnv::LookupRule(const string& rule_name) {
-  map<string, const Rule*>::iterator i = rules_.find(rule_name);
+const Rule* BindingEnv::LookupRule(const std::string& rule_name) {
+  std::map<std::string, const Rule*>::iterator i = rules_.find(rule_name);
   if (i != rules_.end())
     return i->second;
   if (parent_)
@@ -52,11 +50,11 @@ const Rule* BindingEnv::LookupRule(const string& rule_name) {
   return NULL;
 }
 
-void Rule::AddBinding(const string& key, const EvalString& val) {
+void Rule::AddBinding(const std::string& key, const EvalString& val) {
   bindings_[key] = val;
 }
 
-const EvalString* Rule::GetBinding(const string& key) const {
+const EvalString* Rule::GetBinding(const std::string& key) const {
   Bindings::const_iterator i = bindings_.find(key);
   if (i == bindings_.end())
     return NULL;
@@ -64,7 +62,7 @@ const EvalString* Rule::GetBinding(const string& key) const {
 }
 
 // static
-bool Rule::IsReservedBinding(const string& var) {
+bool Rule::IsReservedBinding(const std::string& var) {
   return var == "command" ||
       var == "depfile" ||
       var == "dyndep" ||
@@ -78,14 +76,14 @@ bool Rule::IsReservedBinding(const string& var) {
       var == "msvc_deps_prefix";
 }
 
-const map<string, const Rule*>& BindingEnv::GetRules() const {
+const std::map<std::string, const Rule*>& BindingEnv::GetRules() const {
   return rules_;
 }
 
-string BindingEnv::LookupWithFallback(const string& var,
+std::string BindingEnv::LookupWithFallback(const std::string& var,
                                       const EvalString* eval,
                                       Env* env) {
-  map<string, string>::iterator i = bindings_.find(var);
+  std::map<std::string, std::string>::iterator i = bindings_.find(var);
   if (i != bindings_.end())
     return i->second;
 
@@ -98,8 +96,8 @@ string BindingEnv::LookupWithFallback(const string& var,
   return "";
 }
 
-string EvalString::Evaluate(Env* env) const {
-  string result;
+std::string EvalString::Evaluate(Env* env) const {
+  std::string result;
   for (TokenList::const_iterator i = parsed_.begin(); i != parsed_.end(); ++i) {
     if (i->second == RAW)
       result.append(i->first);
@@ -121,8 +119,8 @@ void EvalString::AddSpecial(StringPiece text) {
   parsed_.push_back(make_pair(text.AsString(), SPECIAL));
 }
 
-string EvalString::Serialize() const {
-  string result;
+std::string EvalString::Serialize() const {
+  std::string result;
   for (TokenList::const_iterator i = parsed_.begin();
        i != parsed_.end(); ++i) {
     result.append("[");
@@ -134,8 +132,8 @@ string EvalString::Serialize() const {
   return result;
 }
 
-string EvalString::Unparse() const {
-  string result;
+std::string EvalString::Unparse() const {
+  std::string result;
   for (TokenList::const_iterator i = parsed_.begin();
        i != parsed_.end(); ++i) {
     bool special = (i->second == SPECIAL);

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -29,9 +29,7 @@
 #include "state.h"
 #include "util.h"
 
-using namespace std;
-
-bool Node::Stat(DiskInterface* disk_interface, string* err) {
+bool Node::Stat(DiskInterface* disk_interface, std::string* err) {
   METRIC_RECORD("node stat");
   mtime_ = disk_interface->Stat(path_, err);
   if (mtime_ == -1) {
@@ -49,7 +47,7 @@ void Node::UpdatePhonyMtime(TimeStamp mtime) {
 
 bool DependencyScan::RecomputeDirty(Node* initial_node,
                                     std::vector<Node*>* validation_nodes,
-                                    string* err) {
+                                    std::string* err) {
   std::vector<Node*> stack;
   std::vector<Node*> new_validation_nodes;
 
@@ -82,7 +80,7 @@ bool DependencyScan::RecomputeDirty(Node* initial_node,
 
 bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
                                         std::vector<Node*>* validation_nodes,
-                                        string* err) {
+                                        std::string* err) {
   Edge* edge = node->in_edge();
   if (!edge) {
     // If we already visited this leaf node then we are done.
@@ -139,7 +137,7 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
   }
 
   // Load output mtimes so we can compare them to the most recent input below.
-  for (vector<Node*>::iterator o = edge->outputs_.begin();
+  for (std::vector<Node*>::iterator o = edge->outputs_.begin();
        o != edge->outputs_.end(); ++o) {
     if (!(*o)->StatIfNecessary(disk_interface_, err))
       return false;
@@ -167,7 +165,7 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
 
   // Visit all inputs; we're dirty if any of the inputs are dirty.
   Node* most_recent_input = NULL;
-  for (vector<Node*>::iterator i = edge->inputs_.begin();
+  for (std::vector<Node*>::iterator i = edge->inputs_.begin();
        i != edge->inputs_.end(); ++i) {
     // Visit this input.
     if (!RecomputeNodeDirty(*i, stack, validation_nodes, err))
@@ -200,7 +198,7 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
       return false;
 
   // Finally, visit each output and update their dirty state if necessary.
-  for (vector<Node*>::iterator o = edge->outputs_.begin();
+  for (std::vector<Node*>::iterator o = edge->outputs_.begin();
        o != edge->outputs_.end(); ++o) {
     if (dirty)
       (*o)->MarkDirty();
@@ -223,7 +221,7 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
   return true;
 }
 
-bool DependencyScan::VerifyDAG(Node* node, vector<Node*>* stack, string* err) {
+bool DependencyScan::VerifyDAG(Node* node, std::vector<Node*>* stack, std::string* err) {
   Edge* edge = node->in_edge();
   assert(edge != NULL);
 
@@ -232,7 +230,7 @@ bool DependencyScan::VerifyDAG(Node* node, vector<Node*>* stack, string* err) {
     return true;
 
   // We have this edge earlier in the call stack.  Find it.
-  vector<Node*>::iterator start = stack->begin();
+  std::vector<Node*>::iterator start = stack->begin();
   while (start != stack->end() && (*start)->in_edge() != edge)
     ++start;
   assert(start != stack->end());
@@ -247,7 +245,8 @@ bool DependencyScan::VerifyDAG(Node* node, vector<Node*>* stack, string* err) {
 
   // Construct the error message rejecting the cycle.
   *err = "dependency cycle: ";
-  for (vector<Node*>::const_iterator i = start; i != stack->end(); ++i) {
+  for (std::vector<Node*>::const_iterator i = start; i != stack->end(); ++i)
+  {
     err->append((*i)->path());
     err->append(" -> ");
   }
@@ -263,9 +262,9 @@ bool DependencyScan::VerifyDAG(Node* node, vector<Node*>* stack, string* err) {
 }
 
 bool DependencyScan::RecomputeOutputsDirty(Edge* edge, Node* most_recent_input,
-                                           bool* outputs_dirty, string* err) {
-  string command = edge->EvaluateCommand(/*incl_rsp_file=*/true);
-  for (vector<Node*>::iterator o = edge->outputs_.begin();
+                                           bool* outputs_dirty, std::string* err) {
+  std::string command = edge->EvaluateCommand(/*incl_rsp_file=*/true);
+  for (std::vector<Node*>::iterator o = edge->outputs_.begin();
        o != edge->outputs_.end(); ++o) {
     if (RecomputeOutputDirty(edge, most_recent_input, command, *o)) {
       *outputs_dirty = true;
@@ -277,7 +276,7 @@ bool DependencyScan::RecomputeOutputsDirty(Edge* edge, Node* most_recent_input,
 
 bool DependencyScan::RecomputeOutputDirty(const Edge* edge,
                                           const Node* most_recent_input,
-                                          const string& command,
+                                          const std::string& command,
                                           Node* output) {
   if (edge->is_phony()) {
     // Phony edges don't write any output.  Outputs are only dirty if
@@ -361,17 +360,17 @@ bool DependencyScan::RecomputeOutputDirty(const Edge* edge,
   return false;
 }
 
-bool DependencyScan::LoadDyndeps(Node* node, string* err) const {
+bool DependencyScan::LoadDyndeps(Node* node, std::string* err) const {
   return dyndep_loader_.LoadDyndeps(node, err);
 }
 
 bool DependencyScan::LoadDyndeps(Node* node, DyndepFile* ddf,
-                                 string* err) const {
+                                 std::string* err) const {
   return dyndep_loader_.LoadDyndeps(node, ddf, err);
 }
 
 bool Edge::AllInputsReady() const {
-  for (vector<Node*>::const_iterator i = inputs_.begin();
+  for (std::vector<Node*>::const_iterator i = inputs_.begin();
        i != inputs_.end(); ++i) {
     if ((*i)->in_edge() && !(*i)->in_edge()->outputs_ready())
       return false;
@@ -385,20 +384,20 @@ struct EdgeEnv : public Env {
 
   EdgeEnv(const Edge* const edge, const EscapeKind escape)
       : edge_(edge), escape_in_out_(escape), recursive_(false) {}
-  virtual string LookupVariable(const string& var);
+  virtual std::string LookupVariable(const std::string& var);
 
   /// Given a span of Nodes, construct a list of paths suitable for a command
   /// line.
   std::string MakePathList(const Node* const* span, size_t size, char sep) const;
 
  private:
-  vector<string> lookups_;
+  std::vector<std::string> lookups_;
   const Edge* const edge_;
   EscapeKind escape_in_out_;
   bool recursive_;
 };
 
-string EdgeEnv::LookupVariable(const string& var) {
+std::string EdgeEnv::LookupVariable(const std::string& var) {
   if (var == "in" || var == "in_newline") {
     int explicit_deps_count = edge_->inputs_.size() - edge_->implicit_deps_ -
       edge_->order_only_deps_;
@@ -410,9 +409,9 @@ string EdgeEnv::LookupVariable(const string& var) {
   }
 
   if (recursive_) {
-    vector<string>::const_iterator it;
-    if ((it = find(lookups_.begin(), lookups_.end(), var)) != lookups_.end()) {
-      string cycle;
+    std::vector<std::string>::const_iterator it;
+    if ((it = std::find(lookups_.begin(), lookups_.end(), var)) != lookups_.end()) {
+      std::string cycle;
       for (; it != lookups_.end(); ++it)
         cycle.append(*it + " -> ");
       cycle.append(var);
@@ -433,11 +432,11 @@ string EdgeEnv::LookupVariable(const string& var) {
 
 std::string EdgeEnv::MakePathList(const Node* const* const span,
                                   const size_t size, const char sep) const {
-  string result;
+  std::string result;
   for (const Node* const* i = span; i != span + size; ++i) {
     if (!result.empty())
       result.push_back(sep);
-    const string& path = (*i)->PathDecanonicalized();
+    const std::string& path = (*i)->PathDecanonicalized();
     if (escape_in_out_ == kShellEscape) {
 #ifdef _WIN32
       GetWin32EscapedString(path, &result);
@@ -474,9 +473,9 @@ void Edge::CollectInputs(bool shell_escape,
 }
 
 std::string Edge::EvaluateCommand(const bool incl_rsp_file) const {
-  string command = GetBinding("command");
+  std::string command = GetBinding("command");
   if (incl_rsp_file) {
-    string rspfile_content = GetBinding("rspfile_content");
+    std::string rspfile_content = GetBinding("rspfile_content");
     if (!rspfile_content.empty())
       command += ";rspfile=" + rspfile_content;
   }
@@ -488,16 +487,16 @@ std::string Edge::GetBinding(const std::string& key) const {
   return env.LookupVariable(key);
 }
 
-bool Edge::GetBindingBool(const string& key) const {
+bool Edge::GetBindingBool(const std::string& key) const {
   return !GetBinding(key).empty();
 }
 
-string Edge::GetUnescapedDepfile() const {
+std::string Edge::GetUnescapedDepfile() const {
   EdgeEnv env(this, EdgeEnv::kDoNotEscape);
   return env.LookupVariable("depfile");
 }
 
-string Edge::GetUnescapedDyndep() const {
+std::string Edge::GetUnescapedDyndep() const {
   EdgeEnv env(this, EdgeEnv::kDoNotEscape);
   return env.LookupVariable("dyndep");
 }
@@ -509,12 +508,12 @@ std::string Edge::GetUnescapedRspfile() const {
 
 void Edge::Dump(const char* prefix) const {
   printf("%s[ ", prefix);
-  for (vector<Node*>::const_iterator i = inputs_.begin();
+  for (std::vector<Node*>::const_iterator i = inputs_.begin();
        i != inputs_.end() && *i != NULL; ++i) {
     printf("%s ", (*i)->path().c_str());
   }
   printf("--%s-> ", rule_->name().c_str());
-  for (vector<Node*>::const_iterator i = outputs_.begin();
+  for (std::vector<Node*>::const_iterator i = outputs_.begin();
        i != outputs_.end() && *i != NULL; ++i) {
     printf("%s ", (*i)->path().c_str());
   }
@@ -552,8 +551,8 @@ bool Edge::maybe_phonycycle_diagnostic() const {
 }
 
 // static
-string Node::PathDecanonicalized(const string& path, uint64_t slash_bits) {
-  string result = path;
+std::string Node::PathDecanonicalized(const std::string& path, uint64_t slash_bits) {
+  std::string result = path;
 #ifdef _WIN32
   uint64_t mask = 1;
   for (char* c = &result[0]; (c = strchr(c, '/')) != NULL;) {
@@ -577,7 +576,7 @@ void Node::Dump(const char* prefix) const {
     printf("no in-edge\n");
   }
   printf(" out edges:\n");
-  for (vector<Edge*>::const_iterator e = out_edges().begin();
+  for (std::vector<Edge*>::const_iterator e = out_edges().begin();
        e != out_edges().end() && *e != NULL; ++e) {
     (*e)->Dump(" +- ");
   }
@@ -590,12 +589,12 @@ void Node::Dump(const char* prefix) const {
   }
 }
 
-bool ImplicitDepLoader::LoadDeps(Edge* edge, string* err) {
-  string deps_type = edge->GetBinding("deps");
+bool ImplicitDepLoader::LoadDeps(Edge* edge, std::string* err) {
+  std::string deps_type = edge->GetBinding("deps");
   if (!deps_type.empty())
     return LoadDepsFromLog(edge, err);
 
-  string depfile = edge->GetUnescapedDepfile();
+  std::string depfile = edge->GetUnescapedDepfile();
   if (!depfile.empty())
     return LoadDepFile(edge, depfile, err);
 
@@ -614,11 +613,11 @@ struct matches {
   std::vector<StringPiece>::iterator i_;
 };
 
-bool ImplicitDepLoader::LoadDepFile(Edge* edge, const string& path,
-                                    string* err) {
+bool ImplicitDepLoader::LoadDepFile(Edge* edge, const std::string& path,
+                                    std::string* err) {
   METRIC_RECORD("depfile load");
   // Read depfile content.  Treat a missing depfile as empty.
-  string content;
+  std::string content;
   switch (disk_interface_->ReadFile(path, &content, err)) {
   case DiskInterface::Okay:
     break;
@@ -638,7 +637,7 @@ bool ImplicitDepLoader::LoadDepFile(Edge* edge, const string& path,
   DepfileParser depfile(depfile_parser_options_
                         ? *depfile_parser_options_
                         : DepfileParserOptions());
-  string depfile_err;
+  std::string depfile_err;
   if (!depfile.Parse(&content, &depfile_err)) {
     *err = path + ": " + depfile_err;
     return false;
@@ -680,7 +679,7 @@ bool ImplicitDepLoader::LoadDepFile(Edge* edge, const string& path,
 bool ImplicitDepLoader::ProcessDepfileDeps(
     Edge* edge, std::vector<StringPiece>* depfile_ins, std::string* err) {
   // Preallocate space in edge->inputs_ to be filled in below.
-  vector<Node*>::iterator implicit_dep =
+  std::vector<Node*>::iterator implicit_dep =
       PreallocateSpace(edge, depfile_ins->size());
 
   // Add all its in-edges.
@@ -697,7 +696,7 @@ bool ImplicitDepLoader::ProcessDepfileDeps(
   return true;
 }
 
-bool ImplicitDepLoader::LoadDepsFromLog(Edge* edge, string* err) {
+bool ImplicitDepLoader::LoadDepsFromLog(Edge* edge, std::string* err) {
   // NOTE: deps are only supported for single-target edges.
   Node* output = edge->outputs_[0];
   DepsLog::Deps* deps = deps_log_ ? deps_log_->GetDeps(output) : NULL;
@@ -713,7 +712,7 @@ bool ImplicitDepLoader::LoadDepsFromLog(Edge* edge, string* err) {
     return false;
   }
 
-  vector<Node*>::iterator implicit_dep =
+  std::vector<Node*>::iterator implicit_dep =
       PreallocateSpace(edge, deps->node_count);
   for (int i = 0; i < deps->node_count; ++i, ++implicit_dep) {
     Node* node = deps->nodes[i];
@@ -724,7 +723,7 @@ bool ImplicitDepLoader::LoadDepsFromLog(Edge* edge, string* err) {
   return true;
 }
 
-vector<Node*>::iterator ImplicitDepLoader::PreallocateSpace(Edge* edge,
+std::vector<Node*>::iterator ImplicitDepLoader::PreallocateSpace(Edge* edge,
                                                             int count) {
   edge->inputs_.insert(edge->inputs_.end() - edge->order_only_deps_,
                        (size_t)count, 0);

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -17,8 +17,6 @@
 
 #include "test.h"
 
-using namespace std;
-
 struct GraphTest : public StateTestWithBuiltinRules {
   GraphTest() : scan_(&state_, NULL, NULL, &fs_, NULL) {}
 
@@ -32,7 +30,7 @@ TEST_F(GraphTest, MissingImplicit) {
   fs_.Create("in", "");
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -50,7 +48,7 @@ TEST_F(GraphTest, ModifiedImplicit) {
   fs_.Tick();
   fs_.Create("implicit", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -70,7 +68,7 @@ TEST_F(GraphTest, FunkyMakefilePath) {
   fs_.Tick();
   fs_.Create("implicit.h", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out.o"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -93,7 +91,7 @@ TEST_F(GraphTest, ExplicitImplicit) {
   fs_.Tick();
   fs_.Create("data", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out.o"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -121,7 +119,7 @@ TEST_F(GraphTest, ImplicitOutputMissing) {
   fs_.Create("in", "");
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -137,7 +135,7 @@ TEST_F(GraphTest, ImplicitOutputOutOfDate) {
   fs_.Create("in", "");
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -161,7 +159,7 @@ TEST_F(GraphTest, ImplicitOutputOnlyMissing) {
 "build | out.imp: cat in\n"));
   fs_.Create("in", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out.imp"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -175,7 +173,7 @@ TEST_F(GraphTest, ImplicitOutputOnlyOutOfDate) {
   fs_.Tick();
   fs_.Create("in", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out.imp"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -192,7 +190,7 @@ TEST_F(GraphTest, PathWithCurrentDirectory) {
   fs_.Create("out.o.d", "out.o: foo.cc\n");
   fs_.Create("out.o", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out.o"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -206,11 +204,11 @@ TEST_F(GraphTest, RootNodes) {
 "build out2: cat mid1\n"
 "build out3 out4: cat mid1\n"));
 
-  string err;
-  vector<Node*> root_nodes = state_.RootNodes(&err);
+  std::string err;
+  std::vector<Node*> root_nodes = state_.RootNodes(&err);
   EXPECT_EQ(4u, root_nodes.size());
   for (size_t i = 0; i < root_nodes.size(); ++i) {
-    string name = root_nodes[i]->path();
+    std::string name = root_nodes[i]->path();
     EXPECT_EQ("out", name.substr(0, 3));
   }
 }
@@ -273,7 +271,7 @@ TEST_F(GraphTest, DepfileWithCanonicalizablePath) {
   fs_.Create("out.o.d", "out.o: bar/../foo.cc\n");
   fs_.Create("out.o", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out.o"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -293,7 +291,7 @@ TEST_F(GraphTest, DepfileRemoved) {
   fs_.Create("out.o.d", "out.o: foo.h\n");
   fs_.Create("out.o", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out.o"), NULL, &err));
   ASSERT_EQ("", err);
   EXPECT_FALSE(GetNode("out.o")->dirty());
@@ -346,7 +344,7 @@ TEST_F(GraphTest, NestedPhonyPrintsDone) {
 "build n1: phony \n"
 "build n2: phony n1\n"
   );
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("n2"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -365,7 +363,7 @@ TEST_F(GraphTest, PhonySelfReferenceError) {
 "build a: phony a\n",
   parser_opts);
 
-  string err;
+  std::string err;
   EXPECT_FALSE(scan_.RecomputeDirty(GetNode("a"), NULL, &err));
   ASSERT_EQ("dependency cycle: a -> a [-w phonycycle=err]", err);
 }
@@ -377,13 +375,13 @@ TEST_F(GraphTest, DependencyCycle) {
 "build in: cat pre\n"
 "build pre: cat out\n");
 
-  string err;
+  std::string err;
   EXPECT_FALSE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("dependency cycle: out -> mid -> in -> pre -> out", err);
 }
 
 TEST_F(GraphTest, CycleInEdgesButNotInNodes1) {
-  string err;
+  std::string err;
   AssertParse(&state_,
 "build a b: cat a\n");
   EXPECT_FALSE(scan_.RecomputeDirty(GetNode("b"), NULL, &err));
@@ -391,7 +389,7 @@ TEST_F(GraphTest, CycleInEdgesButNotInNodes1) {
 }
 
 TEST_F(GraphTest, CycleInEdgesButNotInNodes2) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "build b a: cat a\n"));
   EXPECT_FALSE(scan_.RecomputeDirty(GetNode("b"), NULL, &err));
@@ -399,7 +397,7 @@ TEST_F(GraphTest, CycleInEdgesButNotInNodes2) {
 }
 
 TEST_F(GraphTest, CycleInEdgesButNotInNodes3) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "build a b: cat c\n"
 "build c: cat a\n"));
@@ -408,7 +406,7 @@ TEST_F(GraphTest, CycleInEdgesButNotInNodes3) {
 }
 
 TEST_F(GraphTest, CycleInEdgesButNotInNodes4) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "build d: cat c\n"
 "build c: cat b\n"
@@ -430,7 +428,7 @@ TEST_F(GraphTest, CycleWithLengthZeroFromDepfile) {
   );
   fs_.Create("dep.d", "a: b\n");
 
-  string err;
+  std::string err;
   EXPECT_FALSE(scan_.RecomputeDirty(GetNode("a"), NULL, &err));
   ASSERT_EQ("dependency cycle: b -> b", err);
 
@@ -455,7 +453,7 @@ TEST_F(GraphTest, CycleWithLengthOneFromDepfile) {
   );
   fs_.Create("dep.d", "a: c\n");
 
-  string err;
+  std::string err;
   EXPECT_FALSE(scan_.RecomputeDirty(GetNode("a"), NULL, &err));
   ASSERT_EQ("dependency cycle: b -> c -> b", err);
 
@@ -482,7 +480,7 @@ TEST_F(GraphTest, CycleWithLengthOneFromDepfileOneHopAway) {
   );
   fs_.Create("dep.d", "a: c\n");
 
-  string err;
+  std::string err;
   EXPECT_FALSE(scan_.RecomputeDirty(GetNode("d"), NULL, &err));
   ASSERT_EQ("dependency cycle: b -> c -> b", err);
 
@@ -501,8 +499,8 @@ TEST_F(GraphTest, Decanonicalize) {
 "build out\\out2/out3\\out4: cat mid1\n"
 "build out3 out4\\foo: cat mid1\n"));
 
-  string err;
-  vector<Node*> root_nodes = state_.RootNodes(&err);
+  std::string err;
+  std::vector<Node*> root_nodes = state_.RootNodes(&err);
   EXPECT_EQ(4u, root_nodes.size());
   EXPECT_EQ(root_nodes[0]->path(), "out/out1");
   EXPECT_EQ(root_nodes[1]->path(), "out/out2/out3/out4");
@@ -527,7 +525,7 @@ TEST_F(GraphTest, DyndepLoadTrivial) {
 "build out: dyndep\n"
   );
 
-  string err;
+  std::string err;
   ASSERT_TRUE(GetNode("dd")->dyndep_pending());
   EXPECT_TRUE(scan_.LoadDyndeps(GetNode("dd"), &err));
   EXPECT_EQ("", err);
@@ -557,7 +555,7 @@ TEST_F(GraphTest, DyndepLoadImplicit) {
 "build out1: dyndep | out2\n"
   );
 
-  string err;
+  std::string err;
   ASSERT_TRUE(GetNode("dd")->dyndep_pending());
   EXPECT_TRUE(scan_.LoadDyndeps(GetNode("dd"), &err));
   EXPECT_EQ("", err);
@@ -583,7 +581,7 @@ TEST_F(GraphTest, DyndepLoadMissingFile) {
 "  dyndep = dd\n"
   );
 
-  string err;
+  std::string err;
   ASSERT_TRUE(GetNode("dd")->dyndep_pending());
   EXPECT_FALSE(scan_.LoadDyndeps(GetNode("dd"), &err));
   EXPECT_EQ("loading 'dd': No such file or directory", err);
@@ -600,7 +598,7 @@ TEST_F(GraphTest, DyndepLoadMissingEntry) {
 "ninja_dyndep_version = 1\n"
   );
 
-  string err;
+  std::string err;
   ASSERT_TRUE(GetNode("dd")->dyndep_pending());
   EXPECT_FALSE(scan_.LoadDyndeps(GetNode("dd"), &err));
   EXPECT_EQ("'out' not mentioned in its dyndep file 'dd'", err);
@@ -620,7 +618,7 @@ TEST_F(GraphTest, DyndepLoadExtraEntry) {
 "build out2: dyndep\n"
   );
 
-  string err;
+  std::string err;
   ASSERT_TRUE(GetNode("dd")->dyndep_pending());
   EXPECT_FALSE(scan_.LoadDyndeps(GetNode("dd"), &err));
   EXPECT_EQ("dyndep file 'dd' mentions output 'out2' whose build statement "
@@ -640,7 +638,7 @@ TEST_F(GraphTest, DyndepLoadOutputWithMultipleRules1) {
 "build out2 | out-twice.imp: dyndep\n"
   );
 
-  string err;
+  std::string err;
   ASSERT_TRUE(GetNode("dd")->dyndep_pending());
   EXPECT_FALSE(scan_.LoadDyndeps(GetNode("dd"), &err));
   EXPECT_EQ("multiple rules generate out-twice.imp", err);
@@ -664,7 +662,7 @@ TEST_F(GraphTest, DyndepLoadOutputWithMultipleRules2) {
 "build out2 | out-twice.imp: dyndep\n"
   );
 
-  string err;
+  std::string err;
   ASSERT_TRUE(GetNode("dd1")->dyndep_pending());
   EXPECT_TRUE(scan_.LoadDyndeps(GetNode("dd1"), &err));
   EXPECT_EQ("", err);
@@ -690,7 +688,7 @@ TEST_F(GraphTest, DyndepLoadMultiple) {
 "  restat = 1\n"
   );
 
-  string err;
+  std::string err;
   ASSERT_TRUE(GetNode("dd")->dyndep_pending());
   EXPECT_TRUE(scan_.LoadDyndeps(GetNode("dd"), &err));
   EXPECT_EQ("", err);
@@ -737,7 +735,7 @@ TEST_F(GraphTest, DyndepFileMissing) {
 "  dyndep = dd\n"
   );
 
-  string err;
+  std::string err;
   EXPECT_FALSE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("loading 'dd': No such file or directory", err);
 }
@@ -753,7 +751,7 @@ TEST_F(GraphTest, DyndepFileError) {
 "ninja_dyndep_version = 1\n"
   );
 
-  string err;
+  std::string err;
   EXPECT_FALSE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("'out' not mentioned in its dyndep file 'dd'", err);
 }
@@ -773,7 +771,7 @@ TEST_F(GraphTest, DyndepImplicitInputNewer) {
   fs_.Tick();
   fs_.Create("in", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -801,7 +799,7 @@ TEST_F(GraphTest, DyndepFileReady) {
   fs_.Tick();
   fs_.Create("in", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -826,7 +824,7 @@ TEST_F(GraphTest, DyndepFileNotClean) {
   fs_.Create("dd-in", "");
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -852,7 +850,7 @@ TEST_F(GraphTest, DyndepFileNotReady) {
   fs_.Tick();
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -880,7 +878,7 @@ TEST_F(GraphTest, DyndepFileSecondNotReady) {
   fs_.Create("dd1-in", "");
   fs_.Create("out", "");
 
-  string err;
+  std::string err;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   ASSERT_EQ("", err);
 
@@ -909,7 +907,7 @@ TEST_F(GraphTest, DyndepFileCircular) {
   fs_.Create("out", "");
 
   Edge* edge = GetNode("out")->in_edge();
-  string err;
+  std::string err;
   EXPECT_FALSE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
   EXPECT_EQ("dependency cycle: circ -> in -> circ", err);
 
@@ -929,7 +927,7 @@ TEST_F(GraphTest, Validation) {
 "build validate: cat in\n"));
 
   fs_.Create("in", "");
-  string err;
+  std::string err;
   std::vector<Node*> validation_nodes;
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), &validation_nodes, &err));
   ASSERT_EQ("", err);
@@ -943,7 +941,7 @@ TEST_F(GraphTest, Validation) {
 
 // Check that phony's dependencies' mtimes are propagated.
 TEST_F(GraphTest, PhonyDepsMtimes) {
-  string err;
+  std::string err;
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "rule touch\n"
 " command = touch $out\n"

--- a/src/graphviz.cc
+++ b/src/graphviz.cc
@@ -20,13 +20,12 @@
 #include "dyndep.h"
 #include "graph.h"
 
-using namespace std;
 
 void GraphViz::AddTarget(Node* node) {
   if (visited_nodes_.find(node) != visited_nodes_.end())
     return;
 
-  string pathstr = node->path();
+  std::string pathstr = node->path();
   replace(pathstr.begin(), pathstr.end(), '\\', '/');
   printf("\"%p\" [label=\"%s\"]\n", node, pathstr.c_str());
   visited_nodes_.insert(node);
@@ -59,11 +58,12 @@ void GraphViz::AddTarget(Node* node) {
   } else {
     printf("\"%p\" [label=\"%s\", shape=ellipse]\n",
            edge, edge->rule_->name().c_str());
-    for (vector<Node*>::iterator out = edge->outputs_.begin();
+    for (std::vector<Node*>::iterator out = edge->outputs_.begin();
          out != edge->outputs_.end(); ++out) {
       printf("\"%p\" -> \"%p\"\n", edge, *out);
     }
-    for (vector<Node*>::iterator in = edge->inputs_.begin();
+
+    for (std::vector<Node*>::iterator in = edge->inputs_.begin();
          in != edge->inputs_.end(); ++in) {
       const char* order_only = "";
       if (edge->is_order_only(in - edge->inputs_.begin()))
@@ -72,7 +72,7 @@ void GraphViz::AddTarget(Node* node) {
     }
   }
 
-  for (vector<Node*>::iterator in = edge->inputs_.begin();
+  for (std::vector<Node*>::iterator in = edge->inputs_.begin();
        in != edge->inputs_.end(); ++in) {
     AddTarget(*in);
   }

--- a/src/hash_collision_bench.cc
+++ b/src/hash_collision_bench.cc
@@ -19,7 +19,6 @@
 #include <stdlib.h>
 #include <time.h>
 
-using namespace std;
 
 int random(int low, int high) {
   return int(low + (rand() / double(RAND_MAX)) * (high - low) + 0.5);
@@ -38,13 +37,13 @@ int main() {
 
   // Leak these, else 10% of the runtime is spent destroying strings.
   char** commands = new char*[N];
-  pair<uint64_t, int>* hashes = new pair<uint64_t, int>[N];
+  std::pair<uint64_t, int>* hashes = new std::pair<uint64_t, int>[N];
 
   srand((int)time(NULL));
 
   for (int i = 0; i < N; ++i) {
     RandomCommand(&commands[i]);
-    hashes[i] = make_pair(BuildLog::LogEntry::HashCommand(commands[i]), i);
+    hashes[i] = std::make_pair(BuildLog::LogEntry::HashCommand(commands[i]), i);
   }
 
   sort(hashes, hashes + N);

--- a/src/includes_normalize-win32.cc
+++ b/src/includes_normalize-win32.cc
@@ -22,14 +22,14 @@
 #include <iterator>
 #include <sstream>
 
+#define NOMINMAX
 #include <windows.h>
 
-using namespace std;
 
 namespace {
 
 bool InternalGetFullPathName(const StringPiece& file_name, char* buffer,
-                             size_t buffer_length, string *err) {
+                             size_t buffer_length, std::string *err) {
   DWORD result_size = GetFullPathNameA(file_name.AsString().c_str(),
                                        buffer_length, buffer, NULL);
   if (result_size == 0) {
@@ -71,7 +71,7 @@ bool SameDriveFast(StringPiece a, StringPiece b) {
 }
 
 // Return true if paths a and b are on the same Windows drive.
-bool SameDrive(StringPiece a, StringPiece b, string* err)  {
+bool SameDrive(StringPiece a, StringPiece b, std::string* err)  {
   if (SameDriveFast(a, b)) {
     return true;
   }
@@ -126,8 +126,8 @@ bool IsFullPathName(StringPiece s) {
 
 }  // anonymous namespace
 
-IncludesNormalize::IncludesNormalize(const string& relative_to) {
-  string err;
+IncludesNormalize::IncludesNormalize(const std::string& relative_to) {
+  std::string err;
   relative_to_ = AbsPath(relative_to, &err);
   if (!err.empty()) {
     Fatal("Initializing IncludesNormalize(): %s", err.c_str());
@@ -135,9 +135,9 @@ IncludesNormalize::IncludesNormalize(const string& relative_to) {
   split_relative_to_ = SplitStringPiece(relative_to_, '/');
 }
 
-string IncludesNormalize::AbsPath(StringPiece s, string* err) {
+std::string IncludesNormalize::AbsPath(StringPiece s, std::string* err) {
   if (IsFullPathName(s)) {
-    string result = s.AsString();
+    std::string result = s.AsString();
     for (size_t i = 0; i < result.size(); ++i) {
       if (result[i] == '\\') {
         result[i] = '/';
@@ -156,21 +156,21 @@ string IncludesNormalize::AbsPath(StringPiece s, string* err) {
   return result;
 }
 
-string IncludesNormalize::Relativize(
-    StringPiece path, const vector<StringPiece>& start_list, string* err) {
-  string abs_path = AbsPath(path, err);
+std::string IncludesNormalize::Relativize(
+    StringPiece path, const std::vector<StringPiece>& start_list, std::string* err) {
+  std::string abs_path = AbsPath(path, err);
   if (!err->empty())
     return "";
-  vector<StringPiece> path_list = SplitStringPiece(abs_path, '/');
+  std::vector<StringPiece> path_list = SplitStringPiece(abs_path, '/');
   int i;
-  for (i = 0; i < static_cast<int>(min(start_list.size(), path_list.size()));
+  for (i = 0; i < static_cast<int>(std::min(start_list.size(), path_list.size()));
        ++i) {
     if (!EqualsCaseInsensitiveASCII(start_list[i], path_list[i])) {
       break;
     }
   }
 
-  vector<StringPiece> rel_list;
+  std::vector<StringPiece> rel_list;
   rel_list.reserve(start_list.size() - i + path_list.size() - i);
   for (int j = 0; j < static_cast<int>(start_list.size() - i); ++j)
     rel_list.push_back("..");
@@ -181,8 +181,8 @@ string IncludesNormalize::Relativize(
   return JoinStringPiece(rel_list, '/');
 }
 
-bool IncludesNormalize::Normalize(const string& input,
-                                  string* result, string* err) const {
+bool IncludesNormalize::Normalize(const std::string& input,
+                                  std::string* result, std::string* err) const {
   char copy[_MAX_PATH + 1];
   size_t len = input.size();
   if (len > _MAX_PATH) {
@@ -193,7 +193,7 @@ bool IncludesNormalize::Normalize(const string& input,
   uint64_t slash_bits;
   CanonicalizePath(copy, &len, &slash_bits);
   StringPiece partially_fixed(copy, len);
-  string abs_input = AbsPath(partially_fixed, err);
+  std::string abs_input = AbsPath(partially_fixed, err);
   if (!err->empty())
     return false;
 

--- a/src/includes_normalize_test.cc
+++ b/src/includes_normalize_test.cc
@@ -22,28 +22,27 @@
 #include "test.h"
 #include "util.h"
 
-using namespace std;
 
 namespace {
 
-string GetCurDir() {
+std::string GetCurDir() {
   char buf[_MAX_PATH];
   _getcwd(buf, sizeof(buf));
-  vector<StringPiece> parts = SplitStringPiece(buf, '\\');
+  std::vector<StringPiece> parts = SplitStringPiece(buf, '\\');
   return parts[parts.size() - 1].AsString();
 }
 
-string NormalizeAndCheckNoError(const string& input) {
-  string result, err;
+std::string NormalizeAndCheckNoError(const std::string& input) {
+  std::string result, err;
   IncludesNormalize normalizer(".");
   EXPECT_TRUE(normalizer.Normalize(input, &result, &err));
   EXPECT_EQ("", err);
   return result;
 }
 
-string NormalizeRelativeAndCheckNoError(const string& input,
-                                        const string& relative_to) {
-  string result, err;
+std::string NormalizeRelativeAndCheckNoError(const std::string& input,
+                                        const std::string& relative_to) {
+  std::string result, err;
   IncludesNormalize normalizer(relative_to);
   EXPECT_TRUE(normalizer.Normalize(input, &result, &err));
   EXPECT_EQ("", err);
@@ -60,15 +59,15 @@ TEST(IncludesNormalize, Simple) {
 }
 
 TEST(IncludesNormalize, WithRelative) {
-  string err;
-  string currentdir = GetCurDir();
+  std::string err;
+  std::string currentdir = GetCurDir();
   EXPECT_EQ("c", NormalizeRelativeAndCheckNoError("a/b/c", "a/b"));
   EXPECT_EQ("a",
             NormalizeAndCheckNoError(IncludesNormalize::AbsPath("a", &err)));
   EXPECT_EQ("", err);
-  EXPECT_EQ(string("../") + currentdir + string("/a"),
+  EXPECT_EQ(std::string("../") + currentdir + std::string("/a"),
             NormalizeRelativeAndCheckNoError("a", "../b"));
-  EXPECT_EQ(string("../") + currentdir + string("/a/b"),
+  EXPECT_EQ(std::string("../") + currentdir + std::string("/a/b"),
             NormalizeRelativeAndCheckNoError("a/b", "../c"));
   EXPECT_EQ("../../a", NormalizeRelativeAndCheckNoError("a", "b/c"));
   EXPECT_EQ(".", NormalizeRelativeAndCheckNoError("a", "a"));
@@ -107,7 +106,7 @@ TEST(IncludesNormalize, LongInvalidPath) {
       "is usually a configuration error. Compilation will continue using /Z7 "
       "instead of /Zi, but expect a similar error when you link your program.";
   // Too long, won't be canonicalized. Ensure doesn't crash.
-  string result, err;
+  std::string result, err;
   IncludesNormalize normalizer(".");
   EXPECT_FALSE(
       normalizer.Normalize(kLongInputString, &result, &err));
@@ -137,7 +136,7 @@ TEST(IncludesNormalize, LongInvalidPath) {
   kExactlyMaxPath[_MAX_PATH] = '\0';
   EXPECT_EQ(strlen(kExactlyMaxPath), _MAX_PATH);
 
-  string forward_slashes(kExactlyMaxPath);
+  std::string forward_slashes(kExactlyMaxPath);
   replace(forward_slashes.begin(), forward_slashes.end(), '\\', '/');
   // Make sure a path that's exactly _MAX_PATH long is canonicalized.
   EXPECT_EQ(forward_slashes.substr(cwd_len + 1),
@@ -145,7 +144,7 @@ TEST(IncludesNormalize, LongInvalidPath) {
 }
 
 TEST(IncludesNormalize, ShortRelativeButTooLongAbsolutePath) {
-  string result, err;
+  std::string result, err;
   IncludesNormalize normalizer(".");
   // A short path should work
   EXPECT_TRUE(normalizer.Normalize("a", &result, &err));
@@ -165,5 +164,5 @@ TEST(IncludesNormalize, ShortRelativeButTooLongAbsolutePath) {
 
   // Make sure a path that's exactly _MAX_PATH long fails with a proper error.
   EXPECT_FALSE(normalizer.Normalize(kExactlyMaxPath, &result, &err));
-  EXPECT_TRUE(err.find("GetFullPathName") != string::npos);
+  EXPECT_TRUE(err.find("GetFullPathName") != std::string::npos);
 }

--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -20,9 +20,7 @@
 #include "eval_env.h"
 #include "util.h"
 
-using namespace std;
-
-bool Lexer::Error(const string& message, string* err) {
+bool Lexer::Error(const std::string& message, std::string* err) {
   // Compute line/column.
   int line = 1;
   const char* line_start = input_.str_;
@@ -50,11 +48,11 @@ bool Lexer::Error(const string& message, string* err) {
         break;
       }
     }
-    *err += string(line_start, len);
+    *err += std::string(line_start, len);
     if (truncated)
       *err += "...";
     *err += "\n";
-    *err += string(col, ' ');
+    *err += std::string(col, ' ');
     *err += "^ near here";
   }
 
@@ -103,7 +101,7 @@ const char* Lexer::TokenErrorHint(Token expected) {
   }
 }
 
-string Lexer::DescribeLastError() {
+std::string Lexer::DescribeLastError() {
   if (last_token_) {
     switch (last_token_[0]) {
     case '\t':
@@ -551,7 +549,7 @@ yy89:
   }
 }
 
-bool Lexer::ReadIdent(string* out) {
+bool Lexer::ReadIdent(std::string* out) {
   const char* p = ofs_;
   const char* start;
   for (;;) {
@@ -620,7 +618,7 @@ yy95:
   return true;
 }
 
-bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
+bool Lexer::ReadEvalString(EvalString* eval, bool path, std::string* err) {
   const char* p = ofs_;
   const char* q;
   const char* start;

--- a/src/lexer.in.cc
+++ b/src/lexer.in.cc
@@ -19,9 +19,7 @@
 #include "eval_env.h"
 #include "util.h"
 
-using namespace std;
-
-bool Lexer::Error(const string& message, string* err) {
+bool Lexer::Error(const std::string& message, std::string* err) {
   // Compute line/column.
   int line = 1;
   const char* line_start = input_.str_;
@@ -49,11 +47,11 @@ bool Lexer::Error(const string& message, string* err) {
         break;
       }
     }
-    *err += string(line_start, len);
+    *err += std::string(line_start, len);
     if (truncated)
       *err += "...";
     *err += "\n";
-    *err += string(col, ' ');
+    *err += std::string(col, ' ');
     *err += "^ near here";
   }
 
@@ -102,7 +100,7 @@ const char* Lexer::TokenErrorHint(Token expected) {
   }
 }
 
-string Lexer::DescribeLastError() {
+std::string Lexer::DescribeLastError() {
   if (last_token_) {
     switch (last_token_[0]) {
     case '\t':
@@ -184,7 +182,7 @@ void Lexer::EatWhitespace() {
   }
 }
 
-bool Lexer::ReadIdent(string* out) {
+bool Lexer::ReadIdent(std::string* out) {
   const char* p = ofs_;
   const char* start;
   for (;;) {
@@ -206,7 +204,7 @@ bool Lexer::ReadIdent(string* out) {
   return true;
 }
 
-bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
+bool Lexer::ReadEvalString(EvalString* eval, bool path, std::string* err) {
   const char* p = ofs_;
   const char* q;
   const char* start;

--- a/src/lexer_test.cc
+++ b/src/lexer_test.cc
@@ -17,12 +17,11 @@
 #include "eval_env.h"
 #include "test.h"
 
-using namespace std;
 
 TEST(Lexer, ReadVarValue) {
   Lexer lexer("plain text $var $VaR ${x}\n");
   EvalString eval;
-  string err;
+  std::string err;
   EXPECT_TRUE(lexer.ReadVarValue(&eval, &err));
   EXPECT_EQ("", err);
   EXPECT_EQ("[plain text ][$var][ ][$VaR][ ][$x]",
@@ -32,7 +31,7 @@ TEST(Lexer, ReadVarValue) {
 TEST(Lexer, ReadEvalStringEscapes) {
   Lexer lexer("$ $$ab c$: $\ncde\n");
   EvalString eval;
-  string err;
+  std::string err;
   EXPECT_TRUE(lexer.ReadVarValue(&eval, &err));
   EXPECT_EQ("", err);
   EXPECT_EQ("[ $ab c: cde]",
@@ -41,7 +40,7 @@ TEST(Lexer, ReadEvalStringEscapes) {
 
 TEST(Lexer, ReadIdent) {
   Lexer lexer("foo baR baz_123 foo-bar");
-  string ident;
+  std::string ident;
   EXPECT_TRUE(lexer.ReadIdent(&ident));
   EXPECT_EQ("foo", ident);
   EXPECT_TRUE(lexer.ReadIdent(&ident));
@@ -56,12 +55,12 @@ TEST(Lexer, ReadIdentCurlies) {
   // Verify that ReadIdent includes dots in the name,
   // but in an expansion $bar.dots stops at the dot.
   Lexer lexer("foo.dots $bar.dots ${bar.dots}\n");
-  string ident;
+  std::string ident;
   EXPECT_TRUE(lexer.ReadIdent(&ident));
   EXPECT_EQ("foo.dots", ident);
 
   EvalString eval;
-  string err;
+  std::string err;
   EXPECT_TRUE(lexer.ReadVarValue(&eval, &err));
   EXPECT_EQ("", err);
   EXPECT_EQ("[$bar][.dots ][$bar.dots]",
@@ -71,7 +70,7 @@ TEST(Lexer, ReadIdentCurlies) {
 TEST(Lexer, Error) {
   Lexer lexer("foo$\nbad $");
   EvalString eval;
-  string err;
+  std::string err;
   ASSERT_FALSE(lexer.ReadVarValue(&eval, &err));
   EXPECT_EQ("input:2: bad $-escape (literal $ must be written as $$)\n"
             "bad $\n"

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -30,14 +30,12 @@
 
 #include "util.h"
 
-using namespace std;
-
 LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
   const char* term = getenv("TERM");
 #ifndef _WIN32
-  smart_terminal_ = isatty(1) && term && string(term) != "dumb";
+  smart_terminal_ = isatty(1) && term && std::string(term) != "dumb";
 #else
-  if (term && string(term) == "dumb") {
+  if (term && std::string(term) == "dumb") {
     smart_terminal_ = false;
   } else {
     console_ = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -63,7 +61,7 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
   }
 }
 
-void LinePrinter::Print(string to_print, LineType type) {
+void LinePrinter::Print(std::string to_print, LineType type) {
   if (console_locked_) {
     line_buffer_ = to_print;
     line_type_ = type;
@@ -96,7 +94,7 @@ void LinePrinter::Print(string to_print, LineType type) {
                             static_cast<SHORT>(csbi.dwCursorPosition.X +
                                                csbi.dwSize.X - 1),
                             csbi.dwCursorPosition.Y };
-      vector<CHAR_INFO> char_data(csbi.dwSize.X);
+      std::vector<CHAR_INFO> char_data(csbi.dwSize.X);
       for (size_t i = 0; i < static_cast<size_t>(csbi.dwSize.X); ++i) {
         char_data[i].Char.AsciiChar = i < to_print.size() ? to_print[i] : ' ';
         char_data[i].Attributes = csbi.wAttributes;
@@ -125,13 +123,13 @@ void LinePrinter::PrintOrBuffer(const char* data, size_t size) {
   if (console_locked_) {
     output_buffer_.append(data, size);
   } else {
-    // Avoid printf and C strings, since the actual output might contain null
+    // Avoid printf and C std::strings, since the actual output might contain null
     // bytes like UTF-16 does (yuck).
     fwrite(data, 1, size, stdout);
   }
 }
 
-void LinePrinter::PrintOnNewLine(const string& to_print) {
+void LinePrinter::PrintOnNewLine(const std::string& to_print) {
   if (console_locked_ && !line_buffer_.empty()) {
     output_buffer_.append(line_buffer_);
     output_buffer_.append(1, '\n');

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -23,7 +23,6 @@
 #include "util.h"
 #include "version.h"
 
-using namespace std;
 
 ManifestParser::ManifestParser(State* state, FileReader* file_reader,
                                ManifestParserOptions options)
@@ -32,8 +31,8 @@ ManifestParser::ManifestParser(State* state, FileReader* file_reader,
   env_ = &state->bindings_;
 }
 
-bool ManifestParser::Parse(const string& filename, const string& input,
-                           string* err) {
+bool ManifestParser::Parse(const std::string& filename, const std::string& input,
+                           std::string* err) {
   lexer_.Start(filename, input);
 
   for (;;) {
@@ -57,11 +56,11 @@ bool ManifestParser::Parse(const string& filename, const string& input,
       break;
     case Lexer::IDENT: {
       lexer_.UnreadToken();
-      string name;
+      std::string name;
       EvalString let_value;
       if (!ParseLet(&name, &let_value, err))
         return false;
-      string value = let_value.Evaluate(env_);
+      std::string value = let_value.Evaluate(env_);
       // Check ninja_required_version immediately so we can exit
       // before encountering any syntactic surprises.
       if (name == "ninja_required_version")
@@ -85,7 +84,7 @@ bool ManifestParser::Parse(const string& filename, const string& input,
     case Lexer::NEWLINE:
       break;
     default:
-      return lexer_.Error(string("unexpected ") + Lexer::TokenName(token),
+      return lexer_.Error(std::string("unexpected ") + Lexer::TokenName(token),
                           err);
     }
   }
@@ -93,8 +92,8 @@ bool ManifestParser::Parse(const string& filename, const string& input,
 }
 
 
-bool ManifestParser::ParsePool(string* err) {
-  string name;
+bool ManifestParser::ParsePool(std::string* err) {
+  std::string name;
   if (!lexer_.ReadIdent(&name))
     return lexer_.Error("expected pool name", err);
 
@@ -107,13 +106,13 @@ bool ManifestParser::ParsePool(string* err) {
   int depth = -1;
 
   while (lexer_.PeekToken(Lexer::INDENT)) {
-    string key;
+    std::string key;
     EvalString value;
     if (!ParseLet(&key, &value, err))
       return false;
 
     if (key == "depth") {
-      string depth_string = value.Evaluate(env_);
+      std::string depth_string = value.Evaluate(env_);
       depth = atol(depth_string.c_str());
       if (depth < 0)
         return lexer_.Error("invalid pool depth", err);
@@ -130,8 +129,8 @@ bool ManifestParser::ParsePool(string* err) {
 }
 
 
-bool ManifestParser::ParseRule(string* err) {
-  string name;
+bool ManifestParser::ParseRule(std::string* err) {
+  std::string name;
   if (!lexer_.ReadIdent(&name))
     return lexer_.Error("expected rule name", err);
 
@@ -144,7 +143,7 @@ bool ManifestParser::ParseRule(string* err) {
   Rule* rule = new Rule(name);  // XXX scoped_ptr
 
   while (lexer_.PeekToken(Lexer::INDENT)) {
-    string key;
+    std::string key;
     EvalString value;
     if (!ParseLet(&key, &value, err))
       return false;
@@ -171,7 +170,7 @@ bool ManifestParser::ParseRule(string* err) {
   return true;
 }
 
-bool ManifestParser::ParseLet(string* key, EvalString* value, string* err) {
+bool ManifestParser::ParseLet(std::string* key, EvalString* value, std::string* err) {
   if (!lexer_.ReadIdent(key))
     return lexer_.Error("expected variable name", err);
   if (!ExpectToken(Lexer::EQUALS, err))
@@ -181,7 +180,7 @@ bool ManifestParser::ParseLet(string* key, EvalString* value, string* err) {
   return true;
 }
 
-bool ManifestParser::ParseDefault(string* err) {
+bool ManifestParser::ParseDefault(std::string* err) {
   EvalString eval;
   if (!lexer_.ReadPath(&eval, err))
     return false;
@@ -189,7 +188,7 @@ bool ManifestParser::ParseDefault(string* err) {
     return lexer_.Error("expected target name", err);
 
   do {
-    string path = eval.Evaluate(env_);
+    std::string path = eval.Evaluate(env_);
     if (path.empty())
       return lexer_.Error("empty path", err);
     uint64_t slash_bits;  // Unused because this only does lookup.
@@ -206,8 +205,8 @@ bool ManifestParser::ParseDefault(string* err) {
   return ExpectToken(Lexer::NEWLINE, err);
 }
 
-bool ManifestParser::ParseEdge(string* err) {
-  vector<EvalString> ins, outs, validations;
+bool ManifestParser::ParseEdge(std::string* err) {
+  std::vector<EvalString> ins, outs, validations;
 
   {
     EvalString out;
@@ -242,7 +241,7 @@ bool ManifestParser::ParseEdge(string* err) {
   if (!ExpectToken(Lexer::COLON, err))
     return false;
 
-  string rule_name;
+  std::string rule_name;
   if (!lexer_.ReadIdent(&rule_name))
     return lexer_.Error("expected build command name", err);
 
@@ -307,7 +306,7 @@ bool ManifestParser::ParseEdge(string* err) {
   bool has_indent_token = lexer_.PeekToken(Lexer::INDENT);
   BindingEnv* env = has_indent_token ? new BindingEnv(env_) : env_;
   while (has_indent_token) {
-    string key;
+    std::string key;
     EvalString val;
     if (!ParseLet(&key, &val, err))
       return false;
@@ -319,7 +318,7 @@ bool ManifestParser::ParseEdge(string* err) {
   Edge* edge = state_->AddEdge(rule);
   edge->env_ = env;
 
-  string pool_name = edge->GetBinding("pool");
+  std::string pool_name = edge->GetBinding("pool");
   if (!pool_name.empty()) {
     Pool* pool = state_->LookupPool(pool_name);
     if (pool == NULL)
@@ -329,7 +328,7 @@ bool ManifestParser::ParseEdge(string* err) {
 
   edge->outputs_.reserve(outs.size());
   for (size_t i = 0, e = outs.size(); i != e; ++i) {
-    string path = outs[i].Evaluate(env);
+    std::string path = outs[i].Evaluate(env);
     if (path.empty())
       return lexer_.Error("empty path", err);
     uint64_t slash_bits;
@@ -361,8 +360,8 @@ bool ManifestParser::ParseEdge(string* err) {
   edge->implicit_outs_ = implicit_outs;
 
   edge->inputs_.reserve(ins.size());
-  for (vector<EvalString>::iterator i = ins.begin(); i != ins.end(); ++i) {
-    string path = i->Evaluate(env);
+  for (std::vector<EvalString>::iterator i = ins.begin(); i != ins.end(); ++i) {
+    std::string path = i->Evaluate(env);
     if (path.empty())
       return lexer_.Error("empty path", err);
     uint64_t slash_bits;
@@ -375,7 +374,7 @@ bool ManifestParser::ParseEdge(string* err) {
   edge->validations_.reserve(validations.size());
   for (std::vector<EvalString>::iterator v = validations.begin();
       v != validations.end(); ++v) {
-    string path = v->Evaluate(env);
+    std::string path = v->Evaluate(env);
     if (path.empty())
       return lexer_.Error("empty path", err);
     uint64_t slash_bits;
@@ -390,7 +389,7 @@ bool ManifestParser::ParseEdge(string* err) {
     // build graph but that has since been fixed.  Filter them out to
     // support users of those old CMake versions.
     Node* out = edge->outputs_[0];
-    vector<Node*>::iterator new_end =
+    std::vector<Node*>::iterator new_end =
         remove(edge->inputs_.begin(), edge->inputs_.end(), out);
     if (new_end != edge->inputs_.end()) {
       edge->inputs_.erase(new_end, edge->inputs_.end());
@@ -405,13 +404,13 @@ bool ManifestParser::ParseEdge(string* err) {
   // Lookup, validate, and save any dyndep binding.  It will be used later
   // to load generated dependency information dynamically, but it must
   // be one of our manifest-specified inputs.
-  string dyndep = edge->GetUnescapedDyndep();
+  std::string dyndep = edge->GetUnescapedDyndep();
   if (!dyndep.empty()) {
     uint64_t slash_bits;
     CanonicalizePath(&dyndep, &slash_bits);
     edge->dyndep_ = state_->GetNode(dyndep, slash_bits);
     edge->dyndep_->set_dyndep_pending(true);
-    vector<Node*>::iterator dgi =
+    std::vector<Node*>::iterator dgi =
       std::find(edge->inputs_.begin(), edge->inputs_.end(), edge->dyndep_);
     if (dgi == edge->inputs_.end()) {
       return lexer_.Error("dyndep '" + dyndep + "' is not an input", err);
@@ -421,11 +420,11 @@ bool ManifestParser::ParseEdge(string* err) {
   return true;
 }
 
-bool ManifestParser::ParseFileInclude(bool new_scope, string* err) {
+bool ManifestParser::ParseFileInclude(bool new_scope, std::string* err) {
   EvalString eval;
   if (!lexer_.ReadPath(&eval, err))
     return false;
-  string path = eval.Evaluate(env_);
+  std::string path = eval.Evaluate(env_);
 
   ManifestParser subparser(state_, file_reader_, options_);
   if (new_scope) {

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -40,15 +40,13 @@
 #include "state.h"
 #include "util.h"
 
-using namespace std;
-
-bool WriteFakeManifests(const string& dir, string* err) {
+bool WriteFakeManifests(const std::string& dir, std::string* err) {
   RealDiskInterface disk_interface;
   TimeStamp mtime = disk_interface.Stat(dir + "/build.ninja", err);
   if (mtime != 0)  // 0 means that the file doesn't exist yet.
     return mtime != -1;
 
-  string command = "python misc/write_fake_manifests.py " + dir;
+  std::string command = "python misc/write_fake_manifests.py " + dir;
   printf("Creating manifest data..."); fflush(stdout);
   int exit_code = system(command.c_str());
   printf("done.\n");
@@ -58,7 +56,7 @@ bool WriteFakeManifests(const string& dir, string* err) {
 }
 
 int LoadManifests(bool measure_command_evaluation) {
-  string err;
+  std::string err;
   RealDiskInterface disk_interface;
   State state;
   ManifestParser parser(&state, &disk_interface);
@@ -97,7 +95,7 @@ int main(int argc, char* argv[]) {
 
   const char kManifestDir[] = "build/manifest_perftest";
 
-  string err;
+  std::string err;
   if (!WriteFakeManifests(kManifestDir, &err)) {
     fprintf(stderr, "Failed to write test data: %s\n", err.c_str());
     return 1;
@@ -107,7 +105,7 @@ int main(int argc, char* argv[]) {
     Fatal("chdir: %s", strerror(errno));
 
   const int kNumRepetitions = 5;
-  vector<int> times;
+  std::vector<int> times;
   for (int i = 0; i < kNumRepetitions; ++i) {
     int64_t start = GetTimeMillis();
     int optimization_guard = LoadManifests(measure_command_evaluation);

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -21,12 +21,11 @@
 #include "state.h"
 #include "test.h"
 
-using namespace std;
 
 struct ParserTest : public testing::Test {
   void AssertParse(const char* input) {
     ManifestParser parser(&state, &fs_);
-    string err;
+    std::string err;
     EXPECT_TRUE(parser.ParseTest(input, &err));
     ASSERT_EQ("", err);
     VerifyGraph(state);
@@ -363,7 +362,7 @@ TEST_F(ParserTest, DuplicateEdgeWithMultipleOutputsError) {
   ManifestParserOptions parser_opts;
   parser_opts.dupe_edge_action_ = kDupeEdgeActionError;
   ManifestParser parser(&state, &fs_, parser_opts);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:5: multiple rules generate out1\n", err);
 }
@@ -380,7 +379,7 @@ TEST_F(ParserTest, DuplicateEdgeInIncludedFile) {
   ManifestParserOptions parser_opts;
   parser_opts.dupe_edge_action_ = kDupeEdgeActionError;
   ManifestParser parser(&state, &fs_, parser_opts);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("sub.ninja:5: multiple rules generate out1\n", err);
 }
@@ -401,7 +400,7 @@ TEST_F(ParserTest, PhonySelfReferenceKept) {
   ManifestParserOptions parser_opts;
   parser_opts.phony_cycle_action_ = kPhonyCycleActionError;
   ManifestParser parser(&state, &fs_, parser_opts);
-  string err;
+  std::string err;
   EXPECT_TRUE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("", err);
 
@@ -423,8 +422,8 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
-    EXPECT_FALSE(parser.ParseTest(string("subn", 4), &err));
+    std::string err;
+    EXPECT_FALSE(parser.ParseTest(std::string("subn", 4), &err));
     EXPECT_EQ("input:1: expected '=', got eof\n"
               "subn\n"
               "    ^ near here"
@@ -434,7 +433,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("foobar", &err));
     EXPECT_EQ("input:1: expected '=', got eof\n"
               "foobar\n"
@@ -445,7 +444,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("x 3", &err));
     EXPECT_EQ("input:1: expected '=', got identifier\n"
               "x 3\n"
@@ -456,7 +455,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("x = 3", &err));
     EXPECT_EQ("input:1: unexpected EOF\n"
               "x = 3\n"
@@ -467,7 +466,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("x = 3\ny 2", &err));
     EXPECT_EQ("input:2: expected '=', got identifier\n"
               "y 2\n"
@@ -478,7 +477,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("x = $", &err));
     EXPECT_EQ("input:1: bad $-escape (literal $ must be written as $$)\n"
               "x = $\n"
@@ -489,7 +488,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("x = $\n $[\n", &err));
     EXPECT_EQ("input:2: bad $-escape (literal $ must be written as $$)\n"
               " $[\n"
@@ -500,7 +499,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("x = a$\n b$\n $\n", &err));
     EXPECT_EQ("input:4: unexpected EOF\n"
               , err);
@@ -509,7 +508,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("build\n", &err));
     EXPECT_EQ("input:1: expected path\n"
               "build\n"
@@ -520,7 +519,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("build x: y z\n", &err));
     EXPECT_EQ("input:1: unknown build rule 'y'\n"
               "build x: y z\n"
@@ -531,7 +530,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("build x:: y z\n", &err));
     EXPECT_EQ("input:1: expected build command name\n"
               "build x:: y z\n"
@@ -542,7 +541,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n  command = cat ok\n"
                                   "build x: cat $\n :\n",
                                   &err));
@@ -555,7 +554,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n",
                                   &err));
     EXPECT_EQ("input:2: expected 'command =' line\n", err);
@@ -564,7 +563,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = echo\n"
                                   "rule cat\n"
@@ -578,7 +577,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = echo\n"
                                   "  rspfile = cat.rsp\n", &err));
@@ -590,7 +589,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = ${fafsd\n"
                                   "foo = bar\n",
@@ -605,7 +604,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = cat\n"
                                   "build $.: cat foo\n",
@@ -620,7 +619,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cat\n"
                                   "  command = cat\n"
                                   "build $: cat foo\n",
@@ -634,7 +633,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule %foo\n",
                                   &err));
     EXPECT_EQ("input:1: expected rule name\n"
@@ -646,7 +645,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n"
                                   "  command = foo\n"
                                   "  othervar = bar\n",
@@ -660,7 +659,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n"
                                   "build $.: cc bar.cc\n",
                                   &err));
@@ -673,7 +672,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n  && bar",
                                   &err));
     EXPECT_EQ("input:3: expected variable name\n"
@@ -685,7 +684,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule cc\n  command = foo\n"
                                   "build $: cc bar.cc\n",
                                   &err));
@@ -698,7 +697,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("default\n",
                                   &err));
     EXPECT_EQ("input:1: expected target name\n"
@@ -710,7 +709,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("default nonexistent\n",
                                   &err));
     EXPECT_EQ("input:1: unknown target 'nonexistent'\n"
@@ -722,7 +721,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule r\n  command = r\n"
                                   "build b: r\n"
                                   "default b:\n",
@@ -736,7 +735,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("default $a\n", &err));
     EXPECT_EQ("input:1: empty path\n"
               "default $a\n"
@@ -747,7 +746,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("rule r\n"
                                   "  command = r\n"
                                   "build $a: r $c\n", &err));
@@ -759,7 +758,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     // the indented blank line must terminate the rule
     // this also verifies that "unexpected (token)" errors are correct
     EXPECT_FALSE(parser.ParseTest("rule r\n"
@@ -772,7 +771,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("pool\n", &err));
     EXPECT_EQ("input:1: expected pool name\n"
               "pool\n"
@@ -782,7 +781,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n", &err));
     EXPECT_EQ("input:2: expected 'depth =' line\n", err);
   }
@@ -790,7 +789,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  depth = 4\n"
                                   "pool foo\n", &err));
@@ -803,7 +802,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  depth = -1\n", &err));
     EXPECT_EQ("input:2: invalid pool depth\n"
@@ -815,7 +814,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     EXPECT_FALSE(parser.ParseTest("pool foo\n"
                                   "  bar = 1\n", &err));
     EXPECT_EQ("input:2: unexpected variable 'bar'\n"
@@ -827,7 +826,7 @@ TEST_F(ParserTest, Errors) {
   {
     State local_state;
     ManifestParser parser(&local_state, NULL);
-    string err;
+    std::string err;
     // Pool names are dereferenced at edge parsing time.
     EXPECT_FALSE(parser.ParseTest("rule run\n"
                                   "  command = echo\n"
@@ -840,7 +839,7 @@ TEST_F(ParserTest, Errors) {
 TEST_F(ParserTest, MissingInput) {
   State local_state;
   ManifestParser parser(&local_state, &fs_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.Load("build.ninja", &err));
   EXPECT_EQ("loading 'build.ninja': No such file or directory", err);
 }
@@ -848,7 +847,7 @@ TEST_F(ParserTest, MissingInput) {
 TEST_F(ParserTest, MultipleOutputs) {
   State local_state;
   ManifestParser parser(&local_state, NULL);
-  string err;
+  std::string err;
   EXPECT_TRUE(parser.ParseTest("rule cc\n  command = foo\n  depfile = bar\n"
                                "build a.o b.o: cc c.cc\n",
                                &err));
@@ -858,7 +857,7 @@ TEST_F(ParserTest, MultipleOutputs) {
 TEST_F(ParserTest, MultipleOutputsWithDeps) {
   State local_state;
   ManifestParser parser(&local_state, NULL);
-  string err;
+  std::string err;
   EXPECT_TRUE(parser.ParseTest("rule cc\n  command = foo\n  deps = gcc\n"
                                "build a.o b.o: cc c.cc\n",
                                &err));
@@ -892,7 +891,7 @@ TEST_F(ParserTest, SubNinja) {
 
 TEST_F(ParserTest, MissingSubNinja) {
   ManifestParser parser(&state, &fs_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest("subninja foo.ninja\n", &err));
   EXPECT_EQ("input:1: loading 'foo.ninja': No such file or directory\n"
             "subninja foo.ninja\n"
@@ -905,7 +904,7 @@ TEST_F(ParserTest, DuplicateRuleInDifferentSubninjas) {
   fs_.Create("test.ninja", "rule cat\n"
                          "  command = cat\n");
   ManifestParser parser(&state, &fs_);
-  string err;
+  std::string err;
   EXPECT_TRUE(parser.ParseTest("rule cat\n"
                                 "  command = cat\n"
                                 "subninja test.ninja\n", &err));
@@ -918,7 +917,7 @@ TEST_F(ParserTest, DuplicateRuleInDifferentSubninjasWithInclude) {
   fs_.Create("test.ninja", "include rules.ninja\n"
                          "build x : cat\n");
   ManifestParser parser(&state, &fs_);
-  string err;
+  std::string err;
   EXPECT_TRUE(parser.ParseTest("include rules.ninja\n"
                                 "subninja test.ninja\n"
                                 "build y : cat\n", &err));
@@ -938,7 +937,7 @@ TEST_F(ParserTest, Include) {
 TEST_F(ParserTest, BrokenInclude) {
   fs_.Create("include.ninja", "build\n");
   ManifestParser parser(&state, &fs_);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest("include include.ninja\n", &err));
   EXPECT_EQ("include.ninja:1: expected path\n"
             "build\n"
@@ -1023,7 +1022,7 @@ TEST_F(ParserTest, ImplicitOutputDupes) {
 
 TEST_F(ParserTest, NoExplicitOutput) {
   ManifestParser parser(&state, NULL);
-  string err;
+  std::string err;
   EXPECT_TRUE(parser.ParseTest(
 "rule cat\n"
 "  command = cat $in > $out\n"
@@ -1038,7 +1037,7 @@ TEST_F(ParserTest, DefaultDefault) {
 "build c: cat foo\n"
 "build d: cat foo\n"));
 
-  string err;
+  std::string err;
   EXPECT_EQ(4u, state.DefaultNodes(&err).size());
   EXPECT_EQ("", err);
 }
@@ -1048,7 +1047,7 @@ TEST_F(ParserTest, DefaultDefaultCycle) {
 "rule cat\n  command = cat $in > $out\n"
 "build a: cat a\n"));
 
-  string err;
+  std::string err;
   EXPECT_EQ(0u, state.DefaultNodes(&err).size());
   EXPECT_EQ("could not determine root nodes of build graph", err);
 }
@@ -1064,8 +1063,8 @@ TEST_F(ParserTest, DefaultStatements) {
 "default a b\n"
 "default $third\n"));
 
-  string err;
-  vector<Node*> nodes = state.DefaultNodes(&err);
+  std::string err;
+  std::vector<Node*> nodes = state.DefaultNodes(&err);
   EXPECT_EQ("", err);
   ASSERT_EQ(3u, nodes.size());
   EXPECT_EQ("a", nodes[0]->path());
@@ -1083,7 +1082,7 @@ TEST_F(ParserTest, UTF8) {
 TEST_F(ParserTest, CRLF) {
   State local_state;
   ManifestParser parser(&local_state, NULL);
-  string err;
+  std::string err;
 
   EXPECT_TRUE(parser.ParseTest("# comment with crlf\r\n", &err));
   EXPECT_TRUE(parser.ParseTest("foo = foo\nbar = bar\r\n", &err));
@@ -1108,7 +1107,7 @@ TEST_F(ParserTest, DyndepNotSpecified) {
 TEST_F(ParserTest, DyndepNotInput) {
   State lstate;
   ManifestParser parser(&lstate, NULL);
-  string err;
+  std::string err;
   EXPECT_FALSE(parser.ParseTest(
 "rule touch\n"
 "  command = touch $out\n"

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -21,6 +21,7 @@
 #ifndef _WIN32
 #include <sys/time.h>
 #else
+#define NOMINMAX
 #include <windows.h>
 #endif
 
@@ -28,7 +29,6 @@
 
 #include "util.h"
 
-using namespace std;
 
 Metrics* g_metrics = NULL;
 
@@ -91,7 +91,7 @@ ScopedMetric::~ScopedMetric() {
   metric_->sum += dt;
 }
 
-Metric* Metrics::NewMetric(const string& name) {
+Metric* Metrics::NewMetric(const std::string& name) {
   Metric* metric = new Metric;
   metric->name = name;
   metric->count = 0;
@@ -101,20 +101,20 @@ Metric* Metrics::NewMetric(const string& name) {
 }
 
 void Metrics::Report() {
-  int width = 0;
-  for (vector<Metric*>::iterator i = metrics_.begin();
+  size_t width = 0;
+  for (std::vector<Metric*>::iterator i = metrics_.begin();
        i != metrics_.end(); ++i) {
-    width = max((int)(*i)->name.size(), width);
+    width = std::max((*i)->name.size(), width);
   }
 
-  printf("%-*s\t%-6s\t%-9s\t%s\n", width,
+  printf("%-*s\t%-6s\t%-9s\t%s\n", (int)width,
          "metric", "count", "avg (us)", "total (ms)");
-  for (vector<Metric*>::iterator i = metrics_.begin();
+  for (std::vector<Metric*>::iterator i = metrics_.begin();
        i != metrics_.end(); ++i) {
     Metric* metric = *i;
     double total = metric->sum / (double)1000;
     double avg = metric->sum / (double)metric->count;
-    printf("%-*s\t%-6d\t%-8.1f\t%.1f\n", width, metric->name.c_str(),
+    printf("%-*s\t%-6d\t%-8.1f\t%.1f\n", (int)width, metric->name.c_str(),
            metric->count, avg, total);
   }
 }

--- a/src/minidump-win32.cc
+++ b/src/minidump-win32.cc
@@ -19,7 +19,6 @@
 
 #include "util.h"
 
-using namespace std;
 
 typedef BOOL (WINAPI *MiniDumpWriteDumpFunc) (
     IN HANDLE,

--- a/src/msvc_helper-win32.cc
+++ b/src/msvc_helper-win32.cc
@@ -18,14 +18,13 @@
 
 #include "util.h"
 
-using namespace std;
 
 namespace {
 
-string Replace(const string& input, const string& find, const string& replace) {
-  string result = input;
+std::string Replace(const std::string& input, const std::string& find, const std::string& replace) {
+  std::string result = input;
   size_t start_pos = 0;
-  while ((start_pos = result.find(find, start_pos)) != string::npos) {
+  while ((start_pos = result.find(find, start_pos)) != std::string::npos) {
     result.replace(start_pos, find.length(), replace);
     start_pos += replace.length();
   }
@@ -34,12 +33,12 @@ string Replace(const string& input, const string& find, const string& replace) {
 
 }  // anonymous namespace
 
-string EscapeForDepfile(const string& path) {
+std::string EscapeForDepfile(const std::string& path) {
   // Depfiles don't escape single \.
   return Replace(path, " ", "\\ ");
 }
 
-int CLWrapper::Run(const string& command, string* output) {
+int CLWrapper::Run(const std::string& command, std::string* output) {
   SECURITY_ATTRIBUTES security_attributes = {};
   security_attributes.nLength = sizeof(SECURITY_ATTRIBUTES);
   security_attributes.bInheritHandle = TRUE;

--- a/src/msvc_helper_main-win32.cc
+++ b/src/msvc_helper_main-win32.cc
@@ -24,7 +24,6 @@
 
 #include "getopt.h"
 
-using namespace std;
 
 namespace {
 
@@ -38,7 +37,7 @@ void Usage() {
          );
 }
 
-void PushPathIntoEnvironment(const string& env_block) {
+void PushPathIntoEnvironment(const std::string& env_block) {
   const char* as_str = env_block.c_str();
   while (as_str[0]) {
     if (_strnicmp(as_str, "path=", 5) == 0) {
@@ -51,7 +50,7 @@ void PushPathIntoEnvironment(const string& env_block) {
 }
 
 void WriteDepFileOrDie(const char* object_path, const CLParser& parse) {
-  string depfile_path = string(object_path) + ".d";
+  std::string depfile_path = std::string(object_path) + ".d";
   FILE* depfile = fopen(depfile_path.c_str(), "w");
   if (!depfile) {
     unlink(object_path);
@@ -64,8 +63,8 @@ void WriteDepFileOrDie(const char* object_path, const CLParser& parse) {
     unlink(depfile_path.c_str());
     Fatal("writing %s", depfile_path.c_str());
   }
-  const set<string>& headers = parse.includes_;
-  for (set<string>::const_iterator i = headers.begin();
+  const std::set<std::string>& headers = parse.includes_;
+  for (std::set<std::string>::const_iterator i = headers.begin();
        i != headers.end(); ++i) {
     if (fprintf(depfile, "%s\n", EscapeForDepfile(*i).c_str()) < 0) {
       unlink(object_path);
@@ -88,7 +87,7 @@ int MSVCHelperMain(int argc, char** argv) {
     { NULL, 0, NULL, 0 }
   };
   int opt;
-  string deps_prefix;
+  std::string deps_prefix;
   while ((opt = getopt_long(argc, argv, "e:o:p:h", kLongOptions, NULL)) != -1) {
     switch (opt) {
       case 'e':
@@ -107,9 +106,9 @@ int MSVCHelperMain(int argc, char** argv) {
     }
   }
 
-  string env;
+  std::string env;
   if (envfile) {
-    string err;
+    std::string err;
     if (ReadFile(envfile, &env, &err) != 0)
       Fatal("couldn't open %s: %s", envfile, err.c_str());
     PushPathIntoEnvironment(env);
@@ -125,12 +124,12 @@ int MSVCHelperMain(int argc, char** argv) {
   CLWrapper cl;
   if (!env.empty())
     cl.SetEnvBlock((void*)env.data());
-  string output;
+  std::string output;
   int exit_code = cl.Run(command, &output);
 
   if (output_filename) {
     CLParser parser;
-    string err;
+    std::string err;
     if (!parser.Parse(output, deps_prefix, &output, &err))
       Fatal("%s\n", err.c_str());
     WriteDepFileOrDie(output_filename, parser);
@@ -142,7 +141,7 @@ int MSVCHelperMain(int argc, char** argv) {
   // CLWrapper's output already as \r\n line endings, make sure the C runtime
   // doesn't expand this to \r\r\n.
   _setmode(_fileno(stdout), _O_BINARY);
-  // Avoid printf and C strings, since the actual output might contain null
+  // Avoid printf and C std::strings, since the actual output might contain null
   // bytes like UTF-16 does (yuck).
   fwrite(&output[0], 1, output.size(), stdout);
 

--- a/src/msvc_helper_test.cc
+++ b/src/msvc_helper_test.cc
@@ -17,7 +17,6 @@
 #include "test.h"
 #include "util.h"
 
-using namespace std;
 
 TEST(EscapeForDepfileTest, SpacesInFilename) {
   ASSERT_EQ("sub\\some\\ sdk\\foo.h",
@@ -28,14 +27,14 @@ TEST(MSVCHelperTest, EnvBlock) {
   char env_block[] = "foo=bar\0";
   CLWrapper cl;
   cl.SetEnvBlock(env_block);
-  string output;
+  std::string output;
   cl.Run("cmd /c \"echo foo is %foo%", &output);
   ASSERT_EQ("foo is bar\r\n", output);
 }
 
 TEST(MSVCHelperTest, NoReadOfStderr) {
   CLWrapper cl;
-  string output;
+  std::string output;
   cl.Run("cmd /c \"echo to stdout&& echo to stderr 1>&2", &output);
   ASSERT_EQ("to stdout\r\n", output);
 }

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -24,6 +24,7 @@
 #ifdef _WIN32
 #include "getopt.h"
 #include <direct.h>
+#define NOMINMAX
 #include <windows.h>
 #elif defined(_AIX)
 #include "getopt.h"
@@ -52,7 +53,6 @@
 #include "util.h"
 #include "version.h"
 
-using namespace std;
 
 #ifdef _WIN32
 // Defined in msvc_helper_main-win32.cc.
@@ -104,7 +104,7 @@ struct NinjaMain : public BuildLogUser {
   RealDiskInterface disk_interface_;
 
   /// The build directory, used for storing the build log etc.
-  string build_dir_;
+  std::string build_dir_;
 
   BuildLog build_log_;
   DepsLog deps_log_;
@@ -114,11 +114,11 @@ struct NinjaMain : public BuildLogUser {
 
   /// Get the Node for a given command-line path, handling features like
   /// spell correction.
-  Node* CollectTarget(const char* cpath, string* err);
+  Node* CollectTarget(const char* cpath, std::string* err);
 
   /// CollectTarget for all command-line arguments, filling in \a targets.
   bool CollectTargetsFromArgs(int argc, char* argv[],
-                              vector<Node*>* targets, string* err);
+                              std::vector<Node*>* targets, std::string* err);
 
   // The various subcommands, run via "-t XXX".
   int ToolGraph(const Options* options, int argc, char* argv[]);
@@ -154,7 +154,7 @@ struct NinjaMain : public BuildLogUser {
   /// Rebuild the manifest, if necessary.
   /// Fills in \a err on error.
   /// @return true if the manifest was rebuilt.
-  bool RebuildManifest(const char* input_file, string* err, Status* status);
+  bool RebuildManifest(const char* input_file, std::string* err, Status* status);
 
   /// Build the targets listed on the command line.
   /// @return an exit code.
@@ -176,7 +176,7 @@ struct NinjaMain : public BuildLogUser {
     // which seems good enough for this corner case.)
     // Do keep entries around for files which still exist on disk, for
     // generators that want to use this information.
-    string err;
+    std::string err;
     TimeStamp mtime = disk_interface_.Stat(s.AsString(), &err);
     if (mtime == -1)
       Error("%s", err.c_str());  // Log and ignore Stat() errors.
@@ -253,9 +253,9 @@ int GuessParallelism() {
 
 /// Rebuild the build manifest, if necessary.
 /// Returns true if the manifest was rebuilt.
-bool NinjaMain::RebuildManifest(const char* input_file, string* err,
+bool NinjaMain::RebuildManifest(const char* input_file, std::string* err,
                                 Status* status) {
-  string path = input_file;
+  std::string path = input_file;
   if (path.empty()) {
     *err = "empty path";
     return false;
@@ -289,8 +289,8 @@ bool NinjaMain::RebuildManifest(const char* input_file, string* err,
   return true;
 }
 
-Node* NinjaMain::CollectTarget(const char* cpath, string* err) {
-  string path = cpath;
+Node* NinjaMain::CollectTarget(const char* cpath, std::string* err) {
+  std::string path = cpath;
   if (path.empty()) {
     *err = "empty path";
     return NULL;
@@ -343,7 +343,7 @@ Node* NinjaMain::CollectTarget(const char* cpath, string* err) {
 }
 
 bool NinjaMain::CollectTargetsFromArgs(int argc, char* argv[],
-                                       vector<Node*>* targets, string* err) {
+                                       std::vector<Node*>* targets, std::string* err) {
   if (argc == 0) {
     *targets = state_.DefaultNodes(err);
     return err->empty();
@@ -359,8 +359,8 @@ bool NinjaMain::CollectTargetsFromArgs(int argc, char* argv[],
 }
 
 int NinjaMain::ToolGraph(const Options* options, int argc, char* argv[]) {
-  vector<Node*> nodes;
-  string err;
+  std::vector<Node*> nodes;
+  std::string err;
   if (!CollectTargetsFromArgs(argc, argv, &nodes, &err)) {
     Error("%s", err.c_str());
     return 1;
@@ -368,7 +368,7 @@ int NinjaMain::ToolGraph(const Options* options, int argc, char* argv[]) {
 
   GraphViz graph(&state_, &disk_interface_);
   graph.Start();
-  for (vector<Node*>::const_iterator n = nodes.begin(); n != nodes.end(); ++n)
+  for (std::vector<Node*>::const_iterator n = nodes.begin(); n != nodes.end(); ++n)
     graph.AddTarget(*n);
   graph.Finish();
 
@@ -384,7 +384,7 @@ int NinjaMain::ToolQuery(const Options* options, int argc, char* argv[]) {
   DyndepLoader dyndep_loader(&state_, &disk_interface_);
 
   for (int i = 0; i < argc; ++i) {
-    string err;
+    std::string err;
     Node* node = CollectTarget(argv[i], &err);
     if (!node) {
       Error("%s", err.c_str());
@@ -416,9 +416,9 @@ int NinjaMain::ToolQuery(const Options* options, int argc, char* argv[]) {
       }
     }
     printf("  outputs:\n");
-    for (vector<Edge*>::const_iterator edge = node->out_edges().begin();
+    for (std::vector<Edge*>::const_iterator edge = node->out_edges().begin();
          edge != node->out_edges().end(); ++edge) {
-      for (vector<Node*>::iterator out = (*edge)->outputs_.begin();
+      for (std::vector<Node*>::iterator out = (*edge)->outputs_.begin();
            out != (*edge)->outputs_.end(); ++out) {
         printf("    %s\n", (*out)->path().c_str());
       }
@@ -428,7 +428,7 @@ int NinjaMain::ToolQuery(const Options* options, int argc, char* argv[]) {
       printf("  validation for:\n");
       for (std::vector<Edge*>::const_iterator edge = validation_edges.begin();
            edge != validation_edges.end(); ++edge) {
-        for (vector<Node*>::iterator out = (*edge)->outputs_.begin();
+        for (std::vector<Node*>::iterator out = (*edge)->outputs_.begin();
              out != (*edge)->outputs_.end(); ++out) {
           printf("    %s\n", (*out)->path().c_str());
         }
@@ -461,8 +461,8 @@ int NinjaMain::ToolMSVC(const Options* options, int argc, char* argv[]) {
 }
 #endif
 
-int ToolTargetsList(const vector<Node*>& nodes, int depth, int indent) {
-  for (vector<Node*>::const_iterator n = nodes.begin();
+int ToolTargetsList(const std::vector<Node*>& nodes, int depth, int indent) {
+  for (std::vector<Node*>::const_iterator n = nodes.begin();
        n != nodes.end();
        ++n) {
     for (int i = 0; i < indent; ++i)
@@ -480,9 +480,9 @@ int ToolTargetsList(const vector<Node*>& nodes, int depth, int indent) {
 }
 
 int ToolTargetsSourceList(State* state) {
-  for (vector<Edge*>::iterator e = state->edges_.begin();
+  for (std::vector<Edge*>::iterator e = state->edges_.begin();
        e != state->edges_.end(); ++e) {
-    for (vector<Node*>::iterator inps = (*e)->inputs_.begin();
+    for (std::vector<Node*>::iterator inps = (*e)->inputs_.begin();
          inps != (*e)->inputs_.end(); ++inps) {
       if (!(*inps)->in_edge())
         printf("%s\n", (*inps)->path().c_str());
@@ -491,14 +491,14 @@ int ToolTargetsSourceList(State* state) {
   return 0;
 }
 
-int ToolTargetsList(State* state, const string& rule_name) {
-  set<string> rules;
+int ToolTargetsList(State* state, const std::string& rule_name) {
+  std::set<std::string> rules;
 
   // Gather the outputs.
-  for (vector<Edge*>::iterator e = state->edges_.begin();
+  for (std::vector<Edge*>::iterator e = state->edges_.begin();
        e != state->edges_.end(); ++e) {
     if ((*e)->rule_->name() == rule_name) {
-      for (vector<Node*>::iterator out_node = (*e)->outputs_.begin();
+      for (std::vector<Node*>::iterator out_node = (*e)->outputs_.begin();
            out_node != (*e)->outputs_.end(); ++out_node) {
         rules.insert((*out_node)->path());
       }
@@ -506,7 +506,7 @@ int ToolTargetsList(State* state, const string& rule_name) {
   }
 
   // Print them.
-  for (set<string>::const_iterator i = rules.begin();
+  for (std::set<std::string>::const_iterator i = rules.begin();
        i != rules.end(); ++i) {
     printf("%s\n", (*i).c_str());
   }
@@ -515,9 +515,9 @@ int ToolTargetsList(State* state, const string& rule_name) {
 }
 
 int ToolTargetsList(State* state) {
-  for (vector<Edge*>::iterator e = state->edges_.begin();
+  for (std::vector<Edge*>::iterator e = state->edges_.begin();
        e != state->edges_.end(); ++e) {
-    for (vector<Node*>::iterator out_node = (*e)->outputs_.begin();
+    for (std::vector<Node*>::iterator out_node = (*e)->outputs_.begin();
          out_node != (*e)->outputs_.end(); ++out_node) {
       printf("%s: %s\n",
              (*out_node)->path().c_str(),
@@ -528,15 +528,15 @@ int ToolTargetsList(State* state) {
 }
 
 int NinjaMain::ToolDeps(const Options* options, int argc, char** argv) {
-  vector<Node*> nodes;
+  std::vector<Node*> nodes;
   if (argc == 0) {
-    for (vector<Node*>::const_iterator ni = deps_log_.nodes().begin();
+    for (std::vector<Node*>::const_iterator ni = deps_log_.nodes().begin();
          ni != deps_log_.nodes().end(); ++ni) {
       if (DepsLog::IsDepsEntryLiveFor(*ni))
         nodes.push_back(*ni);
     }
   } else {
-    string err;
+    std::string err;
     if (!CollectTargetsFromArgs(argc, argv, &nodes, &err)) {
       Error("%s", err.c_str());
       return 1;
@@ -544,7 +544,7 @@ int NinjaMain::ToolDeps(const Options* options, int argc, char** argv) {
   }
 
   RealDiskInterface disk_interface;
-  for (vector<Node*>::iterator it = nodes.begin(), end = nodes.end();
+  for (std::vector<Node*>::iterator it = nodes.begin(), end = nodes.end();
        it != end; ++it) {
     DepsLog::Deps* deps = deps_log_.GetDeps(*it);
     if (!deps) {
@@ -552,7 +552,7 @@ int NinjaMain::ToolDeps(const Options* options, int argc, char** argv) {
       continue;
     }
 
-    string err;
+    std::string err;
     TimeStamp mtime = disk_interface.Stat((*it)->path(), &err);
     if (mtime == -1)
       Error("%s", err.c_str());  // Log and ignore Stat() errors;
@@ -568,8 +568,8 @@ int NinjaMain::ToolDeps(const Options* options, int argc, char** argv) {
 }
 
 int NinjaMain::ToolMissingDeps(const Options* options, int argc, char** argv) {
-  vector<Node*> nodes;
-  string err;
+  std::vector<Node*> nodes;
+  std::string err;
   if (!CollectTargetsFromArgs(argc, argv, &nodes, &err)) {
     Error("%s", err.c_str());
     return 1;
@@ -578,7 +578,7 @@ int NinjaMain::ToolMissingDeps(const Options* options, int argc, char** argv) {
   MissingDependencyPrinter printer;
   MissingDependencyScanner scanner(&printer, &deps_log_, &state_,
                                    &disk_interface);
-  for (vector<Node*>::iterator it = nodes.begin(); it != nodes.end(); ++it) {
+  for (std::vector<Node*>::iterator it = nodes.begin(); it != nodes.end(); ++it) {
     scanner.ProcessNode(*it);
   }
   scanner.PrintStats();
@@ -590,9 +590,9 @@ int NinjaMain::ToolMissingDeps(const Options* options, int argc, char** argv) {
 int NinjaMain::ToolTargets(const Options* options, int argc, char* argv[]) {
   int depth = 1;
   if (argc >= 1) {
-    string mode = argv[0];
+    std::string mode = argv[0];
     if (mode == "rule") {
-      string rule;
+      std::string rule;
       if (argc > 1)
         rule = argv[1];
       if (rule.empty())
@@ -617,8 +617,8 @@ int NinjaMain::ToolTargets(const Options* options, int argc, char* argv[]) {
     }
   }
 
-  string err;
-  vector<Node*> root_nodes = state_.RootNodes(&err);
+  std::string err;
+  std::vector<Node*> root_nodes = state_.RootNodes(&err);
   if (err.empty()) {
     return ToolTargetsList(root_nodes, depth, 0);
   } else {
@@ -660,7 +660,7 @@ int NinjaMain::ToolRules(const Options* options, int argc, char* argv[]) {
 
   // Print rules
 
-  typedef map<string, const Rule*> Rules;
+  typedef std::map<std::string, const Rule*> Rules;
   const Rules& rules = state_.bindings_.GetRules();
   for (Rules::const_iterator i = rules.begin(); i != rules.end(); ++i) {
     printf("%s", i->first.c_str());
@@ -695,7 +695,7 @@ void PrintCommands(Edge* edge, EdgeSet* seen, PrintCommandMode mode) {
     return;
 
   if (mode == PCM_All) {
-    for (vector<Node*>::iterator in = edge->inputs_.begin();
+    for (std::vector<Node*>::iterator in = edge->inputs_.begin();
          in != edge->inputs_.end(); ++in)
       PrintCommands((*in)->in_edge(), seen, mode);
   }
@@ -732,15 +732,15 @@ int NinjaMain::ToolCommands(const Options* options, int argc, char* argv[]) {
   argv += optind;
   argc -= optind;
 
-  vector<Node*> nodes;
-  string err;
+  std::vector<Node*> nodes;
+  std::string err;
   if (!CollectTargetsFromArgs(argc, argv, &nodes, &err)) {
     Error("%s", err.c_str());
     return 1;
   }
 
   EdgeSet seen;
-  for (vector<Node*>::iterator in = nodes.begin(); in != nodes.end(); ++in)
+  for (std::vector<Node*>::iterator in = nodes.begin(); in != nodes.end(); ++in)
     PrintCommands((*in)->in_edge(), &seen, mode);
 
   return 0;
@@ -753,7 +753,7 @@ void CollectInputs(Edge* edge, std::set<Edge*>* seen,
   if (!seen->insert(edge).second)
     return;
 
-  for (vector<Node*>::iterator in = edge->inputs_.begin();
+  for (std::vector<Node*>::iterator in = edge->inputs_.begin();
        in != edge->inputs_.end(); ++in)
     CollectInputs((*in)->in_edge(), seen, result);
 
@@ -790,8 +790,8 @@ int NinjaMain::ToolInputs(const Options* options, int argc, char* argv[]) {
   argv += optind;
   argc -= optind;
 
-  vector<Node*> nodes;
-  string err;
+  std::vector<Node*> nodes;
+  std::string err;
   if (!CollectTargetsFromArgs(argc, argv, &nodes, &err)) {
     Error("%s", err.c_str());
     return 1;
@@ -799,7 +799,7 @@ int NinjaMain::ToolInputs(const Options* options, int argc, char* argv[]) {
 
   std::set<Edge*> seen;
   std::vector<std::string> result;
-  for (vector<Node*>::iterator in = nodes.begin(); in != nodes.end(); ++in)
+  for (std::vector<Node*>::iterator in = nodes.begin(); in != nodes.end(); ++in)
     CollectInputs((*in)->in_edge(), &seen, &result);
 
   // Make output deterministic by sorting then removing duplicates.
@@ -872,22 +872,22 @@ enum EvaluateCommandMode {
 };
 std::string EvaluateCommandWithRspfile(const Edge* edge,
                                        const EvaluateCommandMode mode) {
-  string command = edge->EvaluateCommand();
+  std::string command = edge->EvaluateCommand();
   if (mode == ECM_NORMAL)
     return command;
 
-  string rspfile = edge->GetUnescapedRspfile();
+  std::string rspfile = edge->GetUnescapedRspfile();
   if (rspfile.empty())
     return command;
 
   size_t index = command.find(rspfile);
-  if (index == 0 || index == string::npos || command[index - 1] != '@')
+  if (index == 0 || index == std::string::npos || command[index - 1] != '@')
     return command;
 
-  string rspfile_content = edge->GetBinding("rspfile_content");
+  std::string rspfile_content = edge->GetBinding("rspfile_content");
   size_t newline_index = 0;
   while ((newline_index = rspfile_content.find('\n', newline_index)) !=
-         string::npos) {
+         std::string::npos) {
     rspfile_content.replace(newline_index, 1, 1, ' ');
     ++newline_index;
   }
@@ -940,7 +940,7 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
   argc -= optind;
 
   bool first = true;
-  vector<char> cwd;
+  std::vector<char> cwd;
   char* success = NULL;
 
   do {
@@ -954,7 +954,7 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
   }
 
   putchar('[');
-  for (vector<Edge*>::iterator e = state_.edges_.begin();
+  for (std::vector<Edge*>::iterator e = state_.edges_.begin();
        e != state_.edges_.end(); ++e) {
     if ((*e)->inputs_.empty())
       continue;
@@ -1014,11 +1014,11 @@ int NinjaMain::ToolRestat(const Options* options, int argc, char* argv[]) {
   if (!EnsureBuildDirExists())
     return 1;
 
-  string log_path = ".ninja_log";
+  std::string log_path = ".ninja_log";
   if (!build_dir_.empty())
     log_path = build_dir_ + "/" + log_path;
 
-  string err;
+  std::string err;
   const LoadStatus status = build_log_.Load(log_path, &err);
   if (status == LOAD_ERROR) {
     Error("loading build log %s: %s", log_path.c_str(), err.c_str());
@@ -1068,7 +1068,7 @@ int NinjaMain::ToolUrtle(const Options* options, int argc, char** argv) {
     if ('0' <= *p && *p <= '9') {
       count = count*10 + *p - '0';
     } else {
-      for (int i = 0; i < max(count, 1); ++i)
+      for (int i = 0; i < std::max(count, 1); ++i)
         printf("%c", *p);
       count = 0;
     }
@@ -1078,7 +1078,7 @@ int NinjaMain::ToolUrtle(const Options* options, int argc, char** argv) {
 
 /// Find the function to execute for \a tool_name and return it via \a func.
 /// Returns a Tool, or NULL if Ninja should exit.
-const Tool* ChooseTool(const string& tool_name) {
+const Tool* ChooseTool(const std::string& tool_name) {
   static const Tool kTools[] = {
     { "browse", "browse dependency graph in a web browser",
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolBrowse },
@@ -1135,7 +1135,7 @@ const Tool* ChooseTool(const string& tool_name) {
       return tool;
   }
 
-  vector<const char*> words;
+  std::vector<const char*> words;
   for (const Tool* tool = &kTools[0]; tool->name; ++tool)
     words.push_back(tool->name);
   const char* suggestion = SpellcheckStringV(tool_name, words);
@@ -1150,7 +1150,7 @@ const Tool* ChooseTool(const string& tool_name) {
 
 /// Enable a debugging mode.  Returns false if Ninja should exit instead
 /// of continuing.
-bool DebugEnable(const string& name) {
+bool DebugEnable(const std::string& name) {
   if (name == "list") {
     printf("debugging modes:\n"
 "  stats        print operation counts/timing info\n"
@@ -1194,7 +1194,7 @@ bool DebugEnable(const string& name) {
 
 /// Set a warning flag.  Returns false if Ninja should exit instead of
 /// continuing.
-bool WarningEnable(const string& name, Options* options) {
+bool WarningEnable(const std::string& name, Options* options) {
   if (name == "list") {
     printf("warning flags:\n"
 "  phonycycle={err,warn}  phony build statement references itself\n"
@@ -1231,11 +1231,11 @@ bool WarningEnable(const string& name, Options* options) {
 }
 
 bool NinjaMain::OpenBuildLog(bool recompact_only) {
-  string log_path = ".ninja_log";
+  std::string log_path = ".ninja_log";
   if (!build_dir_.empty())
     log_path = build_dir_ + "/" + log_path;
 
-  string err;
+  std::string err;
   const LoadStatus status = build_log_.Load(log_path, &err);
   if (status == LOAD_ERROR) {
     Error("loading build log %s: %s", log_path.c_str(), err.c_str());
@@ -1270,11 +1270,11 @@ bool NinjaMain::OpenBuildLog(bool recompact_only) {
 /// Open the deps log: load it, then open for writing.
 /// @return false on error.
 bool NinjaMain::OpenDepsLog(bool recompact_only) {
-  string path = ".ninja_deps";
+  std::string path = ".ninja_deps";
   if (!build_dir_.empty())
     path = build_dir_ + "/" + path;
 
-  string err;
+  std::string err;
   const LoadStatus status = deps_log_.Load(path, &state_, &err);
   if (status == LOAD_ERROR) {
     Error("loading deps log %s: %s", path.c_str(), err.c_str());
@@ -1329,8 +1329,8 @@ bool NinjaMain::EnsureBuildDirExists() {
 }
 
 int NinjaMain::RunBuild(int argc, char** argv, Status* status) {
-  string err;
-  vector<Node*> targets;
+  std::string err;
+  std::vector<Node*> targets;
   if (!CollectTargetsFromArgs(argc, argv, &targets, &err)) {
     status->Error("%s", err.c_str());
     return 1;
@@ -1362,7 +1362,7 @@ int NinjaMain::RunBuild(int argc, char** argv, Status* status) {
 
   if (!builder.Build(&err)) {
     status->Info("build stopped: %s.", err.c_str());
-    if (err.find("interrupted by user") != string::npos) {
+    if (err.find("interrupted by user") != std::string::npos) {
       return 2;
     }
     return 1;
@@ -1525,7 +1525,7 @@ NORETURN void real_main(int argc, char** argv) {
   Status* status = new StatusPrinter(config);
 
   if (options.working_dir) {
-    // The formatting of this string, complete with funny quotes, is
+    // The formatting of this std::string, complete with funny quotes, is
     // so Emacs can properly identify that the cwd has changed for
     // subsequent commands.
     // Don't print this if a tool is being used, so that tool output
@@ -1557,7 +1557,7 @@ NORETURN void real_main(int argc, char** argv) {
       parser_opts.phony_cycle_action_ = kPhonyCycleActionError;
     }
     ManifestParser parser(&ninja.state_, &ninja.disk_interface_, parser_opts);
-    string err;
+    std::string err;
     if (!parser.Load(options.input_file, &err)) {
       status->Error("%s", err.c_str());
       exit(1);

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -28,7 +28,6 @@
 #include "test.h"
 #include "line_printer.h"
 
-using namespace std;
 
 struct RegisteredTest {
   testing::Test* (*factory)();
@@ -50,7 +49,7 @@ void RegisterTest(testing::Test* (*factory)(), const char* name) {
 }
 
 namespace {
-string StringPrintf(const char* format, ...) {
+std::string StringPrintf(const char* format, ...) {
   const int N = 1024;
   char buf[N];
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -17,28 +17,26 @@
 #include "disk_interface.h"
 #include "metrics.h"
 
-using namespace std;
-
-bool Parser::Load(const string& filename, string* err, Lexer* parent) {
+bool Parser::Load(const std::string& filename, std::string* err, Lexer* parent) {
   METRIC_RECORD(".ninja parse");
-  string contents;
-  string read_err;
+  std::string contents;
+  std::string read_err;
   if (file_reader_->ReadFile(filename, &contents, &read_err) !=
       FileReader::Okay) {
     *err = "loading '" + filename + "': " + read_err;
     if (parent)
-      parent->Error(string(*err), err);
+      parent->Error(std::string(*err), err);
     return false;
   }
 
   return Parse(filename, contents, err);
 }
 
-bool Parser::ExpectToken(Lexer::Token expected, string* err) {
+bool Parser::ExpectToken(Lexer::Token expected, std::string* err) {
   Lexer::Token token = lexer_.ReadToken();
   if (token != expected) {
-    string message = string("expected ") + Lexer::TokenName(expected);
-    message += string(", got ") + Lexer::TokenName(token);
+    std::string message = std::string("expected ") + Lexer::TokenName(expected);
+    message += std::string(", got ") + Lexer::TokenName(token);
     message += Lexer::TokenErrorHint(expected);
     return lexer_.Error(message, err);
   }

--- a/src/state.cc
+++ b/src/state.cc
@@ -21,7 +21,6 @@
 #include "graph.h"
 #include "util.h"
 
-using namespace std;
 
 void Pool::EdgeScheduled(const Edge& edge) {
   if (depth_ != 0)
@@ -76,8 +75,8 @@ void State::AddPool(Pool* pool) {
   pools_[pool->name()] = pool;
 }
 
-Pool* State::LookupPool(const string& pool_name) {
-  map<string, Pool*>::iterator i = pools_.find(pool_name);
+Pool* State::LookupPool(const std::string& pool_name) {
+  std::map<std::string, Pool*>::iterator i = pools_.find(pool_name);
   if (i == pools_.end())
     return NULL;
   return i->second;
@@ -109,7 +108,7 @@ Node* State::LookupNode(StringPiece path) const {
   return NULL;
 }
 
-Node* State::SpellcheckNode(const string& path) {
+Node* State::SpellcheckNode(const std::string& path) {
   const bool kAllowReplacements = true;
   const int kMaxValidEditDistance = 3;
 
@@ -147,7 +146,7 @@ void State::AddValidation(Edge* edge, StringPiece path, uint64_t slash_bits) {
   node->AddValidationOutEdge(edge);
 }
 
-bool State::AddDefault(StringPiece path, string* err) {
+bool State::AddDefault(StringPiece path, std::string* err) {
   Node* node = LookupNode(path);
   if (!node) {
     *err = "unknown target '" + path.AsString() + "'";
@@ -157,12 +156,12 @@ bool State::AddDefault(StringPiece path, string* err) {
   return true;
 }
 
-vector<Node*> State::RootNodes(string* err) const {
-  vector<Node*> root_nodes;
+std::vector<Node*> State::RootNodes(std::string* err) const {
+  std::vector<Node*> root_nodes;
   // Search for nodes with no output.
-  for (vector<Edge*>::const_iterator e = edges_.begin();
+  for (std::vector<Edge*>::const_iterator e = edges_.begin();
        e != edges_.end(); ++e) {
-    for (vector<Node*>::const_iterator out = (*e)->outputs_.begin();
+    for (std::vector<Node*>::const_iterator out = (*e)->outputs_.begin();
          out != (*e)->outputs_.end(); ++out) {
       if ((*out)->out_edges().empty())
         root_nodes.push_back(*out);
@@ -175,14 +174,14 @@ vector<Node*> State::RootNodes(string* err) const {
   return root_nodes;
 }
 
-vector<Node*> State::DefaultNodes(string* err) const {
+std::vector<Node*> State::DefaultNodes(std::string* err) const {
   return defaults_.empty() ? RootNodes(err) : defaults_;
 }
 
 void State::Reset() {
   for (Paths::iterator i = paths_.begin(); i != paths_.end(); ++i)
     i->second->ResetState();
-  for (vector<Edge*>::iterator e = edges_.begin(); e != edges_.end(); ++e) {
+  for (std::vector<Edge*>::iterator e = edges_.begin(); e != edges_.end(); ++e) {
     (*e)->outputs_ready_ = false;
     (*e)->deps_loaded_ = false;
     (*e)->mark_ = Edge::VisitNone;
@@ -200,7 +199,7 @@ void State::Dump() {
   }
   if (!pools_.empty()) {
     printf("resource_pools:\n");
-    for (map<string, Pool*>::const_iterator it = pools_.begin();
+    for (std::map<std::string, Pool*>::const_iterator it = pools_.begin();
          it != pools_.end(); ++it)
     {
       if (!it->second->name().empty()) {

--- a/src/state_test.cc
+++ b/src/state_test.cc
@@ -16,8 +16,6 @@
 #include "state.h"
 #include "test.h"
 
-using namespace std;
-
 namespace {
 
 TEST(State, Basic) {

--- a/src/status.cc
+++ b/src/status.cc
@@ -24,7 +24,6 @@
 
 #include "debug_flags.h"
 
-using namespace std;
 
 StatusPrinter::StatusPrinter(const BuildConfig& config)
     : config_(config),
@@ -59,7 +58,7 @@ void StatusPrinter::BuildEdgeStarted(const Edge* edge,
 }
 
 void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t end_time_millis,
-                                      bool success, const string& output) {
+                                      bool success, const std::string& output) {
   time_millis_ = end_time_millis;
   ++finished_edges_;
 
@@ -76,8 +75,8 @@ void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t end_time_millis,
 
   // Print the command that is spewing before printing its output.
   if (!success) {
-    string outputs;
-    for (vector<Node*>::const_iterator o = edge->outputs_.begin();
+    std::string outputs;
+    for (std::vector<Node*>::const_iterator o = edge->outputs_.begin();
          o != edge->outputs_.end(); ++o)
       outputs += (*o)->path() + " ";
 
@@ -101,7 +100,7 @@ void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t end_time_millis,
     // (Launching subprocesses in pseudo ttys doesn't work because there are
     // only a few hundred available on some systems, and ninja can launch
     // thousands of parallel compile commands.)
-    string final_output;
+    std::string final_output;
     if (!printer_.supports_color())
       final_output = StripAnsiEscapeCodes(output);
     else
@@ -145,9 +144,9 @@ void StatusPrinter::BuildFinished() {
   printer_.PrintOnNewLine("");
 }
 
-string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
-                                           int64_t time_millis) const {
-  string out;
+std::string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
+                                                int64_t time_millis) const {
+  std::string out;
   char buf[32];
   for (const char* s = progress_status_format; *s != '\0'; ++s) {
     if (*s == '%') {
@@ -234,7 +233,7 @@ void StatusPrinter::PrintStatus(const Edge* edge, int64_t time_millis) {
 
   bool force_full_command = config_.verbosity == BuildConfig::VERBOSE;
 
-  string to_print = edge->GetBinding("description");
+  std::string to_print = edge->GetBinding("description");
   if (to_print.empty() || force_full_command)
     to_print = edge->GetBinding("command");
 

--- a/src/string_piece_util.cc
+++ b/src/string_piece_util.cc
@@ -17,16 +17,15 @@
 #include <algorithm>
 #include <string>
 #include <vector>
-using namespace std;
 
-vector<StringPiece> SplitStringPiece(StringPiece input, char sep) {
-  vector<StringPiece> elems;
-  elems.reserve(count(input.begin(), input.end(), sep) + 1);
+std::vector<StringPiece> SplitStringPiece(StringPiece input, char sep) {
+  std::vector<StringPiece> elems;
+  elems.reserve(std::count(input.begin(), input.end(), sep) + 1);
 
   StringPiece::const_iterator pos = input.begin();
 
   for (;;) {
-    const char* next_pos = find(pos, input.end(), sep);
+    const char* next_pos = std::find(pos, input.end(), sep);
     if (next_pos == input.end()) {
       elems.push_back(StringPiece(pos, input.end() - pos));
       break;
@@ -38,12 +37,12 @@ vector<StringPiece> SplitStringPiece(StringPiece input, char sep) {
   return elems;
 }
 
-string JoinStringPiece(const vector<StringPiece>& list, char sep) {
+std::string JoinStringPiece(const std::vector<StringPiece>& list, char sep) {
   if (list.empty()) {
     return "";
   }
 
-  string ret;
+  std::string ret;
 
   {
     size_t cap = list.size() - 1;

--- a/src/string_piece_util_test.cc
+++ b/src/string_piece_util_test.cc
@@ -16,12 +16,11 @@
 
 #include "test.h"
 
-using namespace std;
 
 TEST(StringPieceUtilTest, SplitStringPiece) {
   {
-    string input("a:b:c");
-    vector<StringPiece> list = SplitStringPiece(input, ':');
+    std::string input("a:b:c");
+    std::vector<StringPiece> list = SplitStringPiece(input, ':');
 
     EXPECT_EQ(list.size(), 3);
 
@@ -31,8 +30,8 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
   }
 
   {
-    string empty;
-    vector<StringPiece> list = SplitStringPiece(empty, ':');
+    std::string empty;
+    std::vector<StringPiece> list = SplitStringPiece(empty, ':');
 
     EXPECT_EQ(list.size(), 1);
 
@@ -40,8 +39,8 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
   }
 
   {
-    string one("a");
-    vector<StringPiece> list = SplitStringPiece(one, ':');
+    std::string one("a");
+    std::vector<StringPiece> list = SplitStringPiece(one, ':');
 
     EXPECT_EQ(list.size(), 1);
 
@@ -49,8 +48,8 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
   }
 
   {
-    string sep_only(":");
-    vector<StringPiece> list = SplitStringPiece(sep_only, ':');
+    std::string sep_only(":");
+    std::vector<StringPiece> list = SplitStringPiece(sep_only, ':');
 
     EXPECT_EQ(list.size(), 2);
 
@@ -59,8 +58,8 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
   }
 
   {
-    string sep(":a:b:c:");
-    vector<StringPiece> list = SplitStringPiece(sep, ':');
+    std::string sep(":a:b:c:");
+    std::vector<StringPiece> list = SplitStringPiece(sep, ':');
 
     EXPECT_EQ(list.size(), 5);
 
@@ -74,36 +73,36 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
 
 TEST(StringPieceUtilTest, JoinStringPiece) {
   {
-    string input("a:b:c");
-    vector<StringPiece> list = SplitStringPiece(input, ':');
+    std::string input("a:b:c");
+    std::vector<StringPiece> list = SplitStringPiece(input, ':');
 
     EXPECT_EQ("a:b:c", JoinStringPiece(list, ':'));
     EXPECT_EQ("a/b/c", JoinStringPiece(list, '/'));
   }
 
   {
-    string empty;
-    vector<StringPiece> list = SplitStringPiece(empty, ':');
+    std::string empty;
+    std::vector<StringPiece> list = SplitStringPiece(empty, ':');
 
     EXPECT_EQ("", JoinStringPiece(list, ':'));
   }
 
   {
-    vector<StringPiece> empty_list;
+    std::vector<StringPiece> empty_list;
 
     EXPECT_EQ("", JoinStringPiece(empty_list, ':'));
   }
 
   {
-    string one("a");
-    vector<StringPiece> single_list = SplitStringPiece(one, ':');
+    std::string one("a");
+    std::vector<StringPiece> single_list = SplitStringPiece(one, ':');
 
     EXPECT_EQ("a", JoinStringPiece(single_list, ':'));
   }
 
   {
-    string sep(":a:b:c:");
-    vector<StringPiece> list = SplitStringPiece(sep, ':');
+    std::string sep(":a:b:c:");
+    std::vector<StringPiece> list = SplitStringPiece(sep, ':');
 
     EXPECT_EQ(":a:b:c:", JoinStringPiece(list, ':'));
   }

--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -34,7 +34,6 @@ extern char** environ;
 
 #include "util.h"
 
-using namespace std;
 
 Subprocess::Subprocess(bool use_console) : fd_(-1), pid_(-1),
                                            use_console_(use_console) {
@@ -48,7 +47,7 @@ Subprocess::~Subprocess() {
     Finish();
 }
 
-bool Subprocess::Start(SubprocessSet* set, const string& command) {
+bool Subprocess::Start(SubprocessSet* set, const std::string& command) {
   int output_pipe[2];
   if (pipe(output_pipe) < 0)
     Fatal("pipe: %s", strerror(errno));
@@ -180,7 +179,7 @@ bool Subprocess::Done() const {
   return fd_ == -1;
 }
 
-const string& Subprocess::GetOutput() const {
+const std::string& Subprocess::GetOutput() const {
   return buf_;
 }
 
@@ -238,7 +237,7 @@ SubprocessSet::~SubprocessSet() {
     Fatal("sigprocmask: %s", strerror(errno));
 }
 
-Subprocess *SubprocessSet::Add(const string& command, bool use_console) {
+Subprocess *SubprocessSet::Add(const std::string& command, bool use_console) {
   Subprocess *subprocess = new Subprocess(use_console);
   if (!subprocess->Start(this, command)) {
     delete subprocess;
@@ -250,10 +249,10 @@ Subprocess *SubprocessSet::Add(const string& command, bool use_console) {
 
 #ifdef USE_PPOLL
 bool SubprocessSet::DoWork() {
-  vector<pollfd> fds;
+  std::vector<pollfd> fds;
   nfds_t nfds = 0;
 
-  for (vector<Subprocess*>::iterator i = running_.begin();
+  for (std::vector<Subprocess*>::iterator i = running_.begin();
        i != running_.end(); ++i) {
     int fd = (*i)->fd_;
     if (fd < 0)
@@ -278,7 +277,7 @@ bool SubprocessSet::DoWork() {
     return true;
 
   nfds_t cur_nfd = 0;
-  for (vector<Subprocess*>::iterator i = running_.begin();
+  for (std::vector<Subprocess*>::iterator i = running_.begin();
        i != running_.end(); ) {
     int fd = (*i)->fd_;
     if (fd < 0)
@@ -304,7 +303,7 @@ bool SubprocessSet::DoWork() {
   int nfds = 0;
   FD_ZERO(&set);
 
-  for (vector<Subprocess*>::iterator i = running_.begin();
+  for (std::vector<Subprocess*>::iterator i = running_.begin();
        i != running_.end(); ++i) {
     int fd = (*i)->fd_;
     if (fd >= 0) {
@@ -328,7 +327,7 @@ bool SubprocessSet::DoWork() {
   if (IsInterrupted())
     return true;
 
-  for (vector<Subprocess*>::iterator i = running_.begin();
+  for (std::vector<Subprocess*>::iterator i = running_.begin();
        i != running_.end(); ) {
     int fd = (*i)->fd_;
     if (fd >= 0 && FD_ISSET(fd, &set)) {
@@ -355,13 +354,13 @@ Subprocess* SubprocessSet::NextFinished() {
 }
 
 void SubprocessSet::Clear() {
-  for (vector<Subprocess*>::iterator i = running_.begin();
+  for (std::vector<Subprocess*>::iterator i = running_.begin();
        i != running_.end(); ++i)
     // Since the foreground process is in our process group, it will receive
     // the interruption signal (i.e. SIGINT or SIGTERM) at the same time as us.
     if (!(*i)->use_console_)
       kill(-(*i)->pid_, interrupted_);
-  for (vector<Subprocess*>::iterator i = running_.begin();
+  for (std::vector<Subprocess*>::iterator i = running_.begin();
        i != running_.end(); ++i)
     delete *i;
   running_.clear();

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -21,7 +21,6 @@
 
 #include "util.h"
 
-using namespace std;
 
 Subprocess::Subprocess(bool use_console) : child_(NULL) , overlapped_(),
                                            is_reading_(false),
@@ -74,7 +73,7 @@ HANDLE Subprocess::SetupPipe(HANDLE ioport) {
   return output_write_child;
 }
 
-bool Subprocess::Start(SubprocessSet* set, const string& command) {
+bool Subprocess::Start(SubprocessSet* set, const std::string& command) {
   HANDLE child_pipe = SetupPipe(set->ioport_);
 
   SECURITY_ATTRIBUTES security_attributes;
@@ -207,7 +206,7 @@ bool Subprocess::Done() const {
   return pipe_ == NULL;
 }
 
-const string& Subprocess::GetOutput() const {
+const std::string& Subprocess::GetOutput() const {
   return buf_;
 }
 
@@ -238,7 +237,7 @@ BOOL WINAPI SubprocessSet::NotifyInterrupted(DWORD dwCtrlType) {
   return FALSE;
 }
 
-Subprocess *SubprocessSet::Add(const string& command, bool use_console) {
+Subprocess *SubprocessSet::Add(const std::string& command, bool use_console) {
   Subprocess *subprocess = new Subprocess(use_console);
   if (!subprocess->Start(this, command)) {
     delete subprocess;
@@ -269,7 +268,7 @@ bool SubprocessSet::DoWork() {
   subproc->OnPipeReady();
 
   if (subproc->Done()) {
-    vector<Subprocess*>::iterator end =
+    std::vector<Subprocess*>::iterator end =
         remove(running_.begin(), running_.end(), subproc);
     if (running_.end() != end) {
       finished_.push(subproc);
@@ -289,7 +288,7 @@ Subprocess* SubprocessSet::NextFinished() {
 }
 
 void SubprocessSet::Clear() {
-  for (vector<Subprocess*>::iterator i = running_.begin();
+  for (std::vector<Subprocess*>::iterator i = running_.begin();
        i != running_.end(); ++i) {
     // Since the foreground process is in our process group, it will receive a
     // CTRL_C_EVENT or CTRL_BREAK_EVENT at the same time as us.
@@ -300,7 +299,7 @@ void SubprocessSet::Clear() {
       }
     }
   }
-  for (vector<Subprocess*>::iterator i = running_.begin();
+  for (std::vector<Subprocess*>::iterator i = running_.begin();
        i != running_.end(); ++i)
     delete *i;
   running_.clear();

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -24,7 +24,6 @@
 #include <unistd.h>
 #endif
 
-using namespace std;
 
 namespace {
 
@@ -231,7 +230,7 @@ TEST_F(SubprocessTest, SetWithLots) {
     return;
   }
 
-  vector<Subprocess*> procs;
+  std::vector<Subprocess*> procs;
   for (size_t i = 0; i < kNumProcs; ++i) {
     Subprocess* subproc = subprocs_.Add("/bin/echo");
     ASSERT_NE((Subprocess *) 0, subproc);

--- a/src/test.cc
+++ b/src/test.cc
@@ -43,7 +43,6 @@ extern "C" {
 }
 #endif
 
-using namespace std;
 
 namespace {
 
@@ -66,7 +65,7 @@ char* mkdtemp(char* name_template) {
 }
 #endif  // _WIN32
 
-string GetSystemTempDir() {
+std::string GetSystemTempDir() {
 #ifdef _WIN32
   char buf[1024];
   if (!GetTempPath(sizeof(buf), buf))
@@ -92,7 +91,7 @@ void StateTestWithBuiltinRules::AddCatRule(State* state) {
 "  command = cat $in > $out\n");
 }
 
-Node* StateTestWithBuiltinRules::GetNode(const string& path) {
+Node* StateTestWithBuiltinRules::GetNode(const std::string& path) {
   EXPECT_FALSE(strpbrk(path.c_str(), "/\\"));
   return state_.GetNode(path, 0);
 }
@@ -100,7 +99,7 @@ Node* StateTestWithBuiltinRules::GetNode(const string& path) {
 void AssertParse(State* state, const char* input,
                  ManifestParserOptions opts) {
   ManifestParser parser(state, NULL, opts);
-  string err;
+  std::string err;
   EXPECT_TRUE(parser.ParseTest(input, &err));
   ASSERT_EQ("", err);
   VerifyGraph(*state);
@@ -111,26 +110,26 @@ void AssertHash(const char* expected, uint64_t actual) {
 }
 
 void VerifyGraph(const State& state) {
-  for (vector<Edge*>::const_iterator e = state.edges_.begin();
+  for (std::vector<Edge*>::const_iterator e = state.edges_.begin();
        e != state.edges_.end(); ++e) {
     // All edges need at least one output.
     EXPECT_FALSE((*e)->outputs_.empty());
     // Check that the edge's inputs have the edge as out-edge.
-    for (vector<Node*>::const_iterator in_node = (*e)->inputs_.begin();
+    for (std::vector<Node*>::const_iterator in_node = (*e)->inputs_.begin();
          in_node != (*e)->inputs_.end(); ++in_node) {
-      const vector<Edge*>& out_edges = (*in_node)->out_edges();
+      const std::vector<Edge*>& out_edges = (*in_node)->out_edges();
       EXPECT_NE(find(out_edges.begin(), out_edges.end(), *e),
                 out_edges.end());
     }
     // Check that the edge's outputs have the edge as in-edge.
-    for (vector<Node*>::const_iterator out_node = (*e)->outputs_.begin();
+    for (std::vector<Node*>::const_iterator out_node = (*e)->outputs_.begin();
          out_node != (*e)->outputs_.end(); ++out_node) {
       EXPECT_EQ((*out_node)->in_edge(), *e);
     }
   }
 
   // The union of all in- and out-edges of each nodes should be exactly edges_.
-  set<const Edge*> node_edge_set;
+  std::set<const Edge*> node_edge_set;
   for (State::Paths::const_iterator p = state.paths_.begin();
        p != state.paths_.end(); ++p) {
     const Node* n = p->second;
@@ -138,18 +137,18 @@ void VerifyGraph(const State& state) {
       node_edge_set.insert(n->in_edge());
     node_edge_set.insert(n->out_edges().begin(), n->out_edges().end());
   }
-  set<const Edge*> edge_set(state.edges_.begin(), state.edges_.end());
+  std::set<const Edge*> edge_set(state.edges_.begin(), state.edges_.end());
   EXPECT_EQ(node_edge_set, edge_set);
 }
 
-void VirtualFileSystem::Create(const string& path,
-                               const string& contents) {
+void VirtualFileSystem::Create(const std::string& path,
+                               const std::string& contents) {
   files_[path].mtime = now_;
   files_[path].contents = contents;
   files_created_.insert(path);
 }
 
-TimeStamp VirtualFileSystem::Stat(const string& path, string* err) const {
+TimeStamp VirtualFileSystem::Stat(const std::string& path, std::string* err) const {
   FileMap::const_iterator i = files_.find(path);
   if (i != files_.end()) {
     *err = i->second.stat_error;
@@ -158,19 +157,19 @@ TimeStamp VirtualFileSystem::Stat(const string& path, string* err) const {
   return 0;
 }
 
-bool VirtualFileSystem::WriteFile(const string& path, const string& contents) {
+bool VirtualFileSystem::WriteFile(const std::string& path, const std::string& contents) {
   Create(path, contents);
   return true;
 }
 
-bool VirtualFileSystem::MakeDir(const string& path) {
+bool VirtualFileSystem::MakeDir(const std::string& path) {
   directories_made_.push_back(path);
   return true;  // success
 }
 
-FileReader::Status VirtualFileSystem::ReadFile(const string& path,
-                                               string* contents,
-                                               string* err) {
+FileReader::Status VirtualFileSystem::ReadFile(const std::string& path,
+                                               std::string* contents,
+                                               std::string* err) {
   files_read_.push_back(path);
   FileMap::iterator i = files_.find(path);
   if (i != files_.end()) {
@@ -181,7 +180,7 @@ FileReader::Status VirtualFileSystem::ReadFile(const string& path,
   return NotFound;
 }
 
-int VirtualFileSystem::RemoveFile(const string& path) {
+int VirtualFileSystem::RemoveFile(const std::string& path) {
   if (find(directories_made_.begin(), directories_made_.end(), path)
       != directories_made_.end())
     return -1;
@@ -195,7 +194,7 @@ int VirtualFileSystem::RemoveFile(const string& path) {
   }
 }
 
-void ScopedTempDir::CreateAndEnter(const string& name) {
+void ScopedTempDir::CreateAndEnter(const std::string& name) {
   // First change into the system temp dir and save it for cleanup.
   start_dir_ = GetSystemTempDir();
   if (start_dir_.empty())
@@ -226,9 +225,9 @@ void ScopedTempDir::Cleanup() {
     Fatal("chdir: %s", strerror(errno));
 
 #ifdef _WIN32
-  string command = "rmdir /s /q " + temp_dir_name_;
+  std::string command = "rmdir /s /q " + temp_dir_name_;
 #else
-  string command = "rm -rf " + temp_dir_name_;
+  std::string command = "rm -rf " + temp_dir_name_;
 #endif
   if (system(command.c_str()) < 0)
     Fatal("system: %s", strerror(errno));

--- a/src/util.cc
+++ b/src/util.cc
@@ -60,7 +60,6 @@
 
 #include "edit_distance.h"
 
-using namespace std;
 
 void Fatal(const char* msg, ...) {
   va_list ap;
@@ -119,7 +118,7 @@ void Info(const char* msg, ...) {
   va_end(ap);
 }
 
-void CanonicalizePath(string* path, uint64_t* slash_bits) {
+void CanonicalizePath(std::string* path, uint64_t* slash_bits) {
   size_t len = path->size();
   char* str = 0;
   if (len > 0)
@@ -259,21 +258,21 @@ static inline bool IsKnownWin32SafeCharacter(char ch) {
   }
 }
 
-static inline bool StringNeedsShellEscaping(const string& input) {
+static inline bool StringNeedsShellEscaping(const std::string& input) {
   for (size_t i = 0; i < input.size(); ++i) {
     if (!IsKnownShellSafeCharacter(input[i])) return true;
   }
   return false;
 }
 
-static inline bool StringNeedsWin32Escaping(const string& input) {
+static inline bool StringNeedsWin32Escaping(const std::string& input) {
   for (size_t i = 0; i < input.size(); ++i) {
     if (!IsKnownWin32SafeCharacter(input[i])) return true;
   }
   return false;
 }
 
-void GetShellEscapedString(const string& input, string* result) {
+void GetShellEscapedString(const std::string& input, std::string* result) {
   assert(result);
 
   if (!StringNeedsShellEscaping(input)) {
@@ -286,8 +285,8 @@ void GetShellEscapedString(const string& input, string* result) {
 
   result->push_back(kQuote);
 
-  string::const_iterator span_begin = input.begin();
-  for (string::const_iterator it = input.begin(), end = input.end(); it != end;
+  std::string::const_iterator span_begin = input.begin();
+  for (std::string::const_iterator it = input.begin(), end = input.end(); it != end;
        ++it) {
     if (*it == kQuote) {
       result->append(span_begin, it);
@@ -300,7 +299,7 @@ void GetShellEscapedString(const string& input, string* result) {
 }
 
 
-void GetWin32EscapedString(const string& input, string* result) {
+void GetWin32EscapedString(const std::string& input, std::string* result) {
   assert(result);
   if (!StringNeedsWin32Escaping(input)) {
     result->append(input);
@@ -312,8 +311,8 @@ void GetWin32EscapedString(const string& input, string* result) {
 
   result->push_back(kQuote);
   size_t consecutive_backslash_count = 0;
-  string::const_iterator span_begin = input.begin();
-  for (string::const_iterator it = input.begin(), end = input.end(); it != end;
+  std::string::const_iterator span_begin = input.begin();
+  for (std::string::const_iterator it = input.begin(), end = input.end(); it != end;
        ++it) {
     switch (*it) {
       case kBackslash:
@@ -335,7 +334,7 @@ void GetWin32EscapedString(const string& input, string* result) {
   result->push_back(kQuote);
 }
 
-int ReadFile(const string& path, string* contents, string* err) {
+int ReadFile(const std::string& path, std::string* contents, std::string* err) {
 #ifdef _WIN32
   // This makes a ninja run on a set of 1500 manifest files about 4% faster
   // than using the generic fopen code below.
@@ -413,14 +412,14 @@ void SetCloseOnExec(int fd) {
 }
 
 
-const char* SpellcheckStringV(const string& text,
-                              const vector<const char*>& words) {
+const char* SpellcheckStringV(const std::string& text,
+                              const std::vector<const char*>& words) {
   const bool kAllowReplacements = true;
   const int kMaxValidEditDistance = 3;
 
   int min_distance = kMaxValidEditDistance + 1;
   const char* result = NULL;
-  for (vector<const char*>::const_iterator i = words.begin();
+  for (std::vector<const char*>::const_iterator i = words.begin();
        i != words.end(); ++i) {
     int distance = EditDistance(*i, text, kAllowReplacements,
                                 kMaxValidEditDistance);
@@ -433,11 +432,11 @@ const char* SpellcheckStringV(const string& text,
 }
 
 const char* SpellcheckString(const char* text, ...) {
-  // Note: This takes a const char* instead of a string& because using
+  // Note: This takes a const char* instead of a std::string& because using
   // va_start() with a reference parameter is undefined behavior.
   va_list ap;
   va_start(ap, text);
-  vector<const char*> words;
+  std::vector<const char*> words;
   const char* word;
   while ((word = va_arg(ap, const char*)))
     words.push_back(word);
@@ -446,7 +445,7 @@ const char* SpellcheckString(const char* text, ...) {
 }
 
 #ifdef _WIN32
-string GetLastErrorString() {
+std::string GetLastErrorString() {
   DWORD err = GetLastError();
 
   char* msg_buf;
@@ -460,7 +459,7 @@ string GetLastErrorString() {
         (char*)&msg_buf,
         0,
         NULL);
-  string msg = msg_buf;
+  std::string msg = msg_buf;
   LocalFree(msg_buf);
   return msg;
 }
@@ -479,8 +478,8 @@ bool islatinalpha(int c) {
   return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 }
 
-string StripAnsiEscapeCodes(const string& in) {
-  string stripped;
+std::string StripAnsiEscapeCodes(const std::string& in) {
+  std::string stripped;
   stripped.reserve(in.size());
 
   for (size_t i = 0; i < in.size(); ++i) {
@@ -520,13 +519,13 @@ struct MountPoint {
   StringPiece deviceId;
   StringPiece root;
   StringPiece mountPoint;
-  vector<StringPiece> options;
-  vector<StringPiece> optionalFields;
+  std::vector<StringPiece> options;
+  std::vector<StringPiece> optionalFields;
   StringPiece fsType;
   StringPiece mountSource;
-  vector<StringPiece> superOptions;
-  bool parse(const string& line) {
-    vector<StringPiece> pieces = SplitStringPiece(line, ' ');
+  std::vector<StringPiece> superOptions;
+  bool parse(const std::string& line) {
+    std::vector<StringPiece> pieces = SplitStringPiece(line, ' ');
     if (pieces.size() < 10)
       return false;
     size_t optionalStart = 0;
@@ -547,20 +546,20 @@ struct MountPoint {
     mountPoint = pieces[4];
     options = SplitStringPiece(pieces[5], ',');
     optionalFields =
-        vector<StringPiece>(&pieces[6], &pieces[optionalStart - 1]);
+        std::vector<StringPiece>(&pieces[6], &pieces[optionalStart - 1]);
     fsType = pieces[optionalStart];
     mountSource = pieces[optionalStart + 1];
     superOptions = SplitStringPiece(pieces[optionalStart + 2], ',');
     return true;
   }
-  string translate(string& path) const {
+  std::string translate(std::string& path) const {
     // path must be sub dir of root
     if (path.compare(0, root.len_, root.str_, root.len_) != 0) {
-      return string();
+      return std::string();
     }
     path.erase(0, root.len_);
     if (path == ".." || (path.length() > 2 && path.compare(0, 3, "../") == 0)) {
-      return string();
+      return std::string();
     }
     return mountPoint.AsString() + "/" + path;
   }
@@ -568,20 +567,20 @@ struct MountPoint {
 
 struct CGroupSubSys {
   int id;
-  string name;
-  vector<string> subsystems;
-  bool parse(string& line) {
+  std::string name;
+  std::vector<std::string> subsystems;
+  bool parse(std::string& line) {
     size_t first = line.find(':');
-    if (first == string::npos)
+    if (first == std::string::npos)
       return false;
     line[first] = '\0';
     size_t second = line.find(':', first + 1);
-    if (second == string::npos)
+    if (second == std::string::npos)
       return false;
     line[second] = '\0';
     id = atoi(line.c_str());
     name = line.substr(second + 1);
-    vector<StringPiece> pieces =
+    std::vector<StringPiece> pieces =
         SplitStringPiece(StringPiece(line.c_str() + first + 1), ',');
     for (size_t i = 0; i < pieces.size(); i++) {
       subsystems.push_back(pieces[i].AsString());
@@ -590,13 +589,13 @@ struct CGroupSubSys {
   }
 };
 
-map<string, string> ParseMountInfo(map<string, CGroupSubSys>& subsystems) {
-  map<string, string> cgroups;
-  ifstream mountinfo("/proc/self/mountinfo");
+std::map<std::string, std::string> ParseMountInfo(std::map<std::string, CGroupSubSys>& subsystems) {
+  std::map<std::string, std::string> cgroups;
+  std::ifstream mountinfo("/proc/self/mountinfo");
   if (!mountinfo.is_open())
     return cgroups;
   while (!mountinfo.eof()) {
-    string line;
+    std::string line;
     getline(mountinfo, line);
     MountPoint mp;
     if (!mp.parse(line))
@@ -604,11 +603,11 @@ map<string, string> ParseMountInfo(map<string, CGroupSubSys>& subsystems) {
     if (mp.fsType != "cgroup")
       continue;
     for (size_t i = 0; i < mp.superOptions.size(); i++) {
-      string opt = mp.superOptions[i].AsString();
-      map<string, CGroupSubSys>::iterator subsys = subsystems.find(opt);
+      std::string opt = mp.superOptions[i].AsString();
+      std::map<std::string, CGroupSubSys>::iterator subsys = subsystems.find(opt);
       if (subsys == subsystems.end())
         continue;
-      string newPath = mp.translate(subsys->second.name);
+      std::string newPath = mp.translate(subsys->second.name);
       if (!newPath.empty())
         cgroups.insert(make_pair(opt, newPath));
     }
@@ -616,28 +615,28 @@ map<string, string> ParseMountInfo(map<string, CGroupSubSys>& subsystems) {
   return cgroups;
 }
 
-map<string, CGroupSubSys> ParseSelfCGroup() {
-  map<string, CGroupSubSys> cgroups;
-  ifstream cgroup("/proc/self/cgroup");
+std::map<std::string, CGroupSubSys> ParseSelfCGroup() {
+  std::map<std::string, CGroupSubSys> cgroups;
+  std::ifstream cgroup("/proc/self/cgroup");
   if (!cgroup.is_open())
     return cgroups;
-  string line;
+  std::string line;
   while (!cgroup.eof()) {
     getline(cgroup, line);
     CGroupSubSys subsys;
     if (!subsys.parse(line))
       continue;
     for (size_t i = 0; i < subsys.subsystems.size(); i++) {
-      cgroups.insert(make_pair(subsys.subsystems[i], subsys));
+      cgroups.insert(std::make_pair(subsys.subsystems[i], subsys));
     }
   }
   return cgroups;
 }
 
 int ParseCPUFromCGroup() {
-  map<string, CGroupSubSys> subsystems = ParseSelfCGroup();
-  map<string, string> cgroups = ParseMountInfo(subsystems);
-  map<string, string>::iterator cpu = cgroups.find("cpu");
+  std::map<std::string, CGroupSubSys> subsystems = ParseSelfCGroup();
+  std::map<std::string, std::string> cgroups = ParseMountInfo(subsystems);
+  std::map<std::string, std::string>::iterator cpu = cgroups.find("cpu");
   if (cpu == cgroups.end())
     return -1;
   std::pair<int64_t, bool> quota = readCount(cpu->second + "/cpu.cfs_quota_us");
@@ -830,7 +829,7 @@ double GetLoadAverage() {
 }
 #endif // _WIN32
 
-string ElideMiddle(const string& str, size_t width) {
+std::string ElideMiddle(const std::string& str, size_t width) {
   switch (width) {
       case 0: return "";
       case 1: return ".";
@@ -838,7 +837,7 @@ string ElideMiddle(const string& str, size_t width) {
       case 3: return "...";
   }
   const int kMargin = 3;  // Space for "...".
-  string result = str;
+  std::string result = str;
   if (result.size() > width) {
     size_t elide_size = (width - kMargin) / 2;
     result = result.substr(0, elide_size)
@@ -848,7 +847,7 @@ string ElideMiddle(const string& str, size_t width) {
   return result;
 }
 
-bool Truncate(const string& path, size_t size, string* err) {
+bool Truncate(const std::string& path, size_t size, std::string* err) {
 #ifdef _WIN32
   int fh = _sopen(path.c_str(), _O_RDWR | _O_CREAT, _SH_DENYNO,
                   _S_IREAD | _S_IWRITE);

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -16,11 +16,9 @@
 
 #include "test.h"
 
-using namespace std;
-
 namespace {
 
-void CanonicalizePath(string* path) {
+void CanonicalizePath(std::string* path) {
   uint64_t unused;
   ::CanonicalizePath(path, &unused);
 }
@@ -28,7 +26,7 @@ void CanonicalizePath(string* path) {
 }  // namespace
 
 TEST(CanonicalizePath, PathSamples) {
-  string path;
+  std::string path;
 
   CanonicalizePath(&path);
   EXPECT_EQ("", path);
@@ -112,7 +110,7 @@ TEST(CanonicalizePath, PathSamples) {
 
 #ifdef _WIN32
 TEST(CanonicalizePath, PathSamplesWindows) {
-  string path;
+  std::string path;
 
   CanonicalizePath(&path);
   EXPECT_EQ("", path);
@@ -175,7 +173,7 @@ TEST(CanonicalizePath, PathSamplesWindows) {
 }
 
 TEST(CanonicalizePath, SlashTracking) {
-  string path;
+  std::string path;
   uint64_t slash_bits;
 
   path = "foo.h";
@@ -270,7 +268,7 @@ TEST(CanonicalizePath, CanonicalizeNotExceedingLen) {
 }
 
 TEST(CanonicalizePath, TooManyComponents) {
-  string path;
+  std::string path;
   uint64_t slash_bits;
 
   // 64 is OK.
@@ -325,7 +323,7 @@ TEST(CanonicalizePath, TooManyComponents) {
 #endif
 
 TEST(CanonicalizePath, UpDir) {
-  string path, err;
+  std::string path, err;
   path = "../../foo/bar.h";
   CanonicalizePath(&path);
   EXPECT_EQ("../../foo/bar.h", path);
@@ -336,14 +334,13 @@ TEST(CanonicalizePath, UpDir) {
 }
 
 TEST(CanonicalizePath, AbsolutePath) {
-  string path = "/usr/include/stdio.h";
-  string err;
+  std::string path = "/usr/include/stdio.h";
   CanonicalizePath(&path);
   EXPECT_EQ("/usr/include/stdio.h", path);
 }
 
 TEST(CanonicalizePath, NotNullTerminated) {
-  string path;
+  std::string path;
   size_t len;
   uint64_t unused;
 
@@ -351,17 +348,17 @@ TEST(CanonicalizePath, NotNullTerminated) {
   len = strlen("foo/.");  // Canonicalize only the part before the space.
   CanonicalizePath(&path[0], &len, &unused);
   EXPECT_EQ(strlen("foo"), len);
-  EXPECT_EQ("foo/. bar/.", string(path));
+  EXPECT_EQ("foo/. bar/.", std::string(path));
 
   path = "foo/../file bar/.";
   len = strlen("foo/../file");
   CanonicalizePath(&path[0], &len, &unused);
   EXPECT_EQ(strlen("file"), len);
-  EXPECT_EQ("file ./file bar/.", string(path));
+  EXPECT_EQ("file ./file bar/.", std::string(path));
 }
 
 TEST(PathEscaping, TortureTest) {
-  string result;
+  std::string result;
 
   GetWin32EscapedString("foo bar\\\"'$@d!st!c'\\path'\\", &result);
   EXPECT_EQ("\"foo bar\\\\\\\"'$@d!st!c'\\path'\\\\\"", result);
@@ -373,7 +370,7 @@ TEST(PathEscaping, TortureTest) {
 
 TEST(PathEscaping, SensiblePathsAreNotNeedlesslyEscaped) {
   const char* path = "some/sensible/path/without/crazy/characters.c++";
-  string result;
+  std::string result;
 
   GetWin32EscapedString(path, &result);
   EXPECT_EQ(path, result);
@@ -385,14 +382,14 @@ TEST(PathEscaping, SensiblePathsAreNotNeedlesslyEscaped) {
 
 TEST(PathEscaping, SensibleWin32PathsAreNotNeedlesslyEscaped) {
   const char* path = "some\\sensible\\path\\without\\crazy\\characters.c++";
-  string result;
+  std::string result;
 
   GetWin32EscapedString(path, &result);
   EXPECT_EQ(path, result);
 }
 
 TEST(StripAnsiEscapeCodes, EscapeAtEnd) {
-  string stripped = StripAnsiEscapeCodes("foo\33");
+  std::string stripped = StripAnsiEscapeCodes("foo\33");
   EXPECT_EQ("foo", stripped);
 
   stripped = StripAnsiEscapeCodes("foo\33[");
@@ -401,15 +398,15 @@ TEST(StripAnsiEscapeCodes, EscapeAtEnd) {
 
 TEST(StripAnsiEscapeCodes, StripColors) {
   // An actual clang warning.
-  string input = "\33[1maffixmgr.cxx:286:15: \33[0m\33[0;1;35mwarning: "
+  std::string input = "\33[1maffixmgr.cxx:286:15: \33[0m\33[0;1;35mwarning: "
                  "\33[0m\33[1musing the result... [-Wparentheses]\33[0m";
-  string stripped = StripAnsiEscapeCodes(input);
+  std::string stripped = StripAnsiEscapeCodes(input);
   EXPECT_EQ("affixmgr.cxx:286:15: warning: using the result... [-Wparentheses]",
             stripped);
 }
 
 TEST(ElideMiddle, NothingToElide) {
-  string input = "Nothing to elide in this short string.";
+  std::string input = "Nothing to elide in this short string.";
   EXPECT_EQ(input, ElideMiddle(input, 80));
   EXPECT_EQ(input, ElideMiddle(input, 38));
   EXPECT_EQ("", ElideMiddle(input, 0));
@@ -419,8 +416,8 @@ TEST(ElideMiddle, NothingToElide) {
 }
 
 TEST(ElideMiddle, ElideInTheMiddle) {
-  string input = "01234567890123456789";
-  string elided = ElideMiddle(input, 10);
+  std::string input = "01234567890123456789";
+  std::string elided = ElideMiddle(input, 10);
   EXPECT_EQ("012...789", elided);
   EXPECT_EQ("01234567...23456789", ElideMiddle(input, 19));
 }

--- a/src/version.cc
+++ b/src/version.cc
@@ -18,22 +18,21 @@
 
 #include "util.h"
 
-using namespace std;
 
 const char* kNinjaVersion = "1.12.0.git";
 
-void ParseVersion(const string& version, int* major, int* minor) {
+void ParseVersion(const std::string& version, int* major, int* minor) {
   size_t end = version.find('.');
   *major = atoi(version.substr(0, end).c_str());
   *minor = 0;
-  if (end != string::npos) {
+  if (end != std::string::npos) {
     size_t start = end + 1;
     end = version.find('.', start);
     *minor = atoi(version.substr(start, end).c_str());
   }
 }
 
-void CheckNinjaVersion(const string& version) {
+void CheckNinjaVersion(const std::string& version) {
   int bin_major, bin_minor;
   ParseVersion(kNinjaVersion, &bin_major, &bin_minor);
   int file_major, file_minor;


### PR DESCRIPTION
Rip the band-aide off.

Methodology:

Remove all lines of "using namespace std;"
compile; while(not compiled) { paste std:: in front of the offending symbols; compile; }