### PR TITLE
Fix as_list in ninja_syntax.py to work with generators

### DIFF
--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -23,6 +23,7 @@ use Python.
 
 import re
 import textwrap
+import types
 
 def escape_path(word):
     return word.replace('$ ', '$$ ').replace(' ', '$ ').replace(':', '$:')
@@ -172,7 +173,7 @@ class Writer(object):
 def as_list(input):
     if input is None:
         return []
-    if isinstance(input, list):
+    if isinstance(input, list) or isinstance(input, types.GeneratorType):
         return input
     return [input]
 


### PR DESCRIPTION
If I try to do:
```
ninja.default(os.path.join(output_dir, file) for file in file_list)
```
it fails with:
```
  File "..../ninja_syntax.py", line 121, in default
    self._line('default %s' % ' '.join(as_list(paths)))
TypeError: sequence item 0: expected str instance, generator found
```

This PR fixes that :slightly_smiling_face: 

I dunno if this is the "best" way to detect a generator, I borrowed this approach from https://stackoverflow.com/questions/6416538/how-to-check-if-an-object-is-a-generator-object-in-python