### PR TITLE
cmake: use `check_symbol_exists` for browse support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-include(CheckIncludeFileCXX)
+include(CheckSymbolExists)
 include(CheckIPOSupported)
 
 project(ninja)
@@ -73,10 +73,15 @@ function(check_platform_supports_browse_mode RESULT)
 	endif()
 
 	# Now check availability of the unistd header
-	check_include_file_cxx(unistd.h PLATFORM_HAS_UNISTD_HEADER)
-	set(${RESULT} "${PLATFORM_HAS_UNISTD_HEADER}" PARENT_SCOPE)
-	if(NOT PLATFORM_HAS_UNISTD_HEADER)
-		message(WARNING "browse feature omitted due to missing unistd.h")
+	check_symbol_exists(fork "unistd.h" HAVE_FORK)
+	check_symbol_exists(pipe "unistd.h" HAVE_PIPE)
+	set(browse_supported 0)
+	if (HAVE_FORK AND HAVE_PIPE)
+		set(browse_supported 1)
+	endif ()
+	set(${RESULT} "${browse_supported}" PARENT_SCOPE)
+	if(NOT browse_supported)
+		message(WARNING "browse feature omitted due to missing `fork` and `pipe` functions")
 	endif()
 
 endfunction()


### PR DESCRIPTION
Just because `unistd.h` exists does not mean it has the APIs that are
needed. This occurs when cross-compiling using Fedora's packaged MinGW
toolchain.