### PR TITLE
ninja_syntax.py: add pathlib support

### DIFF
--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -25,6 +25,8 @@ import re
 import textwrap
 
 def escape_path(word):
+    if not isinstance(word, str):
+        word = str(word)
     return word.replace('$ ', '$$ ').replace(' ', '$ ').replace(':', '$:')
 
 class Writer(object):

--- a/misc/ninja_syntax_test.py
+++ b/misc/ninja_syntax_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import unittest
+import pathlib
 
 try:
     from StringIO import StringIO
@@ -186,6 +187,15 @@ class TestExpand(unittest.TestCase):
 
     def test_double(self):
         self.assertEqual('a b$c', ninja_syntax.expand('a$ b$$c', {}))
+
+class TestPath(unittest.TestCase):
+    def setUp(self):
+        self.out = StringIO()
+        self.n = ninja_syntax.Writer(self.out)
+
+    def test_pathlib(self):
+        self.n.build(pathlib.Path('foo') / 'bar', 'bax', [pathlib.Path('qux'), 'fazz'])
+        self.assertEqual('build foo/bar: bax qux fazz\n', self.out.getvalue())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Note that this currently casts all not `str`s to `str`, which would also effect how `int`s are handleled, I'm not sure if you want this. Instead, I could change it to only cast on `pathlib` types.

Also, I may need to change it, depending on which python versions you want to suport (pathlib was added in 3.4)