### PR TITLE
win: Use cl /help to test for /FS requirement

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -84,7 +84,7 @@ class Platform(object):
         return self._platform == 'msvc'
 
     def msvc_needs_fs(self):
-        popen = subprocess.Popen(['cl', '/nologo', '/?'],
+        popen = subprocess.Popen(['cl', '/nologo', '/help'],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         out, err = popen.communicate()


### PR DESCRIPTION
Sometime in the last few years `cl` started doing this with `/?` which means that the check in configure.py for finding whether `/FS` is required started not working (causing pdb errors during self-compilation). Use `/help` instead work around this.

```
c:\...\ninja>cl /?
Microsoft (R) C/C++ Optimizing Compiler Version 19.29.30037 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

cl : Command line error D8004 : '/D' requires an argument
```