### PR TITLE
CLParser: Don't filter filename lines after seeing /showIncludes

### DIFF
--- a/src/clparser.cc
+++ b/src/clparser.cc
@@ -83,6 +83,7 @@ bool CLParser::Parse(const string& output, const string& deps_prefix,
   // Loop over all lines in the output to process them.
   assert(&output != filtered_output);
   size_t start = 0;
+  bool seen_show_includes = false;
 #ifdef _WIN32
   IncludesNormalize normalizer(".");
 #endif
@@ -95,6 +96,7 @@ bool CLParser::Parse(const string& output, const string& deps_prefix,
 
     string include = FilterShowIncludes(line, deps_prefix);
     if (!include.empty()) {
+      seen_show_includes = true;
       string normalized;
 #ifdef _WIN32
       if (!normalizer.Normalize(include, &normalized, err))
@@ -107,7 +109,7 @@ bool CLParser::Parse(const string& output, const string& deps_prefix,
 #endif
       if (!IsSystemInclude(normalized))
         includes_.insert(normalized);
-    } else if (FilterInputFilename(line)) {
+    } else if (!seen_show_includes && FilterInputFilename(line)) {
       // Drop it.
       // TODO: if we support compiling multiple output files in a single
       // cl.exe invocation, we should stash the filename.

--- a/src/clparser_test.cc
+++ b/src/clparser_test.cc
@@ -70,6 +70,17 @@ TEST(CLParserTest, ParseFilenameFilter) {
   ASSERT_EQ("cl: warning\n", output);
 }
 
+TEST(CLParserTest, NoFilenameFilterAfterShowIncludes) {
+  CLParser parser;
+  string output, err;
+  ASSERT_TRUE(parser.Parse(
+      "foo.cc\r\n"
+      "Note: including file: foo.h\r\n"
+      "something something foo.cc\r\n",
+      "", &output, &err));
+  ASSERT_EQ("something something foo.cc\n", output);
+}
+
 TEST(CLParserTest, ParseSystemInclude) {
   CLParser parser;
   string output, err;


### PR DESCRIPTION
The /showIncludes output always comes after cl.exe echos the filename,
so there is no need to filter out filename lines afterwards.

This makes it less likely that CLParser will "over filter" the compiler
output. For example, using the -H flag with clang-cl may lead to output
lines ending in .cc, which are not supposed to be filtered out.