### PR TITLE
Avoid reallocs in EvalString::Evaluate

### DIFF
--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -99,7 +99,15 @@ string BindingEnv::LookupWithFallback(const string& var,
 }
 
 string EvalString::Evaluate(Env* env) const {
+  // Estimate how much space will be needed for the concatenation. This will
+  // usually avoid reallocations, and will be perfectly sized in the ~99% of
+  // cases where all of the components are RAW strings.
+  size_t size_estimate = 0;
+  for (TokenList::const_iterator i = parsed_.begin(); i != parsed_.end(); ++i) {
+    size_estimate += i->first.size();
+  }
   string result;
+  result.reserve(size_estimate);
   for (TokenList::const_iterator i = parsed_.begin(); i != parsed_.end(); ++i) {
     if (i->second == RAW)
       result.append(i->first);


### PR DESCRIPTION
Concatenating strings often requires repeated reallocations as the
string grows, plus the cost of copying. These costs are not huge but
they are easily avoidable when, as in this case, we usually know the
final size.

This saves about 50 ms on a NOP-build of Chromium (not as much as I
had hoped).