### PR TITLE
minidump-win32 is needed by native GNU-like Clang on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,10 +122,8 @@ if(WIN32)
 		src/msvc_helper-win32.cc
 		src/msvc_helper_main-win32.cc
 		src/getopt.c
+		src/minidump-win32.cc
 	)
-	if(MSVC)
-		target_sources(libninja PRIVATE src/minidump-win32.cc)
-	endif()
 else()
 	target_sources(libninja PRIVATE src/subprocess-posix.cc)
 	if(CMAKE_SYSTEM_NAME STREQUAL "OS400" OR CMAKE_SYSTEM_NAME STREQUAL "AIX")


### PR DESCRIPTION
The entire minidump-win32.cc is guarded by ifdef _MSC_VER, so
MSYS2/MinGW Clang will just ignore minidump-win32.cc contents.

fixes #2006