### PR TITLE
NF: clarify documentation's part about rules description

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -304,9 +304,9 @@ _Available since Ninja 1.11._
 `restat`:: updates all recorded file modification timestamps in the `.ninja_log`
 file. _Available since Ninja 1.10._
 
-`rules`:: output the list of all rules (eventually with their description
-if they have one).  It can be used to know which rule name to pass to
-+ninja -t targets rule _name_+ or +ninja -t compdb+.
+`rules`:: output the list of all rules. It can be used to know which rule name
+to pass to +ninja -t targets rule _name_+ or +ninja -t compdb+. Adding the `-d`
+flag also prints the description of the rules.
 
 `wincodepage`:: Available on Windows hosts (_since Ninja 1.11_).
 Prints the Windows code page whose encoding is expected in the build file.


### PR DESCRIPTION
The word "eventually" was quite strange here and should probably removed. I
suspect "potentially" was meant (which in French is "eventuellement", a standard
false friend). In any way, after a quick look at the source/ninja message, I
chose to even clarify this part of the doc, indicating that the `-d` option is
required here.

If it's acceptable, I'd also like to clarify in the same way various other options that I found confusing while reading the doc. I started with this one as it seems a clear problem to begin with