### PR TITLE
Fix two typos

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -2355,7 +2355,7 @@ struct BuildWithDepsLogTest : public BuildTest {
   void* builder_;
 };
 
-/// Run a straightforwad build where the deps log is used.
+/// Run a straightforward build where the deps log is used.
 TEST_F(BuildWithDepsLogTest, Straightforward) {
   string err;
   // Note: in1 was created by the superclass SetUp().

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -67,7 +67,7 @@ void Usage() {
 "usage: ninja_tests [options]\n"
 "\n"
 "options:\n"
-"  --gtest_filter=POSTIVE_PATTERN[-NEGATIVE_PATTERN]\n"
+"  --gtest_filter=POSITIVE_PATTERN[-NEGATIVE_PATTERN]\n"
 "      Run tests whose names match the positive but not the negative pattern.\n"
 "      '*' matches any substring. (gtest's ':', '?' are not implemented).\n");
 }


### PR DESCRIPTION
One in ninja_test usage text, the other in a unit test comment.