### PR TITLE
Use python3 instead of python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ if(platform_supports_ninja_browse)
 		PROPERTIES
 			OBJECT_DEPENDS "${PROJECT_BINARY_DIR}/build/browse_py.h"
 			INCLUDE_DIRECTORIES "${PROJECT_BINARY_DIR}"
-			COMPILE_DEFINITIONS NINJA_PYTHON="python"
+			COMPILE_DEFINITIONS NINJA_PYTHON="python3"
 	)
 endif()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,13 +40,13 @@ for:
     - cmd: >-
         call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 
-        python configure.py --bootstrap
+        python3 configure.py --bootstrap
 
         ninja.bootstrap.exe all
 
         ninja_test
 
-        python misc/ninja_syntax_test.py
+        python3 misc/ninja_syntax_test.py
 
   - matrix:
       only:

--- a/configure.py
+++ b/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2001 Google Inc. All Rights Reserved.
 #

--- a/misc/measure.py
+++ b/misc/measure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2011 Google Inc. All Rights Reserved.
 #

--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Copyright 2011 Google Inc. All Rights Reserved.
 #

--- a/misc/ninja_syntax_test.py
+++ b/misc/ninja_syntax_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2011 Google Inc. All Rights Reserved.
 #

--- a/misc/write_fake_manifests.py
+++ b/misc/write_fake_manifests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Writes large manifest files, for manifest parser performance testing.
 
@@ -6,7 +6,7 @@ The generated manifest files are (eerily) similar in appearance and size to the
 ones used in the Chromium project.
 
 Usage:
-  python misc/write_fake_manifests.py outdir  # Will run for about 5s.
+  python3 misc/write_fake_manifests.py outdir  # Will run for about 5s.
 
 The program contains a hardcoded random seed, so it will generate the same
 output every time it runs.  By changing the seed, it's easy to generate many

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -48,7 +48,7 @@ bool WriteFakeManifests(const string& dir, string* err) {
   if (mtime != 0)  // 0 means that the file doesn't exist yet.
     return mtime != -1;
 
-  string command = "python misc/write_fake_manifests.py " + dir;
+  string command = "python3 misc/write_fake_manifests.py " + dir;
   printf("Creating manifest data..."); fflush(stdout);
   int exit_code = system(command.c_str());
   printf("done.\n");


### PR DESCRIPTION
Some systems do not have python available. Explicitly using python3
makes it clearer and more consistent.

misc/output_test.py was already using "#!/usr/bin/env python3" so there
was some inconsistency already.