### PR TITLE
ci.py: remove src/depfile_parser.cc and src/lexer.cc from ignored

### DIFF
--- a/misc/ci.py
+++ b/misc/ci.py
@@ -6,8 +6,6 @@ ignores = [
 	'.git/',
 	'misc/afl-fuzz-tokens/',
 	'ninja_deps',
-	'src/depfile_parser.cc',
-	'src/lexer.cc',
 ]
 
 error_count = 0


### PR DESCRIPTION
With 054ca7569a42904a11694f222da6a6db7d74da0a, the content of the
generated files shouldn't change anymore. If it changes, it's because of
a difference with the generated re2c code. We want to know about it.

The downside is that the breakage will likely occur on an unrelated
commit. Still better to break there than have local surprises.