### PR TITLE
Print "explain" debug just before each command is run

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -1057,8 +1057,6 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
 }
 
 bool Builder::LoadDyndeps(Node* node, string* err) {
-  status_->BuildLoadDyndeps();
-
   // Load the dyndep information provided by this node.
   DyndepFile ddf;
   if (!scan_.LoadDyndeps(node, &ddf, err))

--- a/src/debug_flags.cc
+++ b/src/debug_flags.cc
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stdio.h>
+#include <map>
+#include <vector>
+#include <string>
+
+#include "graph.h"
+
 bool g_explaining = false;
 
 bool g_keep_depfile = false;
@@ -19,3 +26,21 @@ bool g_keep_depfile = false;
 bool g_keep_rsp = false;
 
 bool g_experimental_statcache = true;
+
+// Reasons each Node needs rebuilding, for "-d explain".
+typedef std::map<const Node*, std::vector<std::string> > Explanations;
+static Explanations explanations_;
+
+void record_explanation(const Node* node, std::string explanation) {
+  explanations_[node].push_back(explanation);
+}
+
+void print_explanations(FILE *stream, const Edge* edge) {
+  for (std::vector<Node*>::const_iterator o = edge->outputs_.begin();
+       o != edge->outputs_.end(); ++o) {
+    for (std::vector<std::string>::iterator s = explanations_[*o].begin();
+         s != explanations_[*o].end(); ++s) {
+      fprintf(stream, "ninja explain: %s\n", (*s).c_str());
+    }
+  }
+}

--- a/src/debug_flags.h
+++ b/src/debug_flags.h
@@ -17,12 +17,20 @@
 
 #include <stdio.h>
 
-#define EXPLAIN(fmt, ...) {                                             \
-  if (g_explaining)                                                     \
-    fprintf(stderr, "ninja explain: " fmt "\n", __VA_ARGS__);           \
+#define EXPLAIN(node, fmt, ...) {                                       \
+  if (g_explaining) {                                                   \
+    char buf[1024];                                                     \
+    snprintf(buf, 1024, fmt, __VA_ARGS__);                              \
+    record_explanation(node, buf);                                      \
+  }                                                                     \
 }
 
+struct Edge;
+struct Node;
+
 extern bool g_explaining;
+void record_explanation(const Node* node, std::string reason);
+void print_explanations(FILE *stream, const Edge* node);
 
 extern bool g_keep_depfile;
 

--- a/src/dyndep.cc
+++ b/src/dyndep.cc
@@ -37,7 +37,7 @@ bool DyndepLoader::LoadDyndeps(Node* node, DyndepFile* ddf,
   node->set_dyndep_pending(false);
 
   // Load the dyndep information from the file.
-  EXPLAIN("loading dyndep file '%s'", node->path().c_str());
+  EXPLAIN(node, "loading dyndep file '%s'", node->path().c_str());
   if (!LoadDyndepFile(node, ddf, err))
     return false;
 

--- a/src/status.h
+++ b/src/status.h
@@ -30,7 +30,6 @@ struct Status {
   virtual void BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
                                  int64_t end_time_millis, bool success,
                                  const std::string& output) = 0;
-  virtual void BuildLoadDyndeps() = 0;
   virtual void BuildStarted() = 0;
   virtual void BuildFinished() = 0;
 

--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -247,20 +247,6 @@ void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
   }
 }
 
-void StatusPrinter::BuildLoadDyndeps() {
-  // The DependencyScan calls EXPLAIN() to print lines explaining why
-  // it considers a portion of the graph to be out of date.  Normally
-  // this is done before the build starts, but our caller is about to
-  // load a dyndep file during the build.  Doing so may generate more
-  // explanation lines (via fprintf directly to stderr), but in an
-  // interactive console the cursor is currently at the end of a status
-  // line.  Start a new line so that the first explanation does not
-  // append to the status line.  After the explanations are done a
-  // new build status line will appear.
-  if (g_explaining)
-    printer_.PrintOnNewLine("");
-}
-
 void StatusPrinter::BuildStarted() {
   started_edges_ = 0;
   finished_edges_ = 0;
@@ -417,6 +403,13 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
 }
 
 void StatusPrinter::PrintStatus(const Edge* edge, int64_t time_millis) {
+  if (g_explaining) {
+    // Start a new line so that the first explanation does not append to the
+    // status line.
+    printer_.PrintOnNewLine("");
+    print_explanations(stderr, edge);
+  }
+
   if (config_.verbosity == BuildConfig::QUIET
       || config_.verbosity == BuildConfig::NO_STATUS_UPDATE)
     return;

--- a/src/status_printer.h
+++ b/src/status_printer.h
@@ -32,7 +32,6 @@ struct StatusPrinter : Status {
   virtual void BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
                                  int64_t end_time_millis, bool success,
                                  const std::string& output);
-  virtual void BuildLoadDyndeps();
   virtual void BuildStarted();
   virtual void BuildFinished();
 


### PR DESCRIPTION
The explanations are printed just before each command is run. Before, it would potentially print pages & pages of explanations at the beginning, and it was hard to tell which explanation caused a particular command to run.

Edges that are pruned due to "restat" used to print all their explanations at the beginning, cluttering up the output with explanations that didn't actually cause any rebuilding. Now, those explanations aren't printed if those edges aren't run.
