### PR TITLE
Allow linking Ninja binary with extra library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,15 @@ endif()
 add_executable(ninja src/ninja.cc)
 target_link_libraries(ninja PRIVATE libninja libninja-re2c)
 
+# Define NINJA_EXTRA_LINK_LIBRARY to add new link-time libraries
+# to the final ninja executable. This can be used to link a custom
+# allocator to speed up the tool.
+if(NINJA_EXTRA_LINK_LIBRARY)
+  add_library(extra_link STATIC IMPORTED)
+  set_property(TARGET extra_link PROPERTY IMPORTED_LOCATION "${NINJA_EXTRA_LINK_LIBRARY}")
+  target_link_libraries(ninja PRIVATE extra_link)
+endif()
+
 if(WIN32)
   target_sources(ninja PRIVATE windows/ninja.manifest)
 endif()

--- a/configure.py
+++ b/configure.py
@@ -223,6 +223,8 @@ parser.add_option('--with-python', metavar='EXE',
 parser.add_option('--force-pselect', action='store_true',
                   help='ppoll() is used by default where available, '
                        'but some platforms may need to use pselect instead',)
+parser.add_option('--link-with', metavar='LIB',
+                  help='Link Ninja executable with additional library LIB.')
 (options, args) = parser.parse_args()
 if args:
     print('ERROR: extra unparsed command-line arguments:', args)
@@ -390,6 +392,9 @@ if platform.supports_ppoll() and not options.force_pselect:
     cflags.append('-DUSE_PPOLL')
 if platform.supports_ninja_browse():
     cflags.append('-DNINJA_HAVE_BROWSE')
+
+if options.link_with:
+  libs.append(options.link_with)
 
 # Search for generated headers relative to build dir.
 cflags.append('-I.')


### PR DESCRIPTION
This patch adds a NINJA_EXTRA_LINK_LIBRARY option to
`CMakeLists.txt`, and a --link-with option to
`configure.py`.

These allow building a version of the Ninja binary that
is linked against a better allocation library.

For example linking against rpmalloc [1] on Linux yields
a notable speedup (10.4 -> 9.1 seconds for a no-op Fuchsia
build with warm filesystem caches).

Example usage:

  mkdir build-cmake && cd build-cmake && rm -rf *
  export LDFLAGS="-lpthread -ldl"
  cmake .. -DCMAKE_BUILD_TYPE=Release -GNinja ... \
           -DNINJA_EXTRA_LINK_LIBRARY=/path/to/librpmalloc_wrapper.a

Or:

  export LDFLAGS="-lpthread -ldl"
  ./configure.py --bootstrap --link-with=/path/to/librpmalloc_wrapper.a

Where the extra linker flags are required by rpmalloc in this case.

[1] https://github.com/mjansson/rpmalloc

Change-Id: I5a50f818f43516ccd82047ce39b6ada156b5232a