### PR TITLE
Filter lines ending with ".c++" in clparser

### DIFF
--- a/src/clparser.cc
+++ b/src/clparser.cc
@@ -72,7 +72,8 @@ bool CLParser::FilterInputFilename(string line) {
   return EndsWith(line, ".c") ||
       EndsWith(line, ".cc") ||
       EndsWith(line, ".cxx") ||
-      EndsWith(line, ".cpp");
+      EndsWith(line, ".cpp") ||
+      EndsWith(line, ".c++");
 }
 
 // static


### PR DESCRIPTION
A few projects like cap n proto uses c++ extensions which generates a lot of
status noise when using ninja.

I believe this change should be safe.

But again I could have missed something. Hope it ok that I just made the PR without first creating a issue.