### PR TITLE
Make the output of `ninja -t inputs` deterministic

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -257,8 +257,8 @@ than the _depth_ mode.
 executed in order, may be used to rebuild those targets, assuming that all
 output files are out of date.
 
-`inputs`:: given a list of targets, print a list of all inputs which are used
-to rebuild those targets.
+`inputs`:: given a list of targets, print a list of all inputs used to
+rebuild those targets.
 _Available since Ninja 1.11._
 
 `clean`:: remove built files. By default it removes all built files

--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -134,5 +134,23 @@ red
         output = run(Output.BUILD_SIMPLE_ECHO, flags='-C$PWD', pipe=True)
         self.assertEqual(output.splitlines()[0][:25], "ninja: Entering directory")
 
+    def test_tool_inputs(self):
+        plan = '''
+rule cat
+  command = cat $in $out
+build out1 : cat in1
+build out2 : cat in2 out1
+build out3 : cat out2 out1 | implicit || order_only
+'''
+        self.assertEqual(run(plan, flags='-t inputs out3'),
+'''implicit
+in1
+in2
+order_only
+out1
+out2
+''')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -456,6 +456,28 @@ std::string EdgeEnv::MakePathList(const Node* const* const span,
   return result;
 }
 
+void Edge::CollectInputs(bool shell_escape,
+                         std::vector<std::string>* out) const {
+  for (std::vector<Node*>::const_iterator it = inputs_.begin();
+       it != inputs_.end(); ++it) {
+    std::string path = (*it)->PathDecanonicalized();
+    if (shell_escape) {
+      std::string unescaped;
+      unescaped.swap(path);
+#ifdef _WIN32
+      GetWin32EscapedString(unescaped, &path);
+#else
+      GetShellEscapedString(unescaped, &path);
+#endif
+    }
+#if __cplusplus >= 201103L
+    out->push_back(std::move(path));
+#else
+    out->push_back(path);
+#endif
+  }
+}
+
 std::string Edge::EvaluateCommand(const bool incl_rsp_file) const {
   string command = GetBinding("command");
   if (incl_rsp_file) {

--- a/src/graph.h
+++ b/src/graph.h
@@ -195,6 +195,9 @@ struct Edge {
 
   void Dump(const char* prefix="") const;
 
+  // Append all edge explicit inputs to |*out|. Possibly with shell escaping.
+  void CollectInputs(bool shell_escape, std::vector<std::string>* out) const;
+
   const Rule* rule_;
   Pool* pool_;
   std::vector<Node*> inputs_;

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -215,6 +215,39 @@ TEST_F(GraphTest, RootNodes) {
   }
 }
 
+TEST_F(GraphTest, CollectInputs) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(
+      &state_,
+      "build out$ 1: cat in1 in2 in$ with$ space | implicit || order_only\n"));
+
+  std::vector<std::string> inputs;
+  Edge* edge = GetNode("out 1")->in_edge();
+
+  // Test without shell escaping.
+  inputs.clear();
+  edge->CollectInputs(false, &inputs);
+  EXPECT_EQ(5u, inputs.size());
+  EXPECT_EQ("in1", inputs[0]);
+  EXPECT_EQ("in2", inputs[1]);
+  EXPECT_EQ("in with space", inputs[2]);
+  EXPECT_EQ("implicit", inputs[3]);
+  EXPECT_EQ("order_only", inputs[4]);
+
+  // Test with shell escaping.
+  inputs.clear();
+  edge->CollectInputs(true, &inputs);
+  EXPECT_EQ(5u, inputs.size());
+  EXPECT_EQ("in1", inputs[0]);
+  EXPECT_EQ("in2", inputs[1]);
+#ifdef _WIN32
+  EXPECT_EQ("\"in with space\"", inputs[2]);
+#else
+  EXPECT_EQ("'in with space'", inputs[2]);
+#endif
+  EXPECT_EQ("implicit", inputs[3]);
+  EXPECT_EQ("order_only", inputs[4]);
+}
+
 TEST_F(GraphTest, VarInOutPathEscaping) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "build a$ b: cat no'space with$ space$$ no\"space2\n"));


### PR DESCRIPTION
This sorts the output of `ninja -t inputs` to make it
deterministic and remove duplicates.