### PR TITLE
Speedup Pool class implementation

### DIFF
--- a/src/state.h
+++ b/src/state.h
@@ -16,6 +16,7 @@
 #define NINJA_STATE_H_
 
 #include <map>
+#include <queue>
 #include <set>
 #include <string>
 #include <vector>
@@ -75,16 +76,26 @@ struct Pool {
   int current_use_;
   int depth_;
 
+  // Comparison struct used to ensure edges with the lowest weight, then
+  // the lowest id appear first.
   struct WeightedEdgeCmp {
     bool operator()(const Edge* a, const Edge* b) const {
-      if (!a) return b;
-      if (!b) return false;
       int weight_diff = a->weight() - b->weight();
       return ((weight_diff < 0) || (weight_diff == 0 && EdgeCmp()(a, b)));
     }
   };
 
-  typedef std::set<Edge*, WeightedEdgeCmp> DelayedEdges;
+  // Comparison struct for the reverse condition, since std::priority_queue
+  // implements a maximal-value queue, while a minimal-value one is needed.
+  struct ReversedWeightedEdgeCmp {
+    bool operator()(const Edge* a, const Edge* b) const {
+      return !WeightedEdgeCmp()(a, b);
+    }
+  };
+
+  typedef std::priority_queue<Edge*, std::vector<Edge*>,
+                              ReversedWeightedEdgeCmp>
+      DelayedEdges;
   DelayedEdges delayed_;
 };
 

--- a/src/state_test.cc
+++ b/src/state_test.cc
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "graph.h"
 #include "state.h"
+
+#include <memory>
+
+#include "graph.h"
 #include "test.h"
 
 using namespace std;
@@ -43,6 +46,141 @@ TEST(State, Basic) {
   EXPECT_FALSE(state.GetNode("in1", 0)->dirty());
   EXPECT_FALSE(state.GetNode("in2", 0)->dirty());
   EXPECT_FALSE(state.GetNode("out", 0)->dirty());
+}
+
+TEST(State, NonDelayingPool) {
+  // A depth of 0 means that this pool will never delay edges.
+  Pool pool(std::string("test_pool"), 0);
+  EXPECT_TRUE(pool.is_valid());
+  EXPECT_EQ(0, pool.depth());
+  EXPECT_EQ(std::string("test_pool"), pool.name());
+  EXPECT_EQ(0, pool.current_use());
+  EXPECT_FALSE(pool.ShouldDelayEdge());
+
+  Edge edge1, edge2, edge3;
+  edge1.id_ = 1;
+  edge2.id_ = 2;
+  edge3.id_ = 3;
+
+  pool.EdgeScheduled(edge1);
+  EXPECT_EQ(0, pool.current_use());
+
+  pool.EdgeScheduled(edge2);
+  EXPECT_EQ(0, pool.current_use());
+
+  pool.EdgeScheduled(edge3);
+  EXPECT_EQ(0, pool.current_use());
+
+  pool.EdgeFinished(edge1);
+  EXPECT_EQ(0, pool.current_use());
+
+  pool.EdgeFinished(edge2);
+  EXPECT_EQ(0, pool.current_use());
+
+  pool.EdgeFinished(edge3);
+  EXPECT_EQ(0, pool.current_use());
+}
+
+TEST(State, DelayingPool) {
+  Pool pool(std::string("delaying_pool"), 2);
+  EXPECT_TRUE(pool.is_valid());
+  EXPECT_EQ(2, pool.depth());
+  EXPECT_EQ(std::string("delaying_pool"), pool.name());
+  EXPECT_EQ(0, pool.current_use());
+  EXPECT_TRUE(pool.ShouldDelayEdge());
+
+  Edge edge1, edge2, edge3;
+  edge1.id_ = 1;
+  edge2.id_ = 2;
+  edge3.id_ = 3;
+
+  EdgeSet ready_edges;
+
+  pool.DelayEdge(&edge1);
+  pool.DelayEdge(&edge2);
+  pool.DelayEdge(&edge3);
+  EXPECT_EQ(0, pool.current_use());
+
+  // Check that edge1 and edge2 are ready (WeightedEdgeCmp currently
+  // ensures that edges with lower ids are scheduled first).
+  pool.RetrieveReadyEdges(&ready_edges);
+  EXPECT_EQ(2, pool.current_use());
+  EXPECT_EQ(2, ready_edges.size());
+  EXPECT_NE(ready_edges.find(&edge1), ready_edges.end());
+  EXPECT_NE(ready_edges.find(&edge2), ready_edges.end());
+  EXPECT_EQ(ready_edges.find(&edge3), ready_edges.end());
+
+  // Finish edge2, verifies that this readies edge3.
+  pool.EdgeFinished(edge2);
+  EXPECT_EQ(1, pool.current_use());
+
+  ready_edges.clear();
+  pool.RetrieveReadyEdges(&ready_edges);
+  EXPECT_EQ(2, pool.current_use());
+  EXPECT_EQ(1, ready_edges.size());
+  EXPECT_NE(ready_edges.find(&edge3), ready_edges.end());
+
+  // Complete edge1 and edge3, verify there is no more work.
+  pool.EdgeFinished(edge1);
+  pool.EdgeFinished(edge3);
+  EXPECT_EQ(0, pool.current_use());
+
+  ready_edges.clear();
+  pool.RetrieveReadyEdges(&ready_edges);
+  EXPECT_TRUE(ready_edges.empty());
+}
+
+TEST(State, DelayingPoolWithDuplicateEdges) {
+  Pool pool(std::string("delaying_pool"), 2);
+  EXPECT_TRUE(pool.is_valid());
+  EXPECT_EQ(2, pool.depth());
+  EXPECT_EQ(std::string("delaying_pool"), pool.name());
+  EXPECT_EQ(0, pool.current_use());
+  EXPECT_TRUE(pool.ShouldDelayEdge());
+
+  Edge edge1, edge2, edge3;
+  edge1.id_ = 1;
+  edge2.id_ = 2;
+  edge3.id_ = 3;
+
+  EdgeSet ready_edges;
+
+  pool.DelayEdge(&edge1);
+  pool.DelayEdge(&edge2);
+  pool.DelayEdge(&edge3);
+  // Insert edge duplicates!
+  pool.DelayEdge(&edge1);
+  pool.DelayEdge(&edge2);
+  pool.DelayEdge(&edge3);
+  EXPECT_EQ(0, pool.current_use());
+
+  // Check that edge1 and edge2 are ready (WeightedEdgeCmp currently
+  // ensures that edges with lower ids are scheduled first).
+  pool.RetrieveReadyEdges(&ready_edges);
+  EXPECT_EQ(2, pool.current_use());
+  EXPECT_EQ(2, ready_edges.size());
+  EXPECT_NE(ready_edges.find(&edge1), ready_edges.end());
+  EXPECT_NE(ready_edges.find(&edge2), ready_edges.end());
+  EXPECT_EQ(ready_edges.find(&edge3), ready_edges.end());
+
+  // Finish edge2, verifies that this readies edge3.
+  pool.EdgeFinished(edge2);
+  EXPECT_EQ(1, pool.current_use());
+
+  ready_edges.clear();
+  pool.RetrieveReadyEdges(&ready_edges);
+  EXPECT_EQ(2, pool.current_use());
+  EXPECT_EQ(1, ready_edges.size());
+  EXPECT_NE(ready_edges.find(&edge3), ready_edges.end());
+
+  // Complete edge1 and edge3, verify there is no more work.
+  pool.EdgeFinished(edge1);
+  pool.EdgeFinished(edge3);
+  EXPECT_EQ(0, pool.current_use());
+
+  ready_edges.clear();
+  pool.RetrieveReadyEdges(&ready_edges);
+  EXPECT_TRUE(ready_edges.empty());
 }
 
 }  // namespace


### PR DESCRIPTION
Add proper unit tests for the Pool class, then change the implementation to use an std::priority_queue instead of an std::set.
This data type uses less memory and is generally faster for this specific case.