### PR TITLE
Don't disable stdout buffering on Windows

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1486,17 +1486,6 @@ NORETURN void real_main(int argc, char** argv) {
     exit((ninja.*options.tool->func)(&options, argc, argv));
   }
 
-#ifdef WIN32
-  // It'd be nice to use line buffering but MSDN says: "For some systems,
-  // [_IOLBF] provides line buffering. However, for Win32, the behavior is the
-  //  same as _IOFBF - Full Buffering."
-  // Buffering used to be disabled in the LinePrinter constructor but that
-  // now disables it too early and breaks -t deps performance (see issue #2018)
-  // so we disable it here instead, but only when not running a tool.
-  if (!options.tool)
-    setvbuf(stdout, NULL, _IONBF, 0);
-#endif
-
   // Limit number of rebuilds, to prevent infinite loops.
   const int kCycleLimit = 100;
   for (int cycle = 1; cycle <= kCycleLimit; ++cycle) {


### PR DESCRIPTION
Long ago ninja disabled stdout buffering. Since then much has changed
and this appears to no longer be needed, while also being actively
harmful. Disabling of stdout buffering is not needed because printing
is done (in LinePrinter::Print) either with WriteConsoleOutput (which
is unaffected by stdout buffering) or by printf followed by fflush.

Meanwhile, the unbuffered printing in the printf case causes dramatic
slowdowns which are most visible in dry-run builds, as documented in
issue #2084.

This fixes issue #2084, finishing off the incomplete buffering fix done
in pull request #2031.