### PR TITLE
Fix ReadFile() handle leak on read error on Windows.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -350,7 +350,8 @@ int ReadFile(const string& path, string* contents, string* err) {
     if (!::ReadFile(f, buf, sizeof(buf), &len, NULL)) {
       err->assign(GetLastErrorString());
       contents->clear();
-      return -1;
+      ::CloseHandle(f);
+      return -EIO;
     }
     if (len == 0)
       break;


### PR DESCRIPTION
Small change to fix a file handle leak in case of error.
Also return -EIO instead of -1 to signal read errors, since it
is more consistent with what is happening here.