### PR TITLE
Build ninja with C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ endif()
 if(MSVC)
 	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 	string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+	# Note that these settings are separately specified in configure.py, and
+	# these lists should be kept in sync.
 	add_compile_options(/W4 /wd4100 /wd4267 /wd4706 /wd4702 /wd4244 /GR- /Zc:__cplusplus)
 	add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 else()
@@ -135,6 +137,8 @@ else()
 		target_link_libraries(libninja PUBLIC "-lperfstat")
 	endif()
 endif()
+
+target_compile_features(libninja PUBLIC cxx_std_11)
 
 #Fixes GetActiveProcessorCount on MinGW
 if(MINGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,9 @@ else()
 	endif()
 endif()
 
-target_compile_features(libninja PUBLIC cxx_std_11)
+if(CMAKE_CXX_STANDARD_DEFAULT EQUAL 98)
+  target_compile_features(libninja PUBLIC cxx_std_11)
+endif()
 
 #Fixes GetActiveProcessorCount on MinGW
 if(MINGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,9 +138,7 @@ else()
 	endif()
 endif()
 
-if(CMAKE_CXX_STANDARD_DEFAULT EQUAL 98)
-  target_compile_features(libninja PUBLIC cxx_std_11)
-endif()
+target_compile_features(libninja PUBLIC cxx_std_11)
 
 #Fixes GetActiveProcessorCount on MinGW
 if(MINGW)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Generally it's the
 a few additions:
 
 * Any code merged into the Ninja codebase which will be part of the main
-  executable must compile as C++03. You may use C++11 features in a test or an
-  unimportant tool if you guard your code with `#if __cplusplus >= 201103L`.
+  executable must compile as C++11. You may use C++14 features in a test or an
+  unimportant tool if you guard your code with `#if __cplusplus >= 201402L`.
 * We have used `using namespace std;` a lot in the past. For new contributions,
   please try to avoid relying on it and instead whenever possible use `std::`.
   However, please do not change existing code simply to add `std::` unless your

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,6 @@ Generally it's the
 [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) with
 a few additions:
 
-* Any code merged into the Ninja codebase which will be part of the main
-  executable must compile as C++11. You may use C++14 features in a test or an
-  unimportant tool if you guard your code with `#if __cplusplus >= 201402L`.
 * We have used `using namespace std;` a lot in the past. For new contributions,
   please try to avoid relying on it and instead whenever possible use `std::`.
   However, please do not change existing code simply to add `std::` unless your

--- a/configure.py
+++ b/configure.py
@@ -305,6 +305,8 @@ if platform.is_msvc():
 else:
     n.variable('ar', configure_env.get('AR', 'ar'))
 
+# Note that build settings are separately specified in CMakeLists.txt and
+# these lists should be kept in sync.
 if platform.is_msvc():
     cflags = ['/showIncludes',
               '/nologo',  # Don't print startup banner.
@@ -320,6 +322,7 @@ if platform.is_msvc():
               # Disable warnings about ignored typedef in DbgHelp.h
               '/wd4091',
               '/GR-',  # Disable RTTI.
+              '/Zc:__cplusplus',
               # Disable size_t -> int truncation warning.
               # We never have strings or arrays larger than 2**31.
               '/wd4267',
@@ -339,6 +342,7 @@ else:
               '-Wno-unused-parameter',
               '-fno-rtti',
               '-fno-exceptions',
+              '-std=c++11',
               '-fvisibility=hidden', '-pipe',
               '-DNINJA_PYTHON="%s"' % options.with_python]
     if options.debug:

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -403,11 +403,7 @@ string EdgeEnv::LookupVariable(const string& var) {
   if (var == "in" || var == "in_newline") {
     int explicit_deps_count = edge_->inputs_.size() - edge_->implicit_deps_ -
       edge_->order_only_deps_;
-#if __cplusplus >= 201103L
     return MakePathList(edge_->inputs_.data(), explicit_deps_count,
-#else
-    return MakePathList(&edge_->inputs_[0], explicit_deps_count,
-#endif
                         var == "in" ? ' ' : '\n');
   } else if (var == "out") {
     int explicit_outs_count = edge_->outputs_.size() - edge_->implicit_outs_;

--- a/src/hash_map.h
+++ b/src/hash_map.h
@@ -53,7 +53,6 @@ unsigned int MurmurHash2(const void* key, size_t len) {
   return h;
 }
 
-#if (__cplusplus >= 201103L) || (_MSC_VER >= 1900)
 #include <unordered_map>
 
 namespace std {
@@ -68,56 +67,13 @@ struct hash<StringPiece> {
 };
 }
 
-#elif defined(_MSC_VER)
-#include <hash_map>
-
-using stdext::hash_map;
-using stdext::hash_compare;
-
-struct StringPieceCmp : public hash_compare<StringPiece> {
-  size_t operator()(const StringPiece& key) const {
-    return MurmurHash2(key.str_, key.len_);
-  }
-  bool operator()(const StringPiece& a, const StringPiece& b) const {
-    int cmp = memcmp(a.str_, b.str_, min(a.len_, b.len_));
-    if (cmp < 0) {
-      return true;
-    } else if (cmp > 0) {
-      return false;
-    } else {
-      return a.len_ < b.len_;
-    }
-  }
-};
-
-#else
-#include <ext/hash_map>
-
-using __gnu_cxx::hash_map;
-
-namespace __gnu_cxx {
-template<>
-struct hash<StringPiece> {
-  size_t operator()(StringPiece key) const {
-    return MurmurHash2(key.str_, key.len_);
-  }
-};
-}
-#endif
-
 /// A template for hash_maps keyed by a StringPiece whose string is
 /// owned externally (typically by the values).  Use like:
 /// ExternalStringHash<Foo*>::Type foos; to make foos into a hash
 /// mapping StringPiece => Foo*.
 template<typename V>
 struct ExternalStringHashMap {
-#if (__cplusplus >= 201103L) || (_MSC_VER >= 1900)
   typedef std::unordered_map<StringPiece, V> Type;
-#elif defined(_MSC_VER)
-  typedef hash_map<StringPiece, V, StringPieceCmp> Type;
-#else
-  typedef hash_map<StringPiece, V> Type;
-#endif
 };
 
 #endif // NINJA_MAP_H_

--- a/src/missing_deps.h
+++ b/src/missing_deps.h
@@ -19,9 +19,7 @@
 #include <set>
 #include <string>
 
-#if __cplusplus >= 201103L
 #include <unordered_map>
-#endif
 
 struct DepsLog;
 struct DiskInterface;
@@ -68,13 +66,8 @@ struct MissingDependencyScanner {
   int missing_dep_path_count_;
 
  private:
-#if __cplusplus >= 201103L
   using InnerAdjacencyMap = std::unordered_map<Edge*, bool>;
   using AdjacencyMap = std::unordered_map<Edge*, InnerAdjacencyMap>;
-#else
-  typedef std::map<Edge*, bool> InnerAdjacencyMap;
-  typedef std::map<Edge*, InnerAdjacencyMap> AdjacencyMap;
-#endif
   AdjacencyMap adjacency_map_;
 };
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -31,13 +31,6 @@ bool Parser::Load(const string& filename, string* err, Lexer* parent) {
     return false;
   }
 
-  // The lexer needs a nul byte at the end of its input, to know when it's done.
-  // It takes a StringPiece, and StringPiece's string constructor uses
-  // string::data().  data()'s return value isn't guaranteed to be
-  // null-terminated (although in practice - libc++, libstdc++, msvc's stl --
-  // it is, and C++11 demands that too), so add an explicit nul byte.
-  contents.resize(contents.size() + 1);
-
   return Parse(filename, contents, err);
 }
 


### PR DESCRIPTION
In order to allow future use of std::chrono to make the stats code
portable it is desirable to compile with C++11. Doing so also allows use
of std::unordered_map, and reduces the number of #ifdefs in the ninja
source code.

Switching to C++11 requires modifying both CMakeLists.txt and
configure.py, for MSVC and for other build systems. For MSVC the
required change is adding /Zc:__cplusplus to tell the compiler to
give a more accurate value for the __cplusplus macro. For other
platforms the change is to add -std=c++11 or the CMake equivalent.

This change makes some progress towards resolving issue #2004.