### PR TITLE
cmake: remove unnecessary install parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,4 +232,4 @@ if(BUILD_TESTING)
   add_test(NAME NinjaTest COMMAND ninja_test)
 endif()
 
-install(TARGETS ninja DESTINATION bin)
+install(TARGETS ninja)


### PR DESCRIPTION
The `install(TARGETS ... DESTINATION bin)` is not necessary as this
subdirectory is implicit for executable targets.

ref: https://cmake.org/cmake/help/v3.15/command/install.html