### PR TITLE
Document C++11 build requirements and enforce them in CI.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -123,6 +123,16 @@ jobs:
       run: pytest-3 --color=yes ../..
       working-directory: build-clang/Release
 
+    - name: Configure (GCC_C++11)
+      run: CXXFLAGS=-std=c++11 cmake -Bbuild-gcc-c++11 -DCMAKE_BUILD_TYPE=Debug -G'Ninja Multi-Config'
+    - name: Build (GCC_C++11, Debug)
+      run: cmake --build build-gcc-c++11 --config Debug
+    - name: Unit tests (GCC_C++11, Debug)
+      run: ./build-gcc-c++11/Debug/ninja_test
+    - name: Python tests (GCC_C++11, Debug)
+      run: pytest-3 --color=yes ../..
+      working-directory: build-gcc-c++11/Debug
+
     - name: clang-tidy
       run: /usr/lib/llvm-10/share/clang/run-clang-tidy.py -header-filter=src
       working-directory: build-clang

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,11 @@ Generally it's the
 a few additions:
 
 * Any code merged into the Ninja codebase which will be part of the main
-  executable must compile as C++03. You may use C++11 features in a test or an
-  unimportant tool if you guard your code with `#if __cplusplus >= 201103L`.
+  executable *must* compile as C++03 as well as C++11. And any C++11 specific
+  code path there *must* be guarded in the code with `#if __cplusplus >= 201103L.
+  New Ninja features *must* *not* depend on the language standard used to
+  build the source code. This last restriction does not apply to tests and
+  unimportant tools.
 * We have used `using namespace std;` a lot in the past. For new contributions,
   please try to avoid relying on it and instead whenever possible use `std::`.
   However, please do not change existing code simply to add `std::` unless your


### PR DESCRIPTION
Clarify the state of C++03 and C++11 support in CONTRIBUTING.md,
and add a new CI test to ensure that Ninja builds and works
correctly with a C++11 compiler.