### PR TITLE
Add ability not to use a smart terminal

### DIFF
--- a/src/status.cc
+++ b/src/status.cc
@@ -32,8 +32,9 @@ StatusPrinter::StatusPrinter(const BuildConfig& config)
       time_millis_(0), progress_status_format_(NULL),
       current_rate_(config.parallelism) {
 
-  // Don't do anything fancy in verbose mode.
-  if (config_.verbosity != BuildConfig::NORMAL)
+  // Don't do anything fancy in verbose mode or if defined `NINJA_NO_SMART_TERMINAL`.
+  if (getenv("NINJA_NO_SMART_TERMINAL") != NULL
+      || config_.verbosity != BuildConfig::NORMAL)
     printer_.set_smart_terminal(false);
 
   progress_status_format_ = getenv("NINJA_STATUS");


### PR DESCRIPTION
Ninja now can disable a smart terminal if users define the `NINJA_NO_SMART_TERMINAL` environmental variable in case users do not want to do overprinting.