### PR TITLE
Add `explicit` specifier for the constructor of `SlidingRateInfo`

### DIFF
--- a/src/status.h
+++ b/src/status.h
@@ -88,7 +88,7 @@ struct StatusPrinter : Status {
   }
 
   struct SlidingRateInfo {
-    SlidingRateInfo(int n) : rate_(-1), N(n), last_update_(-1) {}
+    explicit SlidingRateInfo(int n) : rate_(-1), N(n), last_update_(-1) {}
 
     double rate() { return rate_; }
 


### PR DESCRIPTION
A constructor with only one argument is commonly suggested to use an `explicit` specifier.