### PR TITLE
Enable msvc tool in cross-compiled windows builds of ninja

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -52,10 +52,12 @@
 
 using namespace std;
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 // Defined in msvc_helper_main-win32.cc.
 int MSVCHelperMain(int argc, char** argv);
+#endif
 
+#ifdef _MSC_VER
 // Defined in minidump-win32.cc.
 void CreateWin32MiniDump(_EXCEPTION_POINTERS* pep);
 #endif
@@ -449,7 +451,7 @@ int NinjaMain::ToolBrowse(const Options*, int, char**) {
 }
 #endif
 
-#if defined(_MSC_VER)
+#ifdef _WIN32
 int NinjaMain::ToolMSVC(const Options* options, int argc, char* argv[]) {
   // Reset getopt: push one argument onto the front of argv, reset optind.
   argc++;
@@ -1043,7 +1045,7 @@ const Tool* ChooseTool(const string& tool_name) {
   static const Tool kTools[] = {
     { "browse", "browse dependency graph in a web browser",
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolBrowse },
-#if defined(_MSC_VER)
+#if _WIN32
     { "msvc", "build helper for MSVC cl.exe (EXPERIMENTAL)",
       Tool::RUN_AFTER_FLAGS, &NinjaMain::ToolMSVC },
 #endif


### PR DESCRIPTION
Cross-compiled windows builds of ninja are unable to use `-t msvc` because it is ifdefed to `_MSC_VER` instead of `_WIN32`, even though a non-msvc built ninja is perfectly capable of containing and running that code. This is mentioned in https://github.com/ninja-build/ninja/issues/2082. This PR replaces those defines, so that cross-compiled windows executables will not lack this functionality. 