### PR TITLE
Fix canonicalize path

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -164,6 +164,15 @@ out1
 out2
 ''')
 
+    def test_issue_2008(self):
+        self.assertEqual(run(
+'''rule my_rule
+  command = echo foo
+build foo: my_rule /
+'''),
+'''[1/1] echo foo\x1b[K
+foo
+''')
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -91,11 +91,11 @@ TEST(CanonicalizePath, PathSamples) {
 
   path = "/";
   CanonicalizePath(&path);
-  EXPECT_EQ("", path);
+  EXPECT_EQ("/", path);
 
   path = "/foo/..";
   CanonicalizePath(&path);
-  EXPECT_EQ("", path);
+  EXPECT_EQ("/", path);
 
   path = ".";
   CanonicalizePath(&path);
@@ -171,7 +171,7 @@ TEST(CanonicalizePath, PathSamplesWindows) {
 
   path = "\\";
   CanonicalizePath(&path);
-  EXPECT_EQ("", path);
+  EXPECT_EQ("/", path);
 }
 
 TEST(CanonicalizePath, SlashTracking) {
@@ -353,11 +353,11 @@ TEST(CanonicalizePath, NotNullTerminated) {
   EXPECT_EQ(strlen("foo"), len);
   EXPECT_EQ("foo/. bar/.", string(path));
 
-  path = "foo/../file bar/.";
-  len = strlen("foo/../file");
+  path = "fooxyz/../file bar/.";
+  len = strlen("fooxzy/../file");
   CanonicalizePath(&path[0], &len, &unused);
   EXPECT_EQ(strlen("file"), len);
-  EXPECT_EQ("file ./file bar/.", string(path));
+  EXPECT_EQ("fileyz/../file bar/.", string(path));
 }
 
 TEST(PathEscaping, TortureTest) {


### PR DESCRIPTION
This patch fixes a few annoying bugs in the implementation of
CanonicalizePath():

- It canonicalized "/" and "/foo/.." incorrectly to "",
  while the correct value should be "/". And this was
  enforced by unit-tests :-(

  This was the root cause for issue #2008.

- In certain cases, it would copy the first byte _after_ the
  path buffer into the destination (assuming in the comment
  that this is a terminating zero), though there is no guarantee
  that this is the case, or that this address is accessible.

  This is important because the function is being called in
  build.cc:xxx and :xxx with arguments coming from StringPiece
  values, which do not guarantee anything about the bytes/memory
  that follow the content they point to. It just happens to work
  due to the way the parser are currently implemented, but could
  break easily in the future if they are modified (e.g.
  to read directly from read-only memory-mapped files).

Performance comparisons with `canonical_perfcompare` shows this
implementation to be slightly faster as well, though benchmarking
ninja with a large Fuchsia build plan doesn't show any difference
overall.

Minimal times reported by canon_perftest (best of 5 runs each):

```
  compiler           BEFORE       AFTER

  g++-11 -O2          120ms    110ms
  g++-11 -O3          123ms    110ms
  clang++-13 -O2      115ms    114ms
  clang++-13 -O3      115ms    110ms
```

Note that the loop had to be unrolled for `gcc -O3` due to some
surprising compiler optimization failure :-(
