### PR TITLE
Refactor github workflows to expand build and test coverage

### DIFF
--- a/.github/workflows/analyzers.yml
+++ b/.github/workflows/analyzers.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         tool: [clang-analyzer, iwyu, CodeQL]
         config: [Release, Debug]
@@ -73,6 +74,7 @@ jobs:
     runs-on: windows-latest
 
     strategy:
+      fail-fast: false
       matrix:
         tool: [msvc-code-analysis]
         config: [Release, Debug]

--- a/.github/workflows/analyzers.yml
+++ b/.github/workflows/analyzers.yml
@@ -16,13 +16,17 @@ jobs:
         tool: [clang-analyzer, iwyu, CodeQL]
         config: [Release, Debug]
 
+    permissions:
+      # required for all workflows
+      security-events: write
+
     # Speed the build up
     env:
       CMAKE_C_COMPILER_LAUNCHER:   ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -36,7 +40,7 @@ jobs:
         sudo apt install -y ninja-build clang clang-tidy clang-tools iwyu cmake
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       if: ${{ matrix.tool == 'CodeQL' }}
       with:
         languages: cpp
@@ -45,14 +49,14 @@ jobs:
       run: |
         cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE
 
-    # Must build so that src/build/browse.py.h is generated
+    # Must build so that src/build/browse.py.h is generated, as well as CodeQL analysis
     - name: Build
       run: |
         cmake --build build --parallel
 
     - name: Perform CodeQL Analysis
       if: ${{ matrix.tool == 'CodeQL' }}
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
 
     # Implicitly requires build/compile_commands.json to exist
     - name: Run Clang Analyzer
@@ -67,7 +71,7 @@ jobs:
       if: ${{ matrix.tool == 'iwyu' }}
       run: |
         wget https://raw.githubusercontent.com/include-what-you-use/include-what-you-use/clang_11/iwyu_tool.py
-        chmod +x iwyu_tool.py 
+        chmod +x iwyu_tool.py
         ./iwyu_tool.py -j $(nproc) -p build
 
   analyze-windows:
@@ -79,8 +83,12 @@ jobs:
         tool: [msvc-code-analysis]
         config: [Release, Debug]
 
+    permissions:
+      # required for all workflows
+      security-events: write
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 

--- a/.github/workflows/analyzers.yml
+++ b/.github/workflows/analyzers.yml
@@ -1,0 +1,103 @@
+name: Analyzers
+
+on:
+  pull_request:
+  push:
+  release:
+    types: published
+
+jobs:
+  analyze-linux:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        tool: [clang-analyzer, iwyu, CodeQL]
+        config: [Release, Debug]
+
+    # Speed the build up
+    env:
+      CMAKE_C_COMPILER_LAUNCHER:   ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: analyzers-linux-${{ matrix.config }}
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y ninja-build clang clang-tidy clang-tools iwyu cmake
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      if: ${{ matrix.tool == 'CodeQL' }}
+      with:
+        languages: cpp
+
+    - name: Configure
+      run: |
+        cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE
+
+    # Must build so that src/build/browse.py.h is generated
+    - name: Build
+      run: |
+        cmake --build build --parallel
+
+    - name: Perform CodeQL Analysis
+      if: ${{ matrix.tool == 'CodeQL' }}
+      uses: github/codeql-action/analyze@v1
+
+    # Implicitly requires build/compile_commands.json to exist
+    - name: Run Clang Analyzer
+      if: ${{ matrix.tool == 'clang-analyzer' }}
+      run: |
+        wget https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-11.0.1/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+        chmod +x run-clang-tidy.py
+        ./run-clang-tidy.py -j $(nproc) -p build
+
+    # Implicitly requires build/compile_commands.json to exist
+    - name: Run IWYU
+      if: ${{ matrix.tool == 'iwyu' }}
+      run: |
+        wget https://raw.githubusercontent.com/include-what-you-use/include-what-you-use/clang_11/iwyu_tool.py
+        chmod +x iwyu_tool.py 
+        ./iwyu_tool.py -j $(nproc) -p build
+
+  analyze-windows:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        tool: [msvc-code-analysis]
+        config: [Release, Debug]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Configure
+      run: |
+        cmake -B build -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }}
+
+    - name: Initialize MSVC Code Analysis
+      uses: microsoft/msvc-code-analysis-action@v0.1.0
+      # Provide a unique ID to access the sarif output path
+      id: run-analysis
+      with:
+        cmakeBuildDirectory: build
+        buildConfiguration: ${{ matrix.config }}
+        # Ruleset file that will determine what checks will be run
+        ruleset: NativeRecommendedRules.ruleset
+
+      # Upload SARIF file to GitHub Code Scanning Alerts
+    - name: Upload SARIF to GitHub
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: ${{ steps.run-analysis.outputs.sarif }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,9 +28,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.16.8/cmake-3.16.8-Linux-x86_64.sh
-        chmod +x cmake-3.16.8-Linux-x86_64.sh
-        ./cmake-3.16.8-Linux-x86_64.sh --skip-license --prefix=/usr/local
+        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.15.7/cmake-3.15.7-Linux-x86_64.sh
+        chmod +x cmake-3.15.7-Linux-x86_64.sh
+        ./cmake-3.15.7-Linux-x86_64.sh --skip-license --prefix=/usr/local
         yum install -y make gcc-c++ libasan
 
     - name: Configure
@@ -63,9 +63,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.16.8/cmake-3.16.8-Linux-x86_64.sh
-        chmod +x cmake-3.16.8-Linux-x86_64.sh
-        ./cmake-3.16.8-Linux-x86_64.sh --skip-license --prefix=/usr/local
+        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.15.7/cmake-3.15.7-Linux-x86_64.sh
+        chmod +x cmake-3.15.7-Linux-x86_64.sh
+        ./cmake-3.15.7-Linux-x86_64.sh --skip-license --prefix=/usr/local
         yum install -y make gcc-c++ python3
 
     - name: Bootstrap
@@ -107,8 +107,8 @@ jobs:
     - name: Install dependencies
       run: |
         apt update
-        apt install -y ninja-build clang re2c python3-pip
-        pip3 install cmake==3.16.*
+        apt install -y make clang re2c python3-pip
+        pip3 install cmake==3.15.*
 
     - name: Mkdir build
       run: |
@@ -181,9 +181,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.16.8/cmake-3.16.8-Linux-x86_64.sh
-        chmod +x cmake-3.16.8-Linux-x86_64.sh
-        ./cmake-3.16.8-Linux-x86_64.sh --skip-license --prefix=/usr/local
+        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.15.7/cmake-3.15.7-Linux-x86_64.sh
+        chmod +x cmake-3.15.7-Linux-x86_64.sh
+        ./cmake-3.15.7-Linux-x86_64.sh --skip-license --prefix=/usr/local
         curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/p7zip-16.02-20.el7.x86_64.rpm
         curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/p7zip-plugins-16.02-20.el7.x86_64.rpm
         rpm -U --quiet p7zip-16.02-20.el7.x86_64.rpm

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,54 +7,205 @@ on:
     types: published
 
 jobs:
-  build:
-    runs-on: [ubuntu-latest]
+  CentOS_CMake:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        config: [Release, Debug]
+
     container:
       image: centos:7
+
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
     - uses: codespell-project/actions-codespell@master
       with:
         ignore_words_list: fo,wee
+
     - name: Install dependencies
       run: |
-        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.sh
-        chmod +x cmake-3.16.4-Linux-x86_64.sh
-        ./cmake-3.16.4-Linux-x86_64.sh --skip-license --prefix=/usr/local
+        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.16.8/cmake-3.16.8-Linux-x86_64.sh
+        chmod +x cmake-3.16.8-Linux-x86_64.sh
+        ./cmake-3.16.8-Linux-x86_64.sh --skip-license --prefix=/usr/local
+        yum install -y make gcc-c++ libasan
+
+    - name: Configure
+      env:
+        CFLAGS:   ${{ matrix.config == 'Debug' && '-fstack-protector-all -fsanitize=address' || '' }}
+        CXXFLAGS: ${{ matrix.config == 'Debug' && '-fstack-protector-all -fsanitize=address' || '' }}
+      run: |
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} -B build
+
+    - name: Build
+      run: |
+        cmake --build build --parallel
+
+    - name: Test
+      working-directory: build
+      run: |
+        ctest --schedule-random --progress --output-on-failure --parallel --no-tests error --build-config ${{ matrix.config }}
+
+
+  CentOS_Python:
+    runs-on: ubuntu-latest
+
+    container:
+      image: centos:7
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Install dependencies
+      run: |
+        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.16.8/cmake-3.16.8-Linux-x86_64.sh
+        chmod +x cmake-3.16.8-Linux-x86_64.sh
+        ./cmake-3.16.8-Linux-x86_64.sh --skip-license --prefix=/usr/local
+        yum install -y make gcc-c++ python3
+
+    - name: Bootstrap
+      run: |
+        python3 configure.py --bootstrap
+
+    - name: Build
+      run: |
+        ./ninja all
+
+    - name: Test
+      run: |
+        ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots
+        python3 misc/ninja_syntax_test.py
+        ./misc/output_test.py
+
+
+  Ubuntu_CMake:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image: ['ubuntu:16.04', 'ubuntu:18.04', 'ubuntu:20.04']
+        compiler: [gcc, clang]
+        config: [Release, Debug]
+
+    container:
+      image: ${{ matrix.image }}
+
+    env:
+      CC:  ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang'   }}
+      CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Install dependencies
+      run: |
+        apt update
+        apt install -y ninja-build clang re2c python3-pip
+        pip3 install cmake==3.16.*
+
+    - name: Mkdir build
+      run: |
+        mkdir build
+
+    - name: Configure
+      working-directory: build
+      run: |
+        cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+
+    - name: Build
+      run: |
+        cmake --build build --parallel
+
+    - name: Test
+      working-directory: build
+      run: |
+        ctest --schedule-random --progress --output-on-failure --parallel --no-tests error --build-config ${{ matrix.config }}
+        python3 ../misc/ninja_syntax_test.py
+        ../misc/output_test.py
+
+
+  Ubuntu_Python:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        image: ['ubuntu:16.04', 'ubuntu:18.04', 'ubuntu:20.04']
+
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Install dependencies
+      run: |
+        apt update
+        apt install -y g++ python3
+
+    - name: Bootstrap
+      run: |
+        python3 configure.py --bootstrap
+
+    - name: Build
+      run: |
+        ./ninja all
+
+    - name: Test
+      run: |
+        ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots
+        python3 misc/ninja_syntax_test.py
+        ./misc/output_test.py
+
+
+  Release:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'published'
+    needs: [CentOS_CMake, CentOS_Python, Ubuntu_CMake, Ubuntu_Python]
+
+    container:
+      image: centos:7
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Install dependencies
+      run: |
+        curl -L -O https://github.com/Kitware/CMake/releases/download/v3.16.8/cmake-3.16.8-Linux-x86_64.sh
+        chmod +x cmake-3.16.8-Linux-x86_64.sh
+        ./cmake-3.16.8-Linux-x86_64.sh --skip-license --prefix=/usr/local
         curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/p7zip-16.02-20.el7.x86_64.rpm
         curl -L -O https://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/p7zip-plugins-16.02-20.el7.x86_64.rpm
         rpm -U --quiet p7zip-16.02-20.el7.x86_64.rpm
         rpm -U --quiet p7zip-plugins-16.02-20.el7.x86_64.rpm
-        yum install -y make gcc-c++ libasan clang-analyzer
+        yum install -y make gcc-c++
 
-    - name: Build debug ninja
-      shell: bash
-      env:
-        CFLAGS: -fstack-protector-all -fsanitize=address
-        CXXFLAGS: -fstack-protector-all -fsanitize=address
+    - name: Configure
       run: |
-        scan-build -o scanlogs cmake -DCMAKE_BUILD_TYPE=Debug -B debug-build
-        scan-build -o scanlogs cmake --build debug-build --parallel --config Debug
+        cmake -DCMAKE_BUILD_TYPE=Release -B build
 
-    - name: Test debug ninja
-      run: ./ninja_test
-      working-directory: debug-build
-
-    - name: Build release ninja
-      shell: bash
+    - name: Build
       run: |
-        cmake -DCMAKE_BUILD_TYPE=Release -B release-build
-        cmake --build release-build --parallel --config Release
-        strip release-build/ninja
+        cmake --build build --parallel
 
-    - name: Test release ninja
-      run: ./ninja_test
-      working-directory: release-build
+    - name: Strip
+      run: |
+        strip build/ninja
 
-    - name: Create ninja archive
+    - name: Create archive
       run: |
         mkdir artifact
-        7z a artifact/ninja-linux.zip ./release-build/ninja
+        7z a artifact/ninja-linux.zip ./build/ninja
 
     # Upload ninja binary archive as an artifact
     - name: Upload artifact
@@ -64,7 +215,6 @@ jobs:
         path: artifact
 
     - name: Upload release asset
-      if: github.event.action == 'published'
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,76 +224,3 @@ jobs:
         asset_name: ninja-linux.zip
         asset_content_type: application/zip
 
-  test:
-    runs-on: [ubuntu-latest]
-    container:
-      image: ubuntu:20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        apt update
-        apt install -y python3-pytest ninja-build clang-tidy python3-pip clang
-        pip3 install cmake==3.17.*
-    - name: Configure (GCC)
-      run: cmake -Bbuild-gcc -DCMAKE_BUILD_TYPE=Debug -G'Ninja Multi-Config'
-
-    - name: Build (GCC, Debug)
-      run: cmake --build build-gcc --config Debug
-    - name: Unit tests (GCC, Debug)
-      run: ./build-gcc/Debug/ninja_test
-    - name: Python tests (GCC, Debug)
-      run: pytest-3 --color=yes ../..
-      working-directory: build-gcc/Debug
-
-    - name: Build (GCC, Release)
-      run: cmake --build build-gcc --config Release
-    - name: Unit tests (GCC, Release)
-      run: ./build-gcc/Release/ninja_test
-    - name: Python tests (GCC, Release)
-      run: pytest-3 --color=yes ../..
-      working-directory: build-gcc/Release
-
-    - name: Configure (Clang)
-      run: CC=clang CXX=clang++ cmake -Bbuild-clang -DCMAKE_BUILD_TYPE=Debug -G'Ninja Multi-Config' -DCMAKE_EXPORT_COMPILE_COMMANDS=1
-
-    - name: Build (Clang, Debug)
-      run: cmake --build build-clang --config Debug
-    - name: Unit tests (Clang, Debug)
-      run: ./build-clang/Debug/ninja_test
-    - name: Python tests (Clang, Debug)
-      run: pytest-3 --color=yes ../..
-      working-directory: build-clang/Debug
-
-    - name: Build (Clang, Release)
-      run: cmake --build build-clang --config Release
-    - name: Unit tests (Clang, Release)
-      run: ./build-clang/Release/ninja_test
-    - name: Python tests (Clang, Release)
-      run: pytest-3 --color=yes ../..
-      working-directory: build-clang/Release
-
-    - name: clang-tidy
-      run: /usr/lib/llvm-10/share/clang/run-clang-tidy.py -header-filter=src
-      working-directory: build-clang
-
-  build-with-python:
-    runs-on: [ubuntu-latest]
-    container:
-      image: ${{ matrix.image }}
-    strategy:
-      matrix:
-        image: ['ubuntu:14.04', 'ubuntu:16.04', 'ubuntu:18.04']
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        apt update
-        apt install -y g++ python3
-    - name: ${{ matrix.image }}
-      run: |
-        python3 configure.py --bootstrap
-        ./ninja all
-        ./ninja_test --gtest_filter=-SubprocessTest.SetWithLots
-        python3 misc/ninja_syntax_test.py
-        ./misc/output_test.py

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,6 +37,7 @@ jobs:
       env:
         CFLAGS:   ${{ matrix.config == 'Debug' && '-fstack-protector-all -fsanitize=address' || '' }}
         CXXFLAGS: ${{ matrix.config == 'Debug' && '-fstack-protector-all -fsanitize=address' || '' }}
+        LDFLAGS:  ${{ matrix.config == 'Debug' && '-fsanitize=address' || '' }}
       run: |
         cmake -DCMAKE_BUILD_TYPE=${{ matrix.config }} -B build
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         config: [Release, Debug]
 
@@ -88,6 +89,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         image: ['ubuntu:16.04', 'ubuntu:18.04', 'ubuntu:20.04']
         compiler: [gcc, clang]
@@ -136,6 +138,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         image: ['ubuntu:16.04', 'ubuntu:18.04', 'ubuntu:20.04']
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
       image: centos:7
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -59,7 +59,7 @@ jobs:
       image: centos:7
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -103,7 +103,7 @@ jobs:
       CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -146,7 +146,7 @@ jobs:
       image: ${{ matrix.image }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -179,7 +179,7 @@ jobs:
       image: centos:7
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -213,13 +213,13 @@ jobs:
 
     # Upload ninja binary archive as an artifact
     - name: Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: ninja-binary-archives
         path: artifact
 
     - name: Upload release asset
-      uses: actions/upload-release-asset@v1.0.1
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,29 +7,65 @@ on:
     types: published
 
 jobs:
-  build:
-    runs-on: macos-11.0
+  BuildAndTest:
+    strategy:
+      matrix:
+        image: [macos-10.15, macos-11]
+        config: [Release, Debug]
+
+    runs-on: ${{ matrix.image }}
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: macos-${{ matrix.image }}-${{ matrix.config }}
+
+    - name: Install dependencies
+      run: brew install re2c cmake
+
+    - name: Configure ninja
+      env:
+        MACOSX_DEPLOYMENT_TARGET: 10.12
+      run: |
+        cmake -Bbuild -GXcode -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 
+
+    - name: Build ninja
+      run: |
+        cmake --build build --parallel --config ${{ matrix.config }}
+
+    - name: Test ninja
+      working-directory: build
+      run: |
+        ctest --schedule-random --progress --output-on-failure --parallel --no-tests error --build-config ${{ matrix.config }}
+
+  Release:
+    runs-on: macos-latest
+    if: github.event.action == 'published'
+    needs: BuildAndTest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
 
     - name: Install dependencies
       run: brew install re2c p7zip cmake
 
-    - name: Build ninja
-      shell: bash
+    - name: Configure
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.12
       run: |
-        cmake -Bbuild -GXcode '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'
-        cmake --build build --config Release
+        cmake -B build -GXcode -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_CONFIGURATION_TYPES=Release
 
-    - name: Test ninja
-      run: ctest -C Release -vv
-      working-directory: build
+    - name: Build
+      run: |
+        cmake --build build --parallel --config Release
 
-    - name: Create ninja archive
-      shell: bash
+    - name: Create archive
       run: |
         mkdir artifact
         7z a artifact/ninja-mac.zip ./build/Release/ninja
@@ -42,7 +78,6 @@ jobs:
         path: artifact
 
     - name: Upload release asset
-      if: github.event.action == 'published'
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   BuildAndTest:
     strategy:
+      fail-fast: false
       matrix:
         image: [macos-10.15, macos-11]
         config: [Release, Debug]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,17 +27,20 @@ jobs:
     - name: Install dependencies
       run: brew install re2c cmake
 
-    - name: Configure ninja
+    - name: Configure
       env:
+        CFLAGS:   ${{ matrix.config == 'Debug' && '-fstack-protector-all -fsanitize=address,bounds,enum,pointer-compare,pointer-subtract -fsanitize-address-use-after-scope' || '' }}
+        CXXFLAGS: ${{ matrix.config == 'Debug' && '-fstack-protector-all -fsanitize=address,bounds,enum,pointer-compare,pointer-subtract -fsanitize-address-use-after-scope' || '' }}
+        LDFLAGS:  ${{ matrix.config == 'Debug' && '-fsanitize=address,bounds,enum,pointer-compare,pointer-subtract' || '' }}
         MACOSX_DEPLOYMENT_TARGET: 10.12
       run: |
         cmake -Bbuild -GXcode -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 
 
-    - name: Build ninja
+    - name: Build
       run: |
         cmake --build build --parallel --config ${{ matrix.config }}
 
-    - name: Test ninja
+    - name: Test
       working-directory: build
       run: |
         ctest --schedule-random --progress --output-on-failure --parallel --no-tests error --build-config ${{ matrix.config }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,13 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [macos-10.15, macos-11]
+        image: [macos-10.15, macos-11, macos-12]
         config: [Release, Debug]
 
     runs-on: ${{ matrix.image }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -35,7 +35,7 @@ jobs:
         LDFLAGS:  ${{ matrix.config == 'Debug' && '-fsanitize=address,bounds,enum,pointer-compare,pointer-subtract' || '' }}
         MACOSX_DEPLOYMENT_TARGET: 10.12
       run: |
-        cmake -Bbuild -GXcode -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache 
+        cmake -Bbuild -GXcode -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       run: |
@@ -52,7 +52,7 @@ jobs:
     needs: BuildAndTest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -76,13 +76,13 @@ jobs:
 
     # Upload ninja binary archive as an artifact
     - name: Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: ninja-binary-archives
         path: artifact
 
     - name: Upload release asset
-      uses: actions/upload-release-asset@v1.0.1
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,32 +7,61 @@ on:
     types: published
 
 jobs:
-  build:
-    runs-on: windows-latest
+  BuildAndTest:
+    strategy:
+      matrix:
+        image: [windows-2019, windows-2022]
+        config: [Release, Debug]
+
+    runs-on: ${{ matrix.image }}
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: windows-${{ matrix.image }}-${{ matrix.config }}
 
     - name: Install dependencies
       run: choco install re2c
 
-    - name: Build ninja
-      shell: bash
+    - name: Configure
       run: |
-        cmake -Bbuild
-        cmake --build build --parallel --config Debug
-        cmake --build build --parallel --config Release
+        cmake -B build -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
-    - name: Test ninja (Debug)
-      run: .\ninja_test.exe
-      working-directory: build/Debug
+    - name: Build
+      run: |
+        cmake --build build --parallel --config ${{ matrix.config }}
 
-    - name: Test ninja (Release)
-      run: .\ninja_test.exe
-      working-directory: build/Release
+    - name: Test
+      working-directory: build
+      run: |
+        ctest --schedule-random --progress --output-on-failure --parallel --no-tests error --build-config ${{ matrix.config }}
+
+  Release:
+    runs-on: windows-latest
+    if: github.event.action == 'published'
+    needs: BuildAndTest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Install dependencies
+      run: choco install re2c
+
+    - name: Configure ninja
+      run: |
+        cmake -B build -DCMAKE_CONFIGURATION_TYPES=Release
+
+    - name: Build ninja
+      run: |
+        cmake --build build --parallel --config Release --target ninja
 
     - name: Create ninja archive
-      shell: bash
       run: |
         mkdir artifact
         7z a artifact/ninja-win.zip ./build/Release/ninja.exe
@@ -45,7 +74,6 @@ jobs:
         path: artifact
 
     - name: Upload release asset
-      if: github.event.action == 'published'
       uses: actions/upload-release-asset@v1.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   BuildAndTest:
     strategy:
+      fail-fast: false
       matrix:
         image: [windows-2019, windows-2022]
         config: [Release, Debug]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,6 +28,9 @@ jobs:
       run: choco install re2c
 
     - name: Configure
+      env:
+        CFLAGS:   ${{ matrix.config == 'Debug' && '/fsanitize=address' || '' }}
+        CXXLAGS:  ${{ matrix.config == 'Debug' && '/fsanitize=address' || '' }}
       run: |
         cmake -B build -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,27 +13,34 @@ jobs:
       matrix:
         image: [windows-2019, windows-2022]
         config: [Release, Debug]
+        compiler: [msvc, clangcl]
 
     runs-on: ${{ matrix.image }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
     - uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: windows-${{ matrix.image }}-${{ matrix.config }}
+        key: windows-${{ matrix.image }}-${{ matrix.config }}-${{ matrix.compiler }}
 
     - name: Install dependencies
       run: choco install re2c
 
-    - name: Configure
+    - name: Configure (MSVC)
+      if: ${{ matrix.compiler == 'msvc' }}
       env:
         CFLAGS:   ${{ matrix.config == 'Debug' && '/fsanitize=address' || '' }}
         CXXLAGS:  ${{ matrix.config == 'Debug' && '/fsanitize=address' || '' }}
       run: |
         cmake -B build -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: Configure (ClangCL)
+      if: ${{ matrix.compiler == 'clangcl' }}
+      run: |
+        cmake -B build -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -TClangCL -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       run: |
@@ -50,7 +57,7 @@ jobs:
     needs: BuildAndTest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -72,13 +79,13 @@ jobs:
 
     # Upload ninja binary archive as an artifact
     - name: Upload artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: ninja-binary-archives
         path: artifact
 
     - name: Upload release asset
-      uses: actions/upload-release-asset@v1.0.1
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,7 @@ jobs:
         image: [windows-2019, windows-2022]
         config: [Release, Debug]
         compiler: [msvc, clangcl]
+        arch: [x64, ARM64]
 
     runs-on: ${{ matrix.image }}
 
@@ -35,18 +36,19 @@ jobs:
         CFLAGS:   ${{ matrix.config == 'Debug' && '/fsanitize=address' || '' }}
         CXXLAGS:  ${{ matrix.config == 'Debug' && '/fsanitize=address' || '' }}
       run: |
-        cmake -B build -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake -B build -A ${{ matrix.arch }} -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Configure (ClangCL)
       if: ${{ matrix.compiler == 'clangcl' }}
       run: |
-        cmake -B build -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -TClangCL -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake -B build -A ${{ matrix.arch }} -TClangCL -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       run: |
         cmake --build build --parallel --config ${{ matrix.config }}
 
     - name: Test
+      if: ${{ matrix.arch == 'X64' }} # Can't test ARM64 on a x86_64 machine.
       working-directory: build
       run: |
         ctest --schedule-random --progress --output-on-failure --parallel --no-tests error --build-config ${{ matrix.config }}


### PR DESCRIPTION
This pull request refactors the github workflows to expand test coverage of various platforms that ninja can be built on.

Additionally, it adds an anaylzers.yml workflow that keeps the clang-analyzer in the same place as the newly added analyzers

- include what you use
- Github hosted CodeQL
- Github hosted MSVC analyzer