### PR TITLE
Use python3 instead of python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ function(check_platform_supports_browse_mode RESULT)
 
 endfunction()
 
-set(NINJA_PYTHON "python" CACHE STRING "Python interpreter to use for the browse tool")
+set(NINJA_PYTHON "python3" CACHE STRING "Python interpreter to use for the browse tool")
 
 check_platform_supports_browse_mode(platform_supports_ninja_browse)
 

--- a/configure.py
+++ b/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2001 Google Inc. All Rights Reserved.
 #

--- a/misc/measure.py
+++ b/misc/measure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2011 Google Inc. All Rights Reserved.
 #

--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Copyright 2011 Google Inc. All Rights Reserved.
 #

--- a/misc/ninja_syntax_test.py
+++ b/misc/ninja_syntax_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2011 Google Inc. All Rights Reserved.
 #

--- a/misc/write_fake_manifests.py
+++ b/misc/write_fake_manifests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Writes large manifest files, for manifest parser performance testing.
 
@@ -6,7 +6,7 @@ The generated manifest files are (eerily) similar in appearance and size to the
 ones used in the Chromium project.
 
 Usage:
-  python misc/write_fake_manifests.py outdir  # Will run for about 5s.
+  ./misc/write_fake_manifests.py outdir  # Will run for about 5s.
 
 The program contains a hardcoded random seed, so it will generate the same
 output every time it runs.  By changing the seed, it's easy to generate many

--- a/src/browse.py
+++ b/src/browse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2001 Google Inc. All Rights Reserved.
 #

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -48,7 +48,7 @@ bool WriteFakeManifests(const string& dir, string* err) {
   if (mtime != 0)  // 0 means that the file doesn't exist yet.
     return mtime != -1;
 
-  string command = "python misc/write_fake_manifests.py " + dir;
+  string command = "./misc/write_fake_manifests.py " + dir;
   printf("Creating manifest data..."); fflush(stdout);
   int exit_code = system(command.c_str());
   printf("done.\n");


### PR DESCRIPTION
This is a new version of https://github.com/ninja-build/ninja/pull/2063
for discussion. macOS 12.3 has removed /usr/bin/python entirely, so
there is no longer an executable if you request `/usr/bin/env python`.
So even if you override `--with-python=python3`, you cannot call
`./configure.py` directly, you'd have to run `python3 configure.py`
instead.