### PR TITLE
Introduce NINJA_SHELL environment variable

### DIFF
--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -38,6 +38,12 @@ using namespace std;
 
 Subprocess::Subprocess(bool use_console) : fd_(-1), pid_(-1),
                                            use_console_(use_console) {
+  char* shell_path;
+  shell_path = getenv ("NINJA_SHELL");
+  if (shell_path!=NULL)
+    shell=std::string(shell_path);
+  else
+    shell=std::string("/bin/sh");
 }
 
 Subprocess::~Subprocess() {
@@ -117,8 +123,8 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
   if (err != 0)
     Fatal("posix_spawnattr_setflags: %s", strerror(err));
 
-  const char* spawned_args[] = { "/bin/sh", "-c", command.c_str(), NULL };
-  err = posix_spawn(&pid_, "/bin/sh", &action, &attr,
+  const char* spawned_args[] = { shell.c_str(), "-c", command.c_str(), NULL };
+  err = posix_spawn(&pid_, shell.c_str(), &action, &attr,
         const_cast<char**>(spawned_args), environ);
   if (err != 0)
     Fatal("posix_spawn: %s", strerror(err));

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -70,6 +70,7 @@ struct Subprocess {
 #else
   int fd_;
   pid_t pid_;
+  std::string shell;
 #endif
   bool use_console_;
 


### PR DESCRIPTION
For our application we want to capture the resources consumed of the commands being executed by ninja. We came up with the idea of substituting the hard-coded /bin/sh with our script for capturing the resources needed by the spawned process. As this is running in a docker, perf is unfortunately not easily available to us. 

But aside from our use-case I could for-see some other uses-cases like transforming the output of the command into an azure devops compatible  format.

The environment variable for setting a different shell would be NINJA_SHELL.