### PR TITLE
Really respect the env variable `CLICOLOR_FORCE`

### DIFF
--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -46,17 +46,16 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
   }
 #endif
   supports_color_ = smart_terminal_;
-  if (!supports_color_) {
-    const char* clicolor_force = getenv("CLICOLOR_FORCE");
-    supports_color_ = clicolor_force && string(clicolor_force) != "0";
-  }
+  const char* clicolor_force = getenv("CLICOLOR_FORCE");
+  bool force_color = clicolor_force && string(clicolor_force) != "0";
+  supports_color_ ||= force_color;
 #ifdef _WIN32
   // Try enabling ANSI escape sequence support on Windows 10 terminals.
   if (supports_color_) {
     DWORD mode;
     if (GetConsoleMode(console_, &mode)) {
       if (!SetConsoleMode(console_, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)) {
-        supports_color_ = false;
+        supports_color_ = force_color;
       }
     }
   }

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -46,9 +46,6 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
   }
 #endif
   supports_color_ = smart_terminal_;
-  const char* clicolor_force = getenv("CLICOLOR_FORCE");
-  bool force_color = clicolor_force && string(clicolor_force) != "0";
-  supports_color_ ||= force_color;
 #ifdef _WIN32
   // Try enabling ANSI escape sequence support on Windows 10 terminals.
   if (supports_color_) {
@@ -58,6 +55,10 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
         supports_color_ = force_color;
       }
     }
+  }
+  if (!supports_color_) {
+    const char* clicolor_force = getenv("CLICOLOR_FORCE");
+    supports_color_ = clicolor_force && string(clicolor_force) != "0";
   }
 #endif
 }


### PR DESCRIPTION
Prior to this commit, ninja disables color output even if CLICOLOR_FORCE is set, if it fails to set VT processing on Windows terminal. This does not respect the user's wish.

One use case of this is to force color on MSYS terminal.