### PR TITLE
Really respect the env variable `CLICOLOR_FORCE`.

### DIFF
--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -46,10 +46,6 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
   }
 #endif
   supports_color_ = smart_terminal_;
-  if (!supports_color_) {
-    const char* clicolor_force = getenv("CLICOLOR_FORCE");
-    supports_color_ = clicolor_force && string(clicolor_force) != "0";
-  }
 #ifdef _WIN32
   // Try enabling ANSI escape sequence support on Windows 10 terminals.
   if (supports_color_) {
@@ -61,6 +57,10 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
     }
   }
 #endif
+  if (!supports_color_) {
+    const char* clicolor_force = getenv("CLICOLOR_FORCE");
+    supports_color_ = clicolor_force && string(clicolor_force) != "0";
+  }
 }
 
 void LinePrinter::Print(string to_print, LineType type) {

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -59,7 +59,7 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
 #endif
   if (!supports_color_) {
     const char* clicolor_force = getenv("CLICOLOR_FORCE");
-    supports_color_ = clicolor_force && string(clicolor_force) != "0";
+    supports_color_ = clicolor_force && std::string(clicolor_force) != "0";
   }
 }
 


### PR DESCRIPTION
Prior to this commit, ninja disables color output even if CLICOLOR_FORCE is set, if it fails to set VT processing on Windows terminal. This does not respect the user's wish.

One use case of this is to force color on MSYS terminal.