### PR TITLE
Add an option to avoid building binary when used as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.15)
 include(CheckSymbolExists)
 include(CheckIPOSupported)
 
+option(NINJA_BUILD_BINARY "Build ninja binary" ON)
+
 project(ninja)
 
 # --- optional link-time optimization
@@ -148,11 +150,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "OS400" OR CMAKE_SYSTEM_NAME STREQUAL "AIX")
 endif()
 
 # Main executable is library plus main() function.
-add_executable(ninja src/ninja.cc)
-target_link_libraries(ninja PRIVATE libninja libninja-re2c)
+if(NINJA_BUILD_BINARY)
+	add_executable(ninja src/ninja.cc)
+	target_link_libraries(ninja PRIVATE libninja libninja-re2c)
 
-if(WIN32)
-  target_sources(ninja PRIVATE windows/ninja.manifest)
+	if(WIN32)
+		target_sources(ninja PRIVATE windows/ninja.manifest)
+	endif()
 endif()
 
 # Adds browse mode into the ninja binary if it's supported by the host platform.
@@ -171,8 +175,10 @@ if(platform_supports_ninja_browse)
 		VERBATIM
 	)
 
-	target_compile_definitions(ninja PRIVATE NINJA_HAVE_BROWSE)
-	target_sources(ninja PRIVATE src/browse.cc)
+	if(NINJA_BUILD_BINARY)
+		target_compile_definitions(ninja PRIVATE NINJA_HAVE_BROWSE)
+		target_sources(ninja PRIVATE src/browse.cc)
+	endif()
 	set_source_files_properties(src/browse.cc
 		PROPERTIES
 			OBJECT_DEPENDS "${PROJECT_BINARY_DIR}/build/browse_py.h"
@@ -232,4 +238,6 @@ if(BUILD_TESTING)
   add_test(NAME NinjaTest COMMAND ninja_test)
 endif()
 
-install(TARGETS ninja)
+if(NINJA_BUILD_BINARY)
+	install(TARGETS ninja)
+endif()


### PR DESCRIPTION
When Ninja is used as libraries (`libninja` & `libninja-re2c`), we actually need to build them but not a ninja binary. Therefore, I added a CMake variable: `NINJA_NO_BINARY` to prevent building it if users of Ninja's libraries explicitly set it as `ON` (default is `OFF` for backward compatibility).