### PR TITLE
Support building `libninja-re2c.a` on `configure.py`

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -489,16 +489,27 @@ else:
            "changes to src/*.in.cc will not affect your build.")
 n.newline()
 
-n.comment('Core source files all build into ninja library.')
 cxxvariables = []
 if platform.is_msvc():
     cxxvariables = [('pdb', 'ninja.pdb')]
+
+n.comment('Generate a library for `ninja-re2c`.')
+re2c_objs = []
+for name in ['depfile_parser', 'lexer']:
+    re2c_objs += cxx(name, variables=cxxvariables)
+if platform.is_msvc():
+    n.build(built('ninja-re2c.lib'), 'ar', re2c_objs)
+else:
+    n.build(built('libninja-re2c.a'), 'ar', re2c_objs)
+n.newline()
+
+n.comment('Core source files all build into ninja library.')
+objs.extend(re2c_objs)
 for name in ['build',
              'build_log',
              'clean',
              'clparser',
              'debug_flags',
-             'depfile_parser',
              'deps_log',
              'disk_interface',
              'dyndep',
@@ -508,7 +519,6 @@ for name in ['build',
              'graph',
              'graphviz',
              'json',
-             'lexer',
              'line_printer',
              'manifest_parser',
              'metrics',


### PR DESCRIPTION
`configure.py` currently builds only `libninja.a`, but we also want the `libninja-re2c.a` like `CMakeLists.txt` does:

https://github.com/ninja-build/ninja/blob/55f54511d35716c43637dee2bcb5fbc7839f967b/CMakeLists.txt#L47-L50