### PR TITLE
Flush output after each line

### DIFF
--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -118,6 +118,7 @@ void LinePrinter::Print(string to_print, LineType type) {
     have_blank_line_ = false;
   } else {
     printf("%s\n", to_print.c_str());
+    fflush(stdout);
   }
 }
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -672,6 +672,7 @@ int NinjaMain::ToolRules(const Options* options, int argc, char* argv[]) {
       }
     }
     printf("\n");
+    fflush(stdout);
   }
   return 0;
 }


### PR DESCRIPTION
The output is not flushed automatically after `\n`, at least on Windows 10.