### PR TITLE
Delete memories of `LogEntry` obtained by `new`

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -180,6 +180,10 @@ void BuildLog::Close() {
   if (log_file_)
     fclose(log_file_);
   log_file_ = NULL;
+
+  for (Entries::iterator e = entries_.begin(); e != entries_.end(); ++e) {
+    delete e->second; // LogEntry*
+  }
 }
 
 bool BuildLog::OpenForWriteIfNeeded() {


### PR DESCRIPTION
I am unsure about memory management, but I believe all memories of `LogEntry` that are allocated with `new` must be deleted since the current code would possibly let memory leak.

The memories are allocated in:
https://github.com/ninja-build/ninja/blob/1d4034f0ac2b5cfb809b5ab983d47c3cb2c78415/src/build_log.cc#L156