### PR TITLE
clang-tidy: use C++ headers

### DIFF
--- a/src/browse.cc
+++ b/src/browse.cc
@@ -14,10 +14,11 @@
 
 #include "browse.h"
 
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
 #include <vector>
 
 #include "build/browse_py.h"

--- a/src/build.cc
+++ b/src/build.cc
@@ -14,10 +14,10 @@
 
 #include "build.h"
 
-#include <assert.h>
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
 #include <functional>
 
 #if defined(__SVR4) && defined(__sun)

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -21,16 +21,18 @@
 #endif
 
 #include "build_log.h"
-#include "disk_interface.h"
 
 #include <cassert>
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+
+#include "disk_interface.h"
 
 #ifndef _WIN32
-#include <inttypes.h>
 #include <unistd.h>
+
+#include <cinttypes>
 #endif
 
 #include "build.h"

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -15,8 +15,8 @@
 #ifndef NINJA_BUILD_LOG_H_
 #define NINJA_BUILD_LOG_H_
 
+#include <cstdio>
 #include <string>
-#include <stdio.h>
 
 #include "hash_map.h"
 #include "load_status.h"

--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include "build_log.h"
 #include "graph.h"
 #include "manifest_parser.h"
+#include "metrics.h"
 #include "state.h"
 #include "util.h"
-#include "metrics.h"
 
 #ifndef _WIN32
 #include <unistd.h>

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -14,7 +14,7 @@
 
 #include "build.h"
 
-#include <assert.h>
+#include <cassert>
 
 #include "build_log.h"
 #include "deps_log.h"

--- a/src/canon_perftest.cc
+++ b/src/canon_perftest.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
-#include "util.h"
 #include "metrics.h"
+#include "util.h"
 
 using namespace std;
 

--- a/src/clean.cc
+++ b/src/clean.cc
@@ -14,8 +14,8 @@
 
 #include "clean.h"
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 #include "disk_interface.h"
 #include "graph.h"

--- a/src/clparser.cc
+++ b/src/clparser.cc
@@ -15,8 +15,8 @@
 #include "clparser.h"
 
 #include <algorithm>
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 #include "metrics.h"
 #include "string_piece_util.h"

--- a/src/clparser_perftest.cc
+++ b/src/clparser_perftest.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include "clparser.h"
 #include "metrics.h"

--- a/src/debug_flags.h
+++ b/src/debug_flags.h
@@ -15,7 +15,7 @@
 #ifndef NINJA_EXPLAIN_H_
 #define NINJA_EXPLAIN_H_
 
-#include <stdio.h>
+#include <cstdio>
 
 #define EXPLAIN(fmt, ...) {                                             \
   if (g_explaining)                                                     \

--- a/src/depfile_parser_perftest.cc
+++ b/src/depfile_parser_perftest.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 #include "depfile_parser.h"
-#include "util.h"
 #include "metrics.h"
+#include "util.h"
 
 using namespace std;
 

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -14,10 +14,10 @@
 
 #include "deps_log.h"
 
-#include <assert.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 #ifndef _WIN32
 #include <unistd.h>
 #elif defined(_MSC_VER) && (_MSC_VER < 1900)

--- a/src/deps_log.h
+++ b/src/deps_log.h
@@ -15,10 +15,9 @@
 #ifndef NINJA_DEPS_LOG_H_
 #define NINJA_DEPS_LOG_H_
 
+#include <cstdio>
 #include <string>
 #include <vector>
-
-#include <stdio.h>
 
 #include "load_status.h"
 #include "timestamp.h"

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -14,13 +14,13 @@
 
 #include "disk_interface.h"
 
-#include <algorithm>
-
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 
 #ifdef _WIN32
 #include <sstream>

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 #ifdef _WIN32
 #include <io.h>
 #include <windows.h>

--- a/src/dyndep.cc
+++ b/src/dyndep.cc
@@ -14,8 +14,8 @@
 
 #include "dyndep.h"
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 #include "debug_flags.h"
 #include "disk_interface.h"

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <assert.h>
-
 #include "eval_env.h"
+
+#include <cassert>
 
 using namespace std;
 

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -15,9 +15,9 @@
 #include "graph.h"
 
 #include <algorithm>
+#include <cassert>
+#include <cstdio>
 #include <deque>
-#include <assert.h>
-#include <stdio.h>
 
 #include "build_log.h"
 #include "debug_flags.h"

--- a/src/graphviz.cc
+++ b/src/graphviz.cc
@@ -14,8 +14,8 @@
 
 #include "graphviz.h"
 
-#include <stdio.h>
 #include <algorithm>
+#include <cstdio>
 
 #include "dyndep.h"
 #include "graph.h"

--- a/src/hash_collision_bench.cc
+++ b/src/hash_collision_bench.cc
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "build_log.h"
-
 #include <algorithm>
+#include <cstdlib>
+#include <ctime>
 
-#include <stdlib.h>
-#include <time.h>
+#include "build_log.h"
 
 using namespace std;
 

--- a/src/hash_map.h
+++ b/src/hash_map.h
@@ -16,7 +16,8 @@
 #define NINJA_MAP_H_
 
 #include <algorithm>
-#include <string.h>
+#include <cstring>
+
 #include "string_piece.h"
 #include "util.h"
 

--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -15,7 +15,7 @@
 
 #include "lexer.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "eval_env.h"
 #include "util.h"

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -14,8 +14,8 @@
 
 #include "line_printer.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #ifdef _WIN32
 #include <windows.h>
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING

--- a/src/line_printer.h
+++ b/src/line_printer.h
@@ -15,7 +15,7 @@
 #ifndef NINJA_LINE_PRINTER_H_
 #define NINJA_LINE_PRINTER_H_
 
-#include <stddef.h>
+#include <cstddef>
 #include <string>
 
 /// Prints lines of text, possibly overprinting previously printed lines

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -14,8 +14,8 @@
 
 #include "manifest_parser.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <vector>
 
 #include "graph.h"

--- a/src/manifest_parser_perftest.cc
+++ b/src/manifest_parser_perftest.cc
@@ -15,12 +15,11 @@
 // Tests manifest parser performance.  Expects to be run in ninja's root
 // directory.
 
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <numeric>
-
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #ifdef _WIN32
 #include "getopt.h"

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -14,9 +14,9 @@
 
 #include "metrics.h"
 
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 
 #ifndef _WIN32
 #include <sys/time.h>

--- a/src/missing_deps.cc
+++ b/src/missing_deps.cc
@@ -14,8 +14,7 @@
 
 #include "missing_deps.h"
 
-#include <string.h>
-
+#include <cstring>
 #include <iostream>
 
 #include "depfile_parser.h"

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <errno.h>
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include <algorithm>
+#include <cerrno>
+#include <climits>
+#include <cstdio>
 #include <cstdlib>
+#include <cstring>
 
 #ifdef _WIN32
 #include "getopt.h"

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
 
 #ifdef _WIN32
 #include "getopt.h"

--- a/src/state.cc
+++ b/src/state.cc
@@ -14,8 +14,8 @@
 
 #include "state.h"
 
-#include <assert.h>
-#include <stdio.h>
+#include <cassert>
+#include <cstdio>
 
 #include "edit_distance.h"
 #include "graph.h"

--- a/src/status.cc
+++ b/src/status.cc
@@ -14,8 +14,8 @@
 
 #include "status.h"
 
-#include <stdarg.h>
-#include <stdlib.h>
+#include <cstdarg>
+#include <cstdlib>
 
 #ifdef _WIN32
 #include <fcntl.h>

--- a/src/string_piece.h
+++ b/src/string_piece.h
@@ -15,9 +15,8 @@
 #ifndef NINJA_STRINGPIECE_H_
 #define NINJA_STRINGPIECE_H_
 
+#include <cstring>
 #include <string>
-
-#include <string.h>
 
 /// StringPiece represents a slice of a string whose memory is managed
 /// externally.  It is useful for reducing the number of std::strings

--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "subprocess.h"
-
-#include <sys/select.h>
-#include <assert.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/wait.h>
 #include <spawn.h>
+#include <sys/select.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
+#include "subprocess.h"
 
 #if defined(USE_PPOLL)
 #include <poll.h>

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -22,7 +22,7 @@
 #ifdef _WIN32
 #include <windows.h>
 #else
-#include <signal.h>
+#include <csignal>
 #endif
 
 // ppoll() exists on FreeBSD, but only on newer versions.

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -18,10 +18,11 @@
 
 #ifndef _WIN32
 // SetWithLots need setrlimit.
-#include <stdio.h>
-#include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/time.h>
 #include <unistd.h>
+
+#include <cstdio>
 #endif
 
 using namespace std;

--- a/src/test.cc
+++ b/src/test.cc
@@ -16,12 +16,11 @@
 #include <direct.h>  // Has to be before util.h is included.
 #endif
 
-#include "test.h"
-
 #include <algorithm>
+#include <cerrno>
+#include <cstdlib>
 
-#include <errno.h>
-#include <stdlib.h>
+#include "test.h"
 #ifdef _WIN32
 #include <windows.h>
 #include <io.h>

--- a/src/timestamp.h
+++ b/src/timestamp.h
@@ -21,7 +21,7 @@
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
-#include <inttypes.h>
+#include <cinttypes>
 #endif
 
 // When considering file modification times we only care to compare

--- a/src/util.cc
+++ b/src/util.cc
@@ -23,15 +23,16 @@
 #include <share.h>
 #endif
 
-#include <assert.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#include <cassert>
+#include <cerrno>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #ifndef _WIN32
 #include <unistd.h>

--- a/src/util.h
+++ b/src/util.h
@@ -18,11 +18,10 @@
 #ifdef _WIN32
 #include "win32port.h"
 #else
-#include <stdint.h>
+#include <cstdint>
 #endif
 
-#include <stdarg.h>
-
+#include <cstdarg>
 #include <string>
 #include <vector>
 

--- a/src/version.cc
+++ b/src/version.cc
@@ -14,7 +14,7 @@
 
 #include "version.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "util.h"
 


### PR DESCRIPTION
Found with modernize-deprecated-headers

Signed-off-by: Rosen Penev <rosenp@gmail.com>