### PR TITLE
Remove the contributing guideline for adding Google Inc. as copyright holder to all contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,6 @@ a few additions:
   please try to avoid relying on it and instead whenever possible use `std::`.
   However, please do not change existing code simply to add `std::` unless your
   contribution already needs to change that line of code anyway.
-* All source files should have the Google Inc. license header.
 * Use `///` for [Doxygen](http://www.doxygen.nl/) (use `\a` to refer to
   arguments).
 * It's not necessary to document each argument, especially when they're


### PR DESCRIPTION
Per discussion here https://github.com/ninja-build/ninja/pull/1812#discussion_r456275065: Google does not request this, and claims to not have any ownership of the Ninja project.

This request in CONTRIBUTING.md is a legal liability, as well as unethical, to ask people to claim that Google holds the copyright for code that Google does not own, and did not contribute to the project.

This is also not very compatible with the Github user agreement, which specifies that code contributions to a project are, by default, licensed under the project's configured license, but explicitly says that the copyright of the code remains the original authors copyright.

https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#3-ownership-of-content-right-to-post-and-license-grants
https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license

Finally, this requirement *IS* turning away potential contributors, who feel that it is an unreasonable contributing guideline, or who are otherwise forbidden/unable, regardless of willingness, from assigning copyright to Google Inc. without a real contributor license agreement that can be reviewed and signed.

Both the Google and Microsoft legal departments have commented on this (see linked issue above) saying that this requirement is either not asked for (by Google), or not acceptable (by Microsoft).

Note also that all maintainers of this project have been pinged at least once on the issue, and have refused to comment on it for several years now: https://github.com/ninja-build/ninja/pull/1616#discussion_r310374298