### PR TITLE
also check if stdin is terminal

### DIFF
--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -35,7 +35,7 @@ using namespace std;
 LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
   const char* term = getenv("TERM");
 #ifndef _WIN32
-  smart_terminal_ = isatty(1) && term && string(term) != "dumb";
+  smart_terminal_ = isatty(0) && isatty(1) && term && string(term) != "dumb";
 #else
   if (term && string(term) == "dumb") {
     smart_terminal_ = false;


### PR DESCRIPTION
current version of ninja fails to detect the non-terminal environment in the nix-build sandbox

(and nix fails to print ninja's line-cleared output to the terminal)

downstream issue https://github.com/NixOS/nixpkgs/pull/179027

we want to avoid workarounds like

```sh
TERM=dumb ninja
ninja | cat
```
