### PR TITLE
Windows: assume smart terminal if $TERM is defined and not "dumb"

### DIFF
--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -37,8 +37,8 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
 #ifndef _WIN32
   smart_terminal_ = isatty(1) && term && string(term) != "dumb";
 #else
-  if (term && string(term) == "dumb") {
-    smart_terminal_ = false;
+  if (term) {
+    smart_terminal_ = string(term) != "dumb";
   } else {
     console_ = GetStdHandle(STD_OUTPUT_HANDLE);
     CONSOLE_SCREEN_BUFFER_INFO csbi;
@@ -52,7 +52,7 @@ LinePrinter::LinePrinter() : have_blank_line_(true), console_locked_(false) {
   }
 #ifdef _WIN32
   // Try enabling ANSI escape sequence support on Windows 10 terminals.
-  if (supports_color_) {
+  if (supports_color_ && (!term || string(term) == "dumb")) {
     DWORD mode;
     if (GetConsoleMode(console_, &mode)) {
       if (!SetConsoleMode(console_, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING)) {


### PR DESCRIPTION
On Windows, ninja only uses smart terminal features when outputting to
a Windows console. However, there are applications that act as
terminal emulators and support those features. Emacs and MSYS2's
mintty emulator are some examples.

With this change ninja uses smart terminal features whenever $TERM is
non-empty and its value is different from "dumb".

This fixes #2171