### PR TITLE
Doc fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ a few additions:
   However, please do not change existing code simply to add `std::` unless your
   contribution already needs to change that line of code anyway.
 * All source files should have the Google Inc. license header.
-* Use `///` for [Doxygen](http://www.doxygen.nl/) (use `\a` to refer to
+* Use `///` for [Doxygen](https://www.doxygen.nl/) (use `\a` to refer to
   arguments).
 * It's not necessary to document each argument, especially when they're
   relatively self-evident (e.g. in

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -533,7 +533,7 @@ To create a rule that never rebuilds, use a build rule without any input:
 rule touch
   command = touch $out
 build file_that_always_exists.dummy: touch
-build dummy_target_to_follow_a_pattern: phony file_that_always_exists.dummy
+build dummy_target: phony file_that_always_exists.dummy
 ----------------
 
 
@@ -736,8 +736,8 @@ rule cc
 build foo.exe: link input.obj
 
 # A build statement can be exempted from its rule's pool by setting an
-# empty pool. This effectively puts the build statement back into the default
-# pool, which has infinite depth.
+# empty pool. This effectively puts the build statement back into the
+# default pool, which has infinite depth.
 build other.exe: link input.obj
   pool =
 

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -228,7 +228,7 @@ and a web browser will be opened. This can be changed as follows:
 ----
 ninja -t browse --port=8000 --no-browser mytarget
 ----
-+
+
 `graph`:: output a file in the syntax used by `graphviz`, a automatic
 graph layout tool.  Use it like:
 +
@@ -324,20 +324,19 @@ Where `ENVFILE` is a binary file that contains an environment block suitable
 for CreateProcessA() on Windows (i.e. a series of zero-terminated strings that
 look like NAME=VALUE, followed by an extra zero terminator). Note that this uses
 the local codepage encoding.
-
++
 This tool also supports a deprecated way of parsing the compiler's output when
 the `/showIncludes` flag is used, and generating a GCC-compatible depfile from it.
 +
----
+----
 ninja -t msvc -o DEPFILE [-p STRING] -- cl.exe /showIncludes <arguments>
----
+----
 +
-
 When using this option, `-p STRING` can be used to pass the localized line prefix
 that `cl.exe` uses to output dependency information. For English-speaking regions
 this is `"Note: including file: "` without the double quotes, but will be different
 for other regions.
-
++
 Note that Ninja supports this natively now, with the use of `deps = msvc` and
 `msvc_deps_prefix` in Ninja files. Native support also avoids launching an extra
 tool process each time the compiler must be called, which can speed up builds

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -11,7 +11,7 @@ executables) and orchestrates building them, _quickly_.
 
 Ninja joins a sea of other build systems.  Its distinguishing goal is
 to be fast.  It is born from
-http://neugierig.org/software/chromium/notes/2011/02/ninja.html[my
+https://neugierig.org/software/chromium/notes/2011/02/ninja.html[my
 work on the Chromium browser project], which has over 30,000 source
 files and whose other build systems (including one built from custom
 non-recursive Makefiles) would take ten seconds to start building
@@ -147,7 +147,7 @@ edit-compile cycle time of your project already then Ninja won't help.
 
 There are many other build systems that are more user-friendly or
 featureful than Ninja itself.  For some recommendations: the Ninja
-author found http://gittup.org/tup/[the tup build system] influential
+author found https://gittup.org/tup/[the tup build system] influential
 in Ninja's design, and thinks https://github.com/apenwarr/redo[redo]'s
 design is quite clever.
 
@@ -281,7 +281,7 @@ build file. _Available since Ninja 1.10._
 `compdb`:: given a list of rules, each of which is expected to be a
 C family language compiler rule whose first input is the name of the
 source file, prints on standard output a compilation database in the
-http://clang.llvm.org/docs/JSONCompilationDatabase.html[JSON format] expected
+https://clang.llvm.org/docs/JSONCompilationDatabase.html[JSON format] expected
 by the Clang tooling interface.
 _Available since Ninja 1.2._
 
@@ -675,7 +675,7 @@ Ninja supports this processing in two forms.
 
 2. `deps = msvc` specifies that the tool outputs header dependencies
    in the form produced by Visual Studio's compiler's
-   http://msdn.microsoft.com/en-us/library/hdkef6tk(v=vs.90).aspx[`/showIncludes`
+   https://msdn.microsoft.com/en-us/library/hdkef6tk(v=vs.90).aspx[`/showIncludes`
    flag].  Briefly, this means the tool outputs specially-formatted lines
    to its stdout.  Ninja then filters these lines from the displayed
    output.  No `depfile` attribute is necessary, but the localized string
@@ -1022,8 +1022,8 @@ source file of a compile command.
 +
 This is for expressing dependencies that don't show up on the
 command line of the command; for example, for a rule that runs a
-script that reads a hardcoded file, the hardcoded file should 
-be an implicit dependency, as changes to the file should cause 
+script that reads a hardcoded file, the hardcoded file should
+be an implicit dependency, as changes to the file should cause
 the output to rebuild, even though it doesn't show up in the arguments.
 +
 Note that dependencies as loaded through depfiles have slightly different

--- a/doc/style.css
+++ b/doc/style.css
@@ -14,7 +14,7 @@ pre {
     padding: 1ex;
     background: #eee;
     border: solid 1px #ddd;
-    min-width: 0;
+    min-width: min-content;
     font-size: 90%;
 }
 code {


### PR DESCRIPTION
This PR changes all links in the docs to https, fixes the [list continuation](https://asciidoc-py.github.io/userguide.html#X15) of the [Extra Tools: msvc](https://ninja-build.org/manual.html#_extra_tools) section in the manual, and fixes overflowing code blocks.

Currently overflowing code blocks have been rewritten to fit and to prevent future overflows the `min-width` of `<pre>`s is set to `min-content`, which has been [generally supported since about 2020](https://caniuse.com/mdn-css_properties_width_min-content).