### PR TITLE
Remove requirement for Google copyright from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,6 @@ a few additions:
   please try to avoid relying on it and instead whenever possible use `std::`.
   However, please do not change existing code simply to add `std::` unless your
   contribution already needs to change that line of code anyway.
-* All source files should have the Google Inc. license header.
 * Use `///` for [Doxygen](http://www.doxygen.nl/) (use `\a` to refer to
   arguments).
 * It's not necessary to document each argument, especially when they're


### PR DESCRIPTION
We should keep the Google copyright on files authored by people at Google,
but for new files added by people not at Google, this really isn't necessary.

(Someone from open-source compliance at Google reached out to me and
suggested removing this line.)