### PR TITLE
Dyndep patches

### DIFF
--- a/src/clean.cc
+++ b/src/clean.cc
@@ -127,6 +127,7 @@ int Cleaner::CleanAll(bool generator) {
 int Cleaner::CleanDead(const BuildLog::Entries& entries) {
   Reset();
   PrintHeader();
+  LoadDyndeps();
   for (BuildLog::Entries::const_iterator i = entries.begin(); i != entries.end(); ++i) {
     Node* n = state_->LookupNode(i->first);
     // Detecting stale outputs works as follows:

--- a/src/clean.cc
+++ b/src/clean.cc
@@ -291,9 +291,10 @@ void Cleaner::Reset() {
 
 void Cleaner::LoadDyndeps() {
   // Load dyndep files that exist, before they are cleaned.
+  Node *dyndep;
   for (vector<Edge*>::iterator e = state_->edges_.begin();
        e != state_->edges_.end(); ++e) {
-    if (Node* dyndep = (*e)->dyndep_) {
+    if ((dyndep = (*e)->dyndep_) && dyndep->dyndep_pending()) {
       // Capture and ignore errors loading the dyndep file.
       // We clean as much of the graph as we know.
       std::string err;


### PR DESCRIPTION
This request contains two patches. The first adjusts "ninja -t cleandead" to account for dynamic dependencies. By neglecting dynamic dependencies, Ninja spuriously flags artifacts as "dead" thereby increasing the cost of rebuilds down the road. The second patch improves the "ninja clean" performance for projects with dynamic dependencies. With this patch, on one of my projects I have observed runtimes for "ninja clean" drop from 5 minutes to 25 seconds.