### PR TITLE
have implicit "#pragma once" when including ninja files

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -26,9 +26,9 @@
 using namespace std;
 
 ManifestParser::ManifestParser(State* state, FileReader* file_reader,
-                               ManifestParserOptions options)
+                               ManifestParserOptions options, const std::vector<std::string>& included_files)
     : Parser(state, file_reader),
-      options_(options), quiet_(false) {
+      options_(options), quiet_(false), included_files_(included_files) {
   env_ = &state->bindings_;
 }
 
@@ -427,7 +427,12 @@ bool ManifestParser::ParseFileInclude(bool new_scope, string* err) {
     return false;
   string path = eval.Evaluate(env_);
 
-  ManifestParser subparser(state_, file_reader_, options_);
+  if (std::find(included_files_.cbegin(), included_files_.cend(), path) != included_files_.cend())
+    return true;
+
+  included_files_.push_back(path);
+
+  ManifestParser subparser(state_, file_reader_, options_, included_files_);
   if (new_scope) {
     subparser.env_ = new BindingEnv(env_);
   } else {

--- a/src/manifest_parser.h
+++ b/src/manifest_parser.h
@@ -17,6 +17,8 @@
 
 #include "parser.h"
 
+#include <vector>
+
 struct BindingEnv;
 struct EvalString;
 
@@ -41,7 +43,8 @@ struct ManifestParserOptions {
 /// Parses .ninja files.
 struct ManifestParser : public Parser {
   ManifestParser(State* state, FileReader* file_reader,
-                 ManifestParserOptions options = ManifestParserOptions());
+                 ManifestParserOptions options = ManifestParserOptions(),
+                 const std::vector<std::string>& included_file = std::vector<std::string>());
 
   /// Parse a text string of input.  Used by tests.
   bool ParseTest(const std::string& input, std::string* err) {
@@ -67,6 +70,7 @@ private:
   BindingEnv* env_;
   ManifestParserOptions options_;
   bool quiet_;
+  std::vector<std::string> included_files_;
 };
 
 #endif  // NINJA_MANIFEST_PARSER_H_


### PR DESCRIPTION
I added sharpmake support for ninja, but the fact that ninja includes files no matter what was causing some annoying bugs
adding this small change, which I don't think would cause any issues with existing code will fix that and allows Sharpmake to generate ninja files now