### PR TITLE
Add overridable parameter for name of Python binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,11 @@ function(check_platform_supports_browse_mode RESULT)
 
 endfunction()
 
-if(NOT NINJA_PYTHON)
-	set(NINJA_PYTHON python)
+option(USE_PYTHON3 "Use python3 command to run browse.py" OFF)
+if(USE_PYTHON3)
+    set(NINJA_PYTHON python3)
+else()
+    set(NINJA_PYTHON python)
 endif()
 
 check_platform_supports_browse_mode(platform_supports_ninja_browse)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,12 +90,7 @@ function(check_platform_supports_browse_mode RESULT)
 
 endfunction()
 
-option(USE_PYTHON3 "Use python3 command to run browse.py" OFF)
-if(USE_PYTHON3)
-    set(NINJA_PYTHON python3)
-else()
-    set(NINJA_PYTHON python)
-endif()
+set(NINJA_PYTHON "python" CACHE STRING "Python interpreter to use for the browse tool")
 
 check_platform_supports_browse_mode(platform_supports_ninja_browse)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,10 @@ function(check_platform_supports_browse_mode RESULT)
 
 endfunction()
 
+if(NOT NINJA_PYTHON)
+	set(NINJA_PYTHON python)
+endif()
+
 check_platform_supports_browse_mode(platform_supports_ninja_browse)
 
 # Core source files all build into ninja library.
@@ -195,7 +199,7 @@ if(platform_supports_ninja_browse)
 		PROPERTIES
 			OBJECT_DEPENDS "${PROJECT_BINARY_DIR}/build/browse_py.h"
 			INCLUDE_DIRECTORIES "${PROJECT_BINARY_DIR}"
-			COMPILE_DEFINITIONS NINJA_PYTHON="python"
+			COMPILE_DEFINITIONS NINJA_PYTHON="${NINJA_PYTHON}"
 	)
 endif()
 


### PR DESCRIPTION
On macOS, Python 2 is no longer available. As such, the `python` command does not exist in the operating system. On macOS with the developer tools installed, Python 3 is available under the command `python3`. However, ninja currently hard-codes the name `python`. This breaks my build on macOS. From what I can tell, `browse.py` appears to be written to run correctly on Python 3. Therefore, I need to introduce this parameter so I can override it with the command `python3` on the CMake command line.