### PR TITLE
Fix apostrophe in printed output

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1531,7 +1531,7 @@ NORETURN void real_main(int argc, char** argv) {
     // Don't print this if a tool is being used, so that tool output
     // can be piped into a file without this string showing up.
     if (!options.tool && config.verbosity != BuildConfig::NO_STATUS_UPDATE)
-      status->Info("Entering directory `%s'", options.working_dir);
+      status->Info("Entering directory '%s'", options.working_dir);
     if (chdir(options.working_dir) < 0) {
       Fatal("chdir to '%s' - %s", options.working_dir, strerror(errno));
     }


### PR DESCRIPTION
I should be better to use ' instead of `, to match the closing one.