### PR TITLE
Build loaded files similarly to the main input file

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -1113,10 +1113,10 @@ scope, but it won't affect values of the variables in the parent.
 To include another `.ninja` file in the current scope, much like a C
 `#include` statement, use `include` instead of `subninja`.
 
-In either case, either the file must exist, or, it must be listed as an explicit
-(typically order-only) dependency of `build.ninja`.  This allows `ninja` to not
-only update the file before it is used, but also create it if it is missing,
-that is, bootstrapping the `ninja` build files in a clean working directory.
+If there is a build statement for the loaded file, then `ninja` will update it
+if needed (similarly to updating the main input file). Moreover, `ninja` will
+be able to create the loaded file if it is missing, allowing for bootstrapping
+the build files in a clean development directory by simply typing `ninja`.
 
 Variable declarations indented in a `build` block are scoped to the
 `build` block.  The full lookup order for a variable expanded in a

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -1113,6 +1113,11 @@ scope, but it won't affect values of the variables in the parent.
 To include another `.ninja` file in the current scope, much like a C
 `#include` statement, use `include` instead of `subninja`.
 
+In either case, either the file must exist, or, it must be listed as an explicit
+(typically order-only) dependency of `build.ninja`.  This allows `ninja` to not
+only update the file before it is used, but also create it if it is missing,
+that is, bootstrapping the `ninja` build files in a clean working directory.
+
 Variable declarations indented in a `build` block are scoped to the
 `build` block.  The full lookup order for a variable expanded in a
 `build` block (or the `rule` is uses) is:

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -27,7 +27,7 @@ using namespace std;
 
 ManifestParser::ManifestParser(State* state, FileReader* file_reader,
                                ManifestParserOptions options)
-    : Parser(state, file_reader, options.bootstrap),
+    : Parser(state, file_reader, options.allow_missing_loads),
       options_(options), quiet_(false) {
   env_ = &state->bindings_;
 }
@@ -437,8 +437,11 @@ bool ManifestParser::ParseFileInclude(bool new_scope, string* err) {
   if (!subparser.Load(path, err, &lexer_))
     return false;
 
-  if (subparser.missing_bootstrap_)
-    missing_bootstrap_ = true;
+  if (subparser.any_missing_loads_)
+    any_missing_loads_ = true;
+
+  std::move(subparser.loaded_files_.begin(), subparser.loaded_files_.end(),
+    std::back_inserter(loaded_files_));
 
   if (!ExpectToken(Lexer::NEWLINE, err))
     return false;

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -27,7 +27,7 @@ using namespace std;
 
 ManifestParser::ManifestParser(State* state, FileReader* file_reader,
                                ManifestParserOptions options)
-    : Parser(state, file_reader),
+    : Parser(state, file_reader, options.bootstrap),
       options_(options), quiet_(false) {
   env_ = &state->bindings_;
 }
@@ -436,6 +436,9 @@ bool ManifestParser::ParseFileInclude(bool new_scope, string* err) {
 
   if (!subparser.Load(path, err, &lexer_))
     return false;
+
+  if (subparser.missing_bootstrap_)
+    missing_bootstrap_ = true;
 
   if (!ExpectToken(Lexer::NEWLINE, err))
     return false;

--- a/src/manifest_parser.h
+++ b/src/manifest_parser.h
@@ -36,7 +36,7 @@ struct ManifestParserOptions {
         phony_cycle_action_(kPhonyCycleActionWarn) {}
   DupeEdgeAction dupe_edge_action_;
   PhonyCycleAction phony_cycle_action_;
-  bool bootstrap = false;
+  bool allow_missing_loads = false;
 };
 
 /// Parses .ninja files.

--- a/src/manifest_parser.h
+++ b/src/manifest_parser.h
@@ -36,6 +36,7 @@ struct ManifestParserOptions {
         phony_cycle_action_(kPhonyCycleActionWarn) {}
   DupeEdgeAction dupe_edge_action_;
   PhonyCycleAction phony_cycle_action_;
+  bool bootstrap = false;
 };
 
 /// Parses .ninja files.

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -898,6 +898,7 @@ TEST_F(ParserTest, MissingSubNinja) {
             "subninja foo.ninja\n"
             "                  ^ near here"
             , err);
+  EXPECT_FALSE(parser.MissingBootstrap());
 }
 
 TEST_F(ParserTest, DuplicateRuleInDifferentSubninjas) {
@@ -944,6 +945,17 @@ TEST_F(ParserTest, BrokenInclude) {
             "build\n"
             "     ^ near here"
             , err);
+}
+
+TEST_F(ParserTest, BootstrapInclude) {
+  ManifestParserOptions parser_opts;
+  parser_opts.bootstrap = true;
+  ManifestParser parser(&state, &fs_, parser_opts);
+  string err;
+  EXPECT_TRUE(parser.ParseTest("include bootstrap.ninja\n", &err));
+  EXPECT_TRUE(parser.MissingBootstrap());
+  EXPECT_FALSE(parser.MissingBootstrap());
+  EXPECT_EQ("", err);
 }
 
 TEST_F(ParserTest, Implicit) {

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -898,7 +898,8 @@ TEST_F(ParserTest, MissingSubNinja) {
             "subninja foo.ninja\n"
             "                  ^ near here"
             , err);
-  EXPECT_FALSE(parser.MissingBootstrap());
+  EXPECT_FALSE(parser.AnyMissingLoads());
+  EXPECT_EQ(parser.LoadedFiles().size(), 0);
 }
 
 TEST_F(ParserTest, DuplicateRuleInDifferentSubninjas) {
@@ -947,14 +948,15 @@ TEST_F(ParserTest, BrokenInclude) {
             , err);
 }
 
-TEST_F(ParserTest, BootstrapInclude) {
+TEST_F(ParserTest, AllowedMissingInclude) {
   ManifestParserOptions parser_opts;
-  parser_opts.bootstrap = true;
+  parser_opts.allow_missing_loads = true;
   ManifestParser parser(&state, &fs_, parser_opts);
   string err;
   EXPECT_TRUE(parser.ParseTest("include bootstrap.ninja\n", &err));
-  EXPECT_TRUE(parser.MissingBootstrap());
-  EXPECT_FALSE(parser.MissingBootstrap());
+  EXPECT_TRUE(parser.AnyMissingLoads());
+  EXPECT_EQ(parser.LoadedFiles().size(), 1);
+  EXPECT_EQ(parser.LoadedFiles()[0], "bootstrap.ninja");
   EXPECT_EQ("", err);
 }
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -25,12 +25,15 @@ bool Parser::Load(const string& filename, string* err, Lexer* parent) {
   string read_err;
   if (file_reader_->ReadFile(filename, &contents, &read_err) !=
       FileReader::Okay) {
+    if (bootstrap_) {
+        missing_bootstrap_ = true;
+        return true;
+    }
     *err = "loading '" + filename + "': " + read_err;
     if (parent)
       parent->Error(string(*err), err);
     return false;
   }
-
   return Parse(filename, contents, err);
 }
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -23,10 +23,13 @@ bool Parser::Load(const string& filename, string* err, Lexer* parent) {
   METRIC_RECORD(".ninja parse");
   string contents;
   string read_err;
+  if (allow_missing_loads_) {
+    loaded_files_.push_back(filename);
+  }
   if (file_reader_->ReadFile(filename, &contents, &read_err) !=
       FileReader::Okay) {
-    if (bootstrap_) {
-        missing_bootstrap_ = true;
+    if (allow_missing_loads_) {
+        any_missing_loads_ = true;
         return true;
     }
     *err = "loading '" + filename + "': " + read_err;

--- a/src/parser.h
+++ b/src/parser.h
@@ -16,6 +16,7 @@
 #define NINJA_PARSER_H_
 
 #include <string>
+#include <vector>
 
 #include "lexer.h"
 
@@ -24,17 +25,20 @@ struct State;
 
 /// Base class for parsers.
 struct Parser {
-  Parser(State* state, FileReader* file_reader, bool bootstrap = false)
-      : state_(state), file_reader_(file_reader), bootstrap_(bootstrap), missing_bootstrap_(false) {}
+  Parser(State* state, FileReader* file_reader, bool allow_missing_loads = false)
+      : state_(state), file_reader_(file_reader), allow_missing_loads_(allow_missing_loads) {}
 
   /// Load and parse a file.
   bool Load(const std::string& filename, std::string* err, Lexer* parent = NULL);
 
-  /// Test and clear whether any include or subninja files were missing during bootstrap.
-  bool MissingBootstrap() {
-    bool missed_bootstrap = missing_bootstrap_;
-    missing_bootstrap_ = false;
-    return missed_bootstrap;
+  /// Vector of all files that were loaded.
+  std::vector<std::string> &LoadedFiles() {
+    return loaded_files_;
+  }
+
+  /// Test whether any loaded files were missing.
+  bool AnyMissingLoads() {
+    return any_missing_loads_;
   }
 
 protected:
@@ -45,8 +49,9 @@ protected:
   State* state_;
   FileReader* file_reader_;
   Lexer lexer_;
-  bool bootstrap_;
-  bool missing_bootstrap_;
+  std::vector<std::string> loaded_files_;
+  bool allow_missing_loads_;
+  bool any_missing_loads_ = false;
 
 private:
   /// Parse a file, given its contents as a string.

--- a/src/parser.h
+++ b/src/parser.h
@@ -24,11 +24,18 @@ struct State;
 
 /// Base class for parsers.
 struct Parser {
-  Parser(State* state, FileReader* file_reader)
-      : state_(state), file_reader_(file_reader) {}
+  Parser(State* state, FileReader* file_reader, bool bootstrap = false)
+      : state_(state), file_reader_(file_reader), bootstrap_(bootstrap), missing_bootstrap_(false) {}
 
   /// Load and parse a file.
   bool Load(const std::string& filename, std::string* err, Lexer* parent = NULL);
+
+  /// Test and clear whether any include or subninja files were missing during bootstrap.
+  bool MissingBootstrap() {
+    bool missed_bootstrap = missing_bootstrap_;
+    missing_bootstrap_ = false;
+    return missed_bootstrap;
+  }
 
 protected:
   /// If the next token is not \a expected, produce an error string
@@ -38,6 +45,8 @@ protected:
   State* state_;
   FileReader* file_reader_;
   Lexer lexer_;
+  bool bootstrap_;
+  bool missing_bootstrap_;
 
 private:
   /// Parse a file, given its contents as a string.


### PR DESCRIPTION
This implements https://github.com/ninja-build/ninja/issues/370. This turned out to be easy to achieve (a pretty small change).

It is a natural extension of the current iterative way that `ninja` deals with the main input file. That is, it allows `ninja` to update any `include` or `subninja` file, similarly to how it updates the main input `build.ninja` file. Actually, it goes further - it can also create any loaded files if they doesn't exist yet (which obviously is not possible for the main input file).

For example, it allows placing a fixed small `build.ninja` file in the root of the working directory, check it in as part of the sources, and keep the sources directory read-only when building:

```
include build-dir/generated.ninja

# Normal build statement, e.g. w/ dependencies
build build-dir/generated.ninja: generate_ninja

rule generate_ninja
    command = create_build_dir_and_generate_ninja_in_it
```

Running `ninja` in a clean top-level directory will generate `build-dir/generated.ninja`, then `include` it and continue as usual. Currently one needs to run an arbitrary project-specific bootstrap command before running `ninja` for the first time.

Regardless of bootstrapping, It is also very convenient to be able to define dependencies for the loaded files, so that `ninja` will update them when needed. Specifically, if the generator program depends on some configuration file(s), or is directly modified, then running `ninja` will automatically detect this and update the files. Currently this is only true for the main input file, which makes it more difficult to split the generated build files to follow some modular project structure.