### PR TITLE
Remove auto_ptr

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -215,11 +215,7 @@ struct Builder {
   State* state_;
   const BuildConfig& config_;
   Plan plan_;
-#if __cplusplus < 201703L
-  std::auto_ptr<CommandRunner> command_runner_;
-#else
-  std::unique_ptr<CommandRunner> command_runner_;  // auto_ptr was removed in C++17.
-#endif
+  std::unique_ptr<CommandRunner> command_runner_;
   Status* status_;
 
  private:


### PR DESCRIPTION
C++11 is now a hard requirement.