### PR TITLE
Increment ninja_log version

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -344,14 +344,9 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
     entry->start_time = start_time;
     entry->end_time = end_time;
     entry->mtime = mtime;
-    if (log_version >= 5) {
-      char c = *end; *end = '\0';
-      entry->command_hash = (uint64_t)strtoull(start, NULL, 16);
-      *end = c;
-    } else {
-      entry->command_hash = LogEntry::HashCommand(StringPiece(start,
-                                                              end - start));
-    }
+    char c = *end; *end = '\0';
+    entry->command_hash = (uint64_t)strtoull(start, NULL, 16);
+    *end = c;
   }
   fclose(file);
 

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -279,11 +279,16 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
     if (!log_version) {
       sscanf(line_start, kFileSignature, &log_version);
 
-      if (log_version < kOldestSupportedVersion ||
-          log_version > kCurrentVersion) {
-        *err =
-            ("build log version invalid, perhaps due to being too old or "
-             "too new; starting over");
+      bool invalid_log_version = false;
+      if (log_version < kOldestSupportedVersion) {
+        invalid_log_version = true;
+        *err = "build log version is too old; starting over";
+
+      } else if (log_version > kCurrentVersion) {
+        invalid_log_version = true;
+        *err = "build log version is too new; starting over";
+      }
+      if (invalid_log_version) {
         fclose(file);
         unlink(path.c_str());
         // Don't report this as a failure.  An empty build log will cause

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -279,9 +279,11 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
     if (!log_version) {
       sscanf(line_start, kFileSignature, &log_version);
 
-      if (log_version < kOldestSupportedVersion) {
-        *err = ("build log version invalid, perhaps due to being too old; "
-                "starting over");
+      if (log_version < kOldestSupportedVersion ||
+          log_version > kCurrentVersion) {
+        *err =
+            ("build log version invalid, perhaps due to being too old or "
+             "too new; starting over");
         fclose(file);
         unlink(path.c_str());
         // Don't report this as a failure.  An empty build log will cause

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -53,8 +53,8 @@ using namespace std;
 namespace {
 
 const char kFileSignature[] = "# ninja log v%d\n";
-const int kOldestSupportedVersion = 4;
-const int kCurrentVersion = 5;
+const int kOldestSupportedVersion = 6;
+const int kCurrentVersion = 6;
 
 // 64bit MurmurHash2, by Austin Appleby
 #if defined(_MSC_VER)


### PR DESCRIPTION
The timestamp format changed in https://github.com/ninja-build/ninja/pull/1219 without incrementing the log version number.

This mismatch caused a bug in Chromium that Ninja mis-recognizes some targets fresh, and skips them unexpectedly. 
https://crbug.com/1406628 

Changes 
- Increment `kCurrentVersion`
- Increment `kOldestSupportedVersion` as the current format is not compatible with the version 5.
- Fix `bulid_log_test.cc`