### PR TITLE
Clean up Windows workflow and add an x86 build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - arch: 'win32'
-          suffix: 'x86'
         - arch: 'x64'
           suffix: ''
         - arch: 'arm64'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,6 +10,11 @@ jobs:
   build:
     runs-on: windows-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['win32', 'x64', 'arm64']
+
     steps:
     - uses: actions/checkout@v2
 
@@ -19,15 +24,17 @@ jobs:
     - name: Build ninja
       shell: bash
       run: |
-        cmake -Bbuild
+        cmake -Bbuild -A ${{ matrix.arch }}
         cmake --build build --parallel --config Debug
         cmake --build build --parallel --config Release
 
     - name: Test ninja (Debug)
+      if: matrix.arch != 'arm64'
       run: .\ninja_test.exe
       working-directory: build/Debug
 
     - name: Test ninja (Release)
+      if: matrix.arch != 'arm64'
       run: .\ninja_test.exe
       working-directory: build/Release
 
@@ -35,7 +42,7 @@ jobs:
       shell: bash
       run: |
         mkdir artifact
-        7z a artifact/ninja-win.zip ./build/Release/ninja.exe
+        7z a artifact/ninja-win-${{ matrix.arch }}.zip ./build/Release/ninja.exe
 
     # Upload ninja binary archive as an artifact
     - name: Upload artifact
@@ -51,46 +58,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./artifact/ninja-win.zip
-        asset_name: ninja-win.zip
-        asset_content_type: application/zip
-
-  build-arm64:
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Install dependencies
-      run: choco install re2c
-
-    - name: Build ninja
-      shell: bash
-      run: |
-        cmake -Bbuild -A arm64
-        cmake --build build --parallel --config Debug
-        cmake --build build --parallel --config Release
-
-    - name: Create ninja archive
-      shell: bash
-      run: |
-        mkdir artifact
-        7z a artifact/ninja-winarm64.zip ./build/Release/ninja.exe
-
-    # Upload ninja binary archive as an artifact
-    - name: Upload artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: ninja-binary-archives
-        path: artifact
-
-    - name: Upload release asset
-      if: github.event.action == 'published'
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./artifact/ninja-winarm64.zip
-        asset_name: ninja-winarm64.zip
+        asset_path: ./artifact/ninja-win-${{ matrix.arch }}.zip
+        asset_name: ninja-win-${{ matrix.arch }}.zip
         asset_content_type: application/zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['win32', 'x64', 'arm64']
+        include:
+        - arch: 'win32'
+          suffix: 'x86'
+        - arch: 'x64'
+          suffix: ''
+        - arch: 'arm64'
+          suffix: 'arm64'
 
     steps:
     - uses: actions/checkout@v2
@@ -42,7 +48,7 @@ jobs:
       shell: bash
       run: |
         mkdir artifact
-        7z a artifact/ninja-win-${{ matrix.arch }}.zip ./build/Release/ninja.exe
+        7z a artifact/ninja-win${{ matrix.suffix }}.zip ./build/Release/ninja.exe
 
     # Upload ninja binary archive as an artifact
     - name: Upload artifact
@@ -58,6 +64,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./artifact/ninja-win-${{ matrix.arch }}.zip
-        asset_name: ninja-win-${{ matrix.arch }}.zip
+        asset_path: ./artifact/ninja-win${{ matrix.suffix }}.zip
+        asset_name: ninja-win${{ matrix.suffix }}.zip
         asset_content_type: application/zip


### PR DESCRIPTION
The [Windows workflow](https://github.com/ninja-build/ninja/blob/master/.github/workflows/windows.yml) has a lot of redundant code to support the arm64 version, which is identical to the default x64 build, but without tests.

This can be cleaned up with a matrix build and conditionals. While in there I added in an x86 build as well, because why not.

The current artifact filename, ninja-win.zip, is preserved for the x64 build. The arm64 build also retains the existing suffix.