### PR TITLE
Order clean by path length to ensure directories can be deleted

### DIFF
--- a/src/clean.h
+++ b/src/clean.h
@@ -88,6 +88,9 @@ struct Cleaner {
   /// Remove the depfile and rspfile for an Edge.
   void RemoveEdgeFiles(Edge* edge);
 
+  /// Perform actual file removal
+  void RemoveAllPending();
+
   /// Helper recursive method for CleanTarget().
   void DoCleanTarget(Node* target);
   void PrintHeader();
@@ -103,6 +106,7 @@ struct Cleaner {
   DyndepLoader dyndep_loader_;
   std::set<std::string> removed_;
   std::set<Node*> cleaned_;
+  std::vector<std::string> pending_;
   int cleaned_files_count_;
   DiskInterface* disk_interface_;
   int status_;


### PR DESCRIPTION
My ninja build generator is setup to create intermediate build directories and keep track of these as build outputs in order to properly clean up the intermediate directory structure with the clean ninja target.

It is cumbersome to have to track the directory hierarchy as implicit dependencies, but not doing so results in the clean target not being able to correctly order the deletion, causing directory deletions to fail due to still having files (which will be deleted later by the clean target).

A simple solution is to defer all deletions, sort by path length and perform all deletions starting with the deepest path. That guarantees that any directory is deleted after all the files in that directory.