### PR TITLE
Fixed manual layout

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -324,20 +324,19 @@ Where `ENVFILE` is a binary file that contains an environment block suitable
 for CreateProcessA() on Windows (i.e. a series of zero-terminated strings that
 look like NAME=VALUE, followed by an extra zero terminator). Note that this uses
 the local codepage encoding.
-
++
 This tool also supports a deprecated way of parsing the compiler's output when
 the `/showIncludes` flag is used, and generating a GCC-compatible depfile from it.
 +
----
+----
 ninja -t msvc -o DEPFILE [-p STRING] -- cl.exe /showIncludes <arguments>
----
+----
 +
-
 When using this option, `-p STRING` can be used to pass the localized line prefix
 that `cl.exe` uses to output dependency information. For English-speaking regions
 this is `"Note: including file: "` without the double quotes, but will be different
 for other regions.
-
++
 Note that Ninja supports this natively now, with the use of `deps = msvc` and
 `msvc_deps_prefix` in Ninja files. Native support also avoids launching an extra
 tool process each time the compiler must be called, which can speed up builds
@@ -1022,8 +1021,8 @@ source file of a compile command.
 +
 This is for expressing dependencies that don't show up on the
 command line of the command; for example, for a rule that runs a
-script that reads a hardcoded file, the hardcoded file should 
-be an implicit dependency, as changes to the file should cause 
+script that reads a hardcoded file, the hardcoded file should
+be an implicit dependency, as changes to the file should cause
 the output to rebuild, even though it doesn't show up in the arguments.
 +
 Note that dependencies as loaded through depfiles have slightly different


### PR DESCRIPTION
https://ninja-build.org/manual.html currently looks like this:
![image](https://user-images.githubusercontent.com/39418860/226189628-0c4b7fc7-a36c-493a-9f88-84096e69f798.png)

This looks broken. This PR should fix it.