### PR TITLE
Enable ppoll() usage when available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ include(CheckSymbolExists)
 include(CheckIPOSupported)
 
 option(NINJA_BUILD_BINARY "Build ninja binary" ON)
+option(NINJA_FORCE_PSELECT "Use pselect() even on platforms that provide ppoll()" OFF)
 
 project(ninja CXX)
 
@@ -34,6 +35,16 @@ else()
 	check_cxx_compiler_flag(-fdiagnostics-color flag_color_diag)
 	if(flag_color_diag)
 		add_compile_options(-fdiagnostics-color)
+	endif()
+
+	if(NOT NINJA_FORCE_PSELECT)
+		# Check whether ppoll() is usable on the target platform.
+		# Set -DUSE_PPOLL=1 if this is the case.
+		include(CheckSymbolExists)
+		check_symbol_exists(ppoll poll.h HAVE_PPOLL)
+		if(HAVE_PPOLL)
+			add_compile_definitions(USE_PPOLL=1)
+		endif()
 	endif()
 endif()
 


### PR DESCRIPTION
This patch modifies the CMakeLists.txt file to probe for ppoll() on the target system, and define -DUSE_PPOLL=1 if it is available.

This can be disabled by setting -DNINJA_FORCE_PSELECT=ON when invoking CMake.

This matches the default behavior of the configure.py script (and its `--force-pselect` option). Note that there is no noticeable performance difference before build commands are launched, so this
change is very hard to benchmark properly.

Fix for issue #1821