### PR TITLE
Allow duplicate rule variable usage.

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -112,6 +112,19 @@ red
 \x1b[31mred\x1b[0m
 ''')
 
+    def test_issue_1966(self):
+        self.assertEqual(run(
+'''rule cat
+  command = cat $rspfile $rspfile > $out
+  rspfile = cat.rsp
+  rspfile_content = a b c
+
+build a: cat
+''', '-j3'),
+'''[1/1] cat cat.rsp cat.rsp > a\x1b[K
+''')
+
+
     def test_pr_1685(self):
         # Running those tools without .ninja_deps and .ninja_log shouldn't fail.
         self.assertEqual(run('', flags='-t recompact'), '')


### PR DESCRIPTION
This fixes #1996 by removing the variable name from the lookups stack once the recursive lookup call has been performed. Without this, any previously expanded variable could no longer be referenced in the command, as Ninja would (incorrectly) complain about a cyclical dependency.