### PR TITLE
Fix stats report

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -32,7 +32,6 @@
 using namespace std;
 
 bool Node::Stat(DiskInterface* disk_interface, string* err) {
-  METRIC_RECORD("node stat");
   mtime_ = disk_interface->Stat(path_, err);
   if (mtime_ == -1) {
     return false;

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -85,6 +85,13 @@ struct Stopwatch {
       g_metrics ? g_metrics->NewMetric(name) : NULL;                    \
   ScopedMetric metrics_h_scoped(metrics_h_metric);
 
+/// A variant of METRIC_RECORD that doesn't record anything if |condition|
+/// is false.
+#define METRIC_RECORD_IF(name, condition)            \
+  static Metric* metrics_h_metric =                  \
+      g_metrics ? g_metrics->NewMetric(name) : NULL; \
+  ScopedMetric metrics_h_scoped((condition) ? metrics_h_metric : NULL);
+
 extern Metrics* g_metrics;
 
 #endif // NINJA_METRICS_H_

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -20,7 +20,10 @@
 using namespace std;
 
 bool Parser::Load(const string& filename, string* err, Lexer* parent) {
-  METRIC_RECORD(".ninja parse");
+  // If |parent| is not NULL, metrics collection has been started by a parent
+  // Parser::Load() in our call stack. Do not start a new one here to avoid
+  // over-counting parsing times.
+  METRIC_RECORD_IF(".ninja parse", parent == NULL);
   string contents;
   string read_err;
   if (file_reader_->ReadFile(filename, &contents, &read_err) !=


### PR DESCRIPTION
Fix two minor issues in the output of `-d stats` where things were not counted properly:

- The `node stat` metric appeared twice with different values, which was a bit confusing :-)
- The .ninja_parse value was double-counting the parsing time due to recursive manifest parser calls.

In short:

BEFORE:

```
metric                  count   avg (us)        total (ms)
.ninja parse            27304   372.6           10172.2
node stat               119145  2.9             340.7
node stat               270673  3.0             819.3
...
```

AFTER:

```
metric                  count   avg (us)        total (ms)
.ninja parse            1       4109354.0       4109.4
node stat               270673  2.9             774.0
...
```