### PR TITLE
CMakeLists: Fix ppoll() feature detection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,16 @@ else()
 	if(NOT NINJA_FORCE_PSELECT)
 		# Check whether ppoll() is usable on the target platform.
 		# Set -DUSE_PPOLL=1 if this is the case.
-		include(CheckSymbolExists)
-		check_symbol_exists(ppoll poll.h HAVE_PPOLL)
+		#
+		# NOTE: Use check_cxx_symbol_exists() instead of check_symbol_exists()
+		# because on Linux, <poll.h> only exposes the symbol when _GNU_SOURCE
+		# is defined.
+		#
+		# Both g++ and clang++ define the symbol by default, because the C++
+		# standard library headers require it, but *not* gcc and clang, which
+		# are used by check_symbol_exists().
+		include(CheckCXXSymbolExists)
+		check_cxx_symbol_exists(ppoll poll.h HAVE_PPOLL)
 		if(HAVE_PPOLL)
 			add_compile_definitions(USE_PPOLL=1)
 		endif()


### PR DESCRIPTION
Use check_cxx_symbol_exists() instead of check_symbol_exists() because the latter cannot detect ppoll() on Linux (or more precisely with GLibc and Musl).

The reason is subtle: _GNU_SOURCE must be defined for <poll.h> to expose the symbol, and this macro is defined implicitly by C++ compilers, but not C ones, on Linux, because the standard C++ library headers require it (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=2082#c8).

Due to this, subprocess-posix.cc doesn't need to define _GNU_SOURCE before include <poll.h>, but the feature check performed by check_symbol_exists() used the C compiler that does not define the symbol, and failed (unless it was already defined in CFLAGS or CMAKE_C_FLAGS).

Using check_cxx_symbol_exists() instead fixes the issue, and consistent with the fact that _GNU_SOURCE is never defined in the Ninja source files too.