### PR TITLE
Add failfast mode

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -156,7 +156,8 @@ struct CommandRunner {
 /// Options (e.g. verbosity, parallelism) passed to a build.
 struct BuildConfig {
   BuildConfig() : verbosity(NORMAL), dry_run(false), parallelism(1),
-                  failures_allowed(1), max_load_average(-0.0f) {}
+                  failures_allowed(1), max_load_average(-0.0f),
+                  failfast_mode(false)	{}
 
   enum Verbosity {
     QUIET,  // No output -- used when testing.
@@ -171,6 +172,9 @@ struct BuildConfig {
   /// The maximum load average we must not exceed. A negative value
   /// means that we do not have any limit.
   double max_load_average;
+  /// In case of first subcommand failure, abort (send SIGINT) to all
+  /// other running subcommands.
+  bool failfast_mode;
   DepfileParserOptions depfile_parser_options;
 };
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -228,6 +228,7 @@ void Usage(const BuildConfig& config) {
 "\n"
 "  -j N     run N jobs in parallel (0 means infinity) [default=%d on this system]\n"
 "  -k N     keep going until N jobs fail (0 means infinity) [default=1]\n"
+"  -K       abort all jobs after first job fails; implies -k 1\n"
 "  -l N     do not start new jobs if the load average is greater than N\n"
 "  -n       dry run (don't run commands but act like they succeeded)\n"
 "\n"
@@ -1429,7 +1430,7 @@ int ReadFlags(int* argc, char*** argv,
 
   int opt;
   while (!options->tool &&
-         (opt = getopt_long(*argc, *argv, "d:f:j:k:l:nt:vw:C:h", kLongOptions,
+         (opt = getopt_long(*argc, *argv, "d:f:j:k:Kl:nt:vw:C:h", kLongOptions,
                             NULL)) != -1) {
     switch (opt) {
       case 'd':
@@ -1461,6 +1462,10 @@ int ReadFlags(int* argc, char*** argv,
         // N failures and then stop.  For N <= 0, INT_MAX is close enough
         // to infinite for most sane builds.
         config->failures_allowed = value > 0 ? value : INT_MAX;
+        break;
+      }
+      case 'K': {
+        config->failfast_mode = true;
         break;
       }
       case 'l': {


### PR DESCRIPTION
Commit adds new command line option, -K, that aborts all running jobs after first failed job.

This implements #2083.