### PR TITLE
Update status on edge finished

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -70,11 +70,11 @@ build b: echo
 build c: echo
   delay = 1
 ''', '-j3'),
-'''[1/3] echo c\x1b[K
+'''[1*3/3] echo c\x1b[K
 c
-[2/3] echo b\x1b[K
+[2*2/3] echo b\x1b[K
 b
-[3/3] echo a\x1b[K
+[3*1/3] echo a\x1b[K
 a
 ''')
 
@@ -87,7 +87,7 @@ build a: echo
 '''
         # Only strip color when ninja's output is piped.
         self.assertEqual(run(print_red),
-'''[1/1] echo a\x1b[K
+'''[1*1/1] echo a\x1b[K
 \x1b[31mred\x1b[0m
 ''')
         self.assertEqual(run(print_red, pipe=True),
@@ -121,7 +121,7 @@ red
 
 build a: cat
 ''', '-j3'),
-'''[1/1] cat cat.rsp cat.rsp > a\x1b[K
+'''[0*1/1] cat cat.rsp cat.rsp > a\x1b[K
 ''')
 
 
@@ -136,7 +136,7 @@ build a: cat
 
     def test_ninja_status_default(self):
         'Do we show the default status by default?'
-        self.assertEqual(run(Output.BUILD_SIMPLE_ECHO), '[1/1] echo a\x1b[K\ndo thing\n')
+        self.assertEqual(run(Output.BUILD_SIMPLE_ECHO), '[1*1/1] echo a\x1b[K\ndo thing\n')
 
     def test_ninja_status_quiet(self):
         'Do we suppress the status information when --quiet is specified?'

--- a/src/status.h
+++ b/src/status.h
@@ -15,7 +15,9 @@
 #ifndef NINJA_STATUS_H_
 #define NINJA_STATUS_H_
 
+#include <deque>
 #include <map>
+#include <queue>
 #include <string>
 
 #include "build.h"
@@ -72,6 +74,7 @@ struct StatusPrinter : Status {
 
   int started_edges_, finished_edges_, total_edges_, running_edges_;
   int64_t time_millis_;
+  std::deque<const Edge*> edges_;
 
   /// Prints progress output.
   LinePrinter printer_;


### PR DESCRIPTION
In the terminal, when an edge finishes update the status to display the first started (longest running) action. Usually this will be immediately overwritten with the next started action but if there is a bottleneck in the build or if it is reaching the end, this ensures that the console displays status of a build that is actually running and not one that has completed.
This ensures that the user attributes any delay to the (or an) action that is actually causing the slowdown and not unfairly to an action that has already finished just because it happened to be the last started.

To make this clear, also change the default NINJA_STATUS to include current actual parallelism level - this will reduce from number of cores to 1 as the bottleneck or end of build approaches.

Implementation stores currently running nodes in a deque, with NULL for interior completed nodes. This should be fairly efficient and allows future extension to e.g. display multiple parallel action names, as in #2249 and @orgads prototype for #111.

Partially resolves #111 (should be enough for most purposes).