### PR TITLE
Improve EXPECT_XXX and ASSERT_XXX output in case of failure.

### DIFF
--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -295,7 +295,7 @@ TEST_F(BuildLogTest, VeryLongInputLine) {
   ASSERT_EQ("", err);
 
   BuildLog::LogEntry* e = log.LookupByOutput("out");
-  ASSERT_EQ(NULL, e);
+  ASSERT_NULL(e);
 
   e = log.LookupByOutput("out2");
   ASSERT_TRUE(e);

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -84,7 +84,7 @@ TEST_F(PlanTest, Basic) {
 
   ASSERT_FALSE(plan_.more_to_do());
   edge = plan_.FindWork();
-  ASSERT_EQ(0, edge);
+  ASSERT_NULL(edge);
 }
 
 // Test that two outputs from one rule can be handled as inputs to the next.
@@ -234,7 +234,7 @@ void PlanTest::TestPoolWithDepthOne(const char* test_case) {
 
   ASSERT_FALSE(plan_.more_to_do());
   edge = plan_.FindWork();
-  ASSERT_EQ(0, edge);
+  ASSERT_NULL(edge);
 }
 
 TEST_F(PlanTest, PoolWithDepthOne) {
@@ -464,7 +464,7 @@ TEST_F(PlanTest, PoolWithFailingEdge) {
 
   ASSERT_TRUE(plan_.more_to_do()); // Jobs have failed
   edge = plan_.FindWork();
-  ASSERT_EQ(0, edge);
+  ASSERT_NULL(edge);
 }
 
 /// Fake implementation of CommandRunner, useful for tests.

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -487,7 +487,7 @@ TEST_F(DepsLogTest, TruncatedRecovery) {
     err.clear();
 
     // The truncated entry should've been discarded.
-    EXPECT_EQ(NULL, log.GetDeps(state.GetNode("out2.o", 0)));
+    EXPECT_NULL(log.GetDeps(state.GetNode("out2.o", 0)));
 
     EXPECT_TRUE(log.OpenForWrite(kTestFilename, &err));
     ASSERT_EQ("", err);

--- a/src/ninja_test.cc
+++ b/src/ninja_test.cc
@@ -118,14 +118,31 @@ bool ReadFlags(int* argc, char*** argv, const char** test_filter) {
 
 }  // namespace
 
-bool testing::Test::Check(bool condition, const char* file, int line,
-                          const char* error) {
-  if (!condition) {
-    printer.PrintOnNewLine(
-        StringPrintf("*** Failure in %s:%d\n%s\n", file, line, error));
-    failed_ = true;
-  }
-  return condition;
+bool testing::Test::NullFailure(bool null_expected, const char* file, int line,
+                                const char* error, const char* value) {
+  printer.PrintOnNewLine(StringPrintf(
+      "*** Failure in %s:%d\n%s\nExpected: %s\nActual:   %s\n", file, line,
+      error, null_expected ? "nullptr" : "not nullptr", value));
+  failed_ = true;
+  return false;
+}
+
+bool testing::Test::BooleanFailure(bool expected, const char* file, int line,
+                          const char* error, const char* value) {
+  printer.PrintOnNewLine(
+      StringPrintf("*** Failure in %s:%d\n%s\nExpected: %s\nActual:   %s\n",
+                   file, line, error, expected ? "true" : "false", value));
+  failed_ = true;
+  return false;
+}
+
+bool testing::Test::BinopFailure(const char* file, int line,
+                                 const char* error, const char* first_value,
+                                 const char* second_value) {
+  printer.PrintOnNewLine(
+      StringPrintf("*** Failure in %s:%d\n%s\nLeft:  %s\nRight: %s\n", file, line, error, first_value, second_value));
+  failed_ = true;
+  return false;
 }
 
 int main(int argc, char **argv) {

--- a/src/test.cc
+++ b/src/test.cc
@@ -82,6 +82,13 @@ string GetSystemTempDir() {
 
 }  // anonymous namespace
 
+
+::testing::AsString<void*, void>::AsString(const void* ptr) {
+  char temp[32];
+  ::snprintf(temp, sizeof(temp), "%p", ptr);
+  str_ = temp;
+}
+
 StateTestWithBuiltinRules::StateTestWithBuiltinRules() {
   AddCatRule(&state_);
 }

--- a/src/test.h
+++ b/src/test.h
@@ -15,6 +15,8 @@
 #ifndef NINJA_TEST_H_
 #define NINJA_TEST_H_
 
+#include <stddef.h>
+
 #include "disk_interface.h"
 #include "manifest_parser.h"
 #include "state.h"
@@ -40,8 +42,143 @@ class Test {
   bool Failed() const { return failed_; }
   int AssertionFailures() const { return assertion_failures_; }
   void AddAssertionFailure() { assertion_failures_++; }
-  bool Check(bool condition, const char* file, int line, const char* error);
+  bool NullFailure(bool expected, const char* file, int line, const char* error,
+                   const char* value);
+  bool BooleanFailure(bool expected, const char* file, int line,
+                      const char* error, const char* value);
+  bool BinopFailure(const char* file, int line, const char* error, const char* first_value, const char* second_value);
 };
+
+/// std::void_t<T> is only available since C++17, so use
+/// ::testing::Void<T>::type for the same thing. Used by AsString<> below.
+template <class ...>
+struct Void {
+  using type = void;
+};
+
+/// Expand to a type expression that is only valid if |expression| compiles
+/// properly. Only useful for C++ SFINAE.
+#define TESTING_ENABLE_IF_EXPRESSION_COMPILES(expression) \
+  typename ::testing::Void<decltype(expression)>::type
+
+/// Expand to a type expression that is only valid if type T provides
+/// an AsString() method. Note: for simplicity, there is no check that
+/// the result is convertible into an std::string here.
+#define TESTING_ENABLE_IF_METHOD_AS_STRING_EXISTS_FOR_TYPE(T) \
+  TESTING_ENABLE_IF_EXPRESSION_COMPILES(std::declval<T>().AsString())
+
+/// Expand to a type expression that is only valid if type T is supported
+/// as an std::to_string() argument type.
+#define TESTING_ENABLE_IF_STD_TO_STRING_SUPPORTS_TYPE(T) \
+  TESTING_ENABLE_IF_EXPRESSION_COMPILES(std::to_string(std::declval<T>()))
+
+/// RemoveCVRef<T> remove references as well as const and volatile modifier.
+/// Used by AsString<> below.
+template <typename T>
+struct RemoveCVRef {
+  using type = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+};
+
+/// Expand to the base type of expression value |v|, which means without
+/// any reference, const or volatile qualifier. This can be used as a
+/// type argument when defining template specializations.
+#define TESTING_BASE_TYPE_FOR_VALUE(v) \
+  typename ::testing::RemoveCVRef<decltype(v)>::type
+
+/// ::testing::AsString<T> is a helper struct used to convert expression
+/// in EXPECT_XXX and ASSERT_XXX macros into the string representation of
+/// their value. This uses C++11 template metadata magic which can be easily
+/// confusing, so as a short technical note:
+///
+/// - An AsString<T> value is an object that provides a `c_str()` method that
+///   will be used to print it in case of test failure.
+///
+/// - By default, AsString<T>::c_str() will return `"<UNPRINTABLE>"`. This
+///   would happen when T is an std::pair<> or something more complex.
+///
+/// - If type T has an AsString() method, it will be used automatically
+///   to retrieve a printable version of the value. E.g. StringPiece!
+///
+/// - If type T is supported by std::to_string(), the latter is used
+///   automatically as well (so all integral and floating point values).
+///
+/// - AsString<T*>::c_str() will return an hexadecimal address (just like %p)
+///
+
+/// The generic / fallback version.
+template <typename T, typename Enable = void>
+struct AsString {
+  AsString(const T& value) {}
+  const char* c_str() const { return "<UNPRINTABLE>"; }
+};
+
+/// Print booleans as either "true" or "false".
+template <>
+struct AsString<bool, void> {
+  AsString(bool value) : value_(value) {}
+  const char* c_str() const { return value_ ? "true" : "false"; }
+  bool value_;
+};
+
+/// Print pointers with %p by default. See implementation in ninja_test.cc
+template <>
+struct AsString<void*, void> {
+  AsString(const void* ptr);
+  const char* c_str() const { return str_.c_str(); }
+  std::string str_;
+};
+
+template <typename T>
+struct AsString<T*, void> : public AsString<void*, void> {
+  AsString(const T* ptr) : AsString<void*, void>(ptr) {}
+};
+
+/// Anything supported by std::to_string() is supported implicitly too.
+template <typename T>
+struct AsString<T, TESTING_ENABLE_IF_STD_TO_STRING_SUPPORTS_TYPE(T)> {
+  AsString(const T value) : str_(std::to_string(value)) {}
+  const char* c_str() const { return str_.c_str(); }
+  std::string str_;
+};
+
+/// Anything that has an AsString() method is supported implicitly too.
+/// For example, StringPiece!
+template <typename T>
+struct AsString<T, TESTING_ENABLE_IF_METHOD_AS_STRING_EXISTS_FOR_TYPE(T)> {
+  AsString(const T& value) : str_(value.AsString()) {}
+  const char* c_str() const { return str_.c_str(); }
+  std::string str_;
+};
+
+/// Support for std::string, avoids a copy.
+template <>
+struct AsString<std::string> {
+  AsString(const std::string& value) : str_(value) {}
+  const char* c_str() const { return str_.c_str(); }
+  const std::string& str_;
+};
+
+/// Support for literal C strings.
+template <size_t N>
+struct AsString<char [N], void> {
+  AsString(const char* value) : value_(value) {}
+  const char* c_str() const { return value_; }
+  const char* value_;
+};
+
+/// Support for C string pointers.
+template <>
+struct AsString<const char*> {
+  AsString(const char* value) : value_(value) {}
+  const char* c_str() const { return value_; }
+  const char* value_;
+};
+
+template <>
+struct AsString<char*> : public AsString<const char*> {
+  AsString(const char* value) : AsString<const char*>(value) {}
+};
+
 }
 
 void RegisterTest(testing::Test* (*)(), const char*);
@@ -61,22 +198,57 @@ extern testing::Test* g_current_test;
 #define TEST_F(x, y) TEST_F_(x, x##y, #x "." #y)
 #define TEST(x, y) TEST_F_(testing::Test, x##y, #x "." #y)
 
-#define EXPECT_EQ(a, b) \
-  g_current_test->Check(a == b, __FILE__, __LINE__, #a " == " #b)
-#define EXPECT_NE(a, b) \
-  g_current_test->Check(a != b, __FILE__, __LINE__, #a " != " #b)
-#define EXPECT_GT(a, b) \
-  g_current_test->Check(a > b, __FILE__, __LINE__, #a " > " #b)
-#define EXPECT_LT(a, b) \
-  g_current_test->Check(a < b, __FILE__, __LINE__, #a " < " #b)
-#define EXPECT_GE(a, b) \
-  g_current_test->Check(a >= b, __FILE__, __LINE__, #a " >= " #b)
-#define EXPECT_LE(a, b) \
-  g_current_test->Check(a <= b, __FILE__, __LINE__, #a " <= " #b)
-#define EXPECT_TRUE(a) \
-  g_current_test->Check(static_cast<bool>(a), __FILE__, __LINE__, #a)
-#define EXPECT_FALSE(a) \
-  g_current_test->Check(!static_cast<bool>(a), __FILE__, __LINE__, #a)
+/// Generic EXPECT macro for binary operations. The use of a lambda here
+/// is necessary to ensure that the expressions in (a) and (b) are only
+/// evaluated once at runtime in case of failure.
+#define EXPECT_BINARY_OP(a, b, op)                                             \
+  ([](const decltype(a)& va, const decltype(b)& vb) -> bool {                  \
+    return ((va op vb)                                                         \
+                ? true                                                         \
+                : g_current_test->BinopFailure(                                \
+                      __FILE__, __LINE__, #a " " #op " " #b,                   \
+                      ::testing::AsString<TESTING_BASE_TYPE_FOR_VALUE(va)>(va) \
+                          .c_str(),                                            \
+                      ::testing::AsString<TESTING_BASE_TYPE_FOR_VALUE(vb)>(vb) \
+                          .c_str()));                                          \
+  }(a, b))
+
+#define EXPECT_EQ(a, b) EXPECT_BINARY_OP(a, b, ==)
+#define EXPECT_NE(a, b) EXPECT_BINARY_OP(a, b, !=)
+#define EXPECT_GT(a, b) EXPECT_BINARY_OP(a, b, >)
+#define EXPECT_LT(a, b) EXPECT_BINARY_OP(a, b, <)
+#define EXPECT_GE(a, b) EXPECT_BINARY_OP(a, b, >=)
+#define EXPECT_LE(a, b) EXPECT_BINARY_OP(a, b, <=)
+
+/// Generic EXPECT macro for boolean comparisons.
+#define EXPECT_BOOLEAN_OP(a, expected)                                        \
+  ([](const decltype(a)& va) -> bool {                                        \
+    return (static_cast<bool>(va) == expected)                                \
+               ? true                                                         \
+               : g_current_test->BooleanFailure(                              \
+                     expected, __FILE__, __LINE__, #a,                        \
+                     ::testing::AsString<TESTING_BASE_TYPE_FOR_VALUE(va)>(va) \
+                         .c_str());                                           \
+  }(a))
+
+#define EXPECT_TRUE(a) EXPECT_BOOLEAN_OP(a, true)
+#define EXPECT_FALSE(a) EXPECT_BOOLEAN_OP(a, false)
+
+/// Generic EXPECT macro for pointer nullptr comparisons.
+/// Note that boolean comparisons should work too, but the message in case
+/// of failure is slightly clearer when using this macro.
+#define EXPECT_NULL_OP(a, expected)                                           \
+  ([](const decltype(a)& va) -> bool {                                        \
+    return (expected == ((va) == nullptr))                                    \
+               ? true                                                         \
+               : g_current_test->NullFailure(                                 \
+                     expected, __FILE__, __LINE__, #a,                        \
+                     ::testing::AsString<TESTING_BASE_TYPE_FOR_VALUE(va)>(va) \
+                         .c_str());                                           \
+  }(a))
+
+#define EXPECT_NULL(a) EXPECT_NULL_OP(a, true)
+#define EXPECT_NOT_NULL(a) EXPECT_NULL_OP(a, false)
 
 #define ASSERT_EQ(a, b) \
   if (!EXPECT_EQ(a, b)) { g_current_test->AddAssertionFailure(); return; }
@@ -94,6 +266,16 @@ extern testing::Test* g_current_test;
   if (!EXPECT_TRUE(a))  { g_current_test->AddAssertionFailure(); return; }
 #define ASSERT_FALSE(a) \
   if (!EXPECT_FALSE(a)) { g_current_test->AddAssertionFailure(); return; }
+#define ASSERT_NULL(a)                     \
+  if (!EXPECT_NULL(a)) {                   \
+    g_current_test->AddAssertionFailure(); \
+    return;                                \
+  }
+#define ASSERT_NOT_NULL(a)                 \
+  if (!EXPECT_NOT_NULL(a)) {               \
+    g_current_test->AddAssertionFailure(); \
+    return;                                \
+  }
 #define ASSERT_NO_FATAL_FAILURE(a)                           \
   {                                                          \
     int fail_count = g_current_test->AssertionFailures();    \


### PR DESCRIPTION
Ensure that binary comparisons (e.g. EXPECT_EQ) display the actual values of the left and right side operands, and not just their source expression, as in:

```
Failure on file.cc:10:  expected != actual
Left:  10
Right: 20
```

Also ensure that boolean comparisons (e.g. EXPECT_TRUE) display the expected and actual values too as in:

```
Failure on file.cc:10: vec.size()
Expected: false
Actual:   1
```

This uses a small amount of C++11 SFINAE, without needing to change any of the test macro invocations. If a value is not supported, then "<UNPRINTABLE>" will be used instead.