### PR TITLE
Ensure tests do not leave stale files in current directory.

### DIFF
--- a/src/missing_deps_test.cc
+++ b/src/missing_deps_test.cc
@@ -36,6 +36,11 @@ struct MissingDependencyScannerTest : public testing::Test {
     ASSERT_EQ("", err);
   }
 
+  ~MissingDependencyScannerTest() {
+    // Remove test file.
+    deps_log_.Close();
+  }
+
   MissingDependencyScanner& scanner() { return scanner_; }
 
   void RecordDepsLogDep(const std::string& from, const std::string& to) {
@@ -79,6 +84,7 @@ struct MissingDependencyScannerTest : public testing::Test {
     ASSERT_EQ(1u, scanner().generator_rules_.count(rule));
   }
 
+  ScopedFilePath scoped_file_path_ = kTestDepsLogFilename;
   MissingDependencyTestDelegate delegate_;
   Rule generator_rule_;
   Rule compile_rule_;

--- a/src/test.h
+++ b/src/test.h
@@ -182,4 +182,31 @@ struct ScopedTempDir {
   std::string temp_dir_name_;
 };
 
+/// A class that records a file path and ensures that it is removed
+/// on destruction. This ensures that tests do not keep stale files in the
+/// current directory where they run, even in case of assertion failure.
+struct ScopedFilePath {
+  /// Constructor just records the file path.
+  ScopedFilePath(const std::string& path) : path_(path) {}
+  ScopedFilePath(const char* path) : path_(path) {}
+
+  /// Allow move operations.
+  ScopedFilePath(ScopedFilePath&&) noexcept;
+  ScopedFilePath& operator=(ScopedFilePath&&) noexcept;
+
+  /// Destructor destroys the file, unless Release() was called.
+  ~ScopedFilePath();
+
+  /// Release the file, the destructor will not remove the file.
+  void Release();
+
+  const char* c_str() const { return path_.c_str(); }
+  const std::string& path() const { return path_; }
+  bool released() const { return released_; }
+
+ private:
+  std::string path_;
+  bool released_ = false;
+};
+
 #endif // NINJA_TEST_H_


### PR DESCRIPTION
This patch fixes a minor but annoying issue during development where some tests would leave stale files in the current directory.

+ Introduce new ScopedFilePath class to perform remove-on-scope-exit of a given file path.

Fixes #1583