### PR TITLE
Replace pipes.quote with shlex.quote in configure.py 

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -22,7 +22,6 @@ or use a meta-build system that supports Ninja output."""
 from optparse import OptionParser
 import os
 import shlex
-import string
 import subprocess
 import sys
 

--- a/configure.py
+++ b/configure.py
@@ -21,7 +21,7 @@ or use a meta-build system that supports Ninja output."""
 
 from optparse import OptionParser
 import os
-import pipes
+import shlex
 import string
 import subprocess
 import sys
@@ -262,7 +262,7 @@ n.variable('configure_args', ' '.join(configure_args))
 env_keys = set(['CXX', 'AR', 'CFLAGS', 'CXXFLAGS', 'LDFLAGS'])
 configure_env = dict((k, os.environ[k]) for k in os.environ if k in env_keys)
 if configure_env:
-    config_str = ' '.join([k + '=' + pipes.quote(configure_env[k])
+    config_str = ' '.join([k + '=' + shlex.quote(configure_env[k])
                            for k in configure_env])
     n.variable('configure_env', config_str + '$ ')
 n.newline()


### PR DESCRIPTION
Python 3.12 deprecated the pipes module and it will be removed
in Python 3.13. In configure.py, I have replaced the usage of `pipes.quote`
with `shlex.quote`, which is exactly the same function as `pipes.quote`.

For more details, refer to PEP 0594: https://peps.python.org/pep-0594