### PR TITLE
Do not print 'no work to do' with --quiet

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -133,6 +133,7 @@ build a: cat
     def test_status(self):
         self.assertEqual(run(''), 'ninja: no work to do.\n')
         self.assertEqual(run('', pipe=True), 'ninja: no work to do.\n')
+        self.assertEqual(run('', flags='--quiet'), '')
 
     def test_ninja_status_default(self):
         'Do we show the default status by default?'

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1366,7 +1366,9 @@ int NinjaMain::RunBuild(int argc, char** argv, Status* status) {
   disk_interface_.AllowStatCache(false);
 
   if (builder.AlreadyUpToDate()) {
-    status->Info("no work to do.");
+    if (config_.verbosity != BuildConfig::NO_STATUS_UPDATE) {
+      status->Info("no work to do.");
+    }
     return 0;
   }
 


### PR DESCRIPTION
I added a simple check to suppress the `ninja: no work to do.` output if the `--quiet` flag was passed.

Resolves #2342.