### PR TITLE
Use "LOCAL" pipe instead of globally available pipe

### DIFF
--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -41,7 +41,7 @@ Subprocess::~Subprocess() {
 HANDLE Subprocess::SetupPipe(HANDLE ioport) {
   char pipe_name[100];
   snprintf(pipe_name, sizeof(pipe_name),
-           "\\\\.\\pipe\\ninja_pid%lu_sp%p", GetCurrentProcessId(), this);
+           "\\\\.\\pipe\\LOCAL\\ninja_pid%lu_sp%p", GetCurrentProcessId(), this);
 
   pipe_ = ::CreateNamedPipeA(pipe_name,
                              PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,


### PR DESCRIPTION
At Compiler-Explorer we're working on CMake support for Windows compilers under heavy sandboxing (using Windows AppContainer), and we encountered the issue not being able to Create a named pipe.

There seems to be no capability that we can give the AppContainer environment to enable the creation of named pipes

However at https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createnamedpipea I read that if you named the pipe `\\.\pipe\LOCAL\...` things should work fine.

And it actually does work with `\LOCAL\`

The question is if this will remain compatible with the regular execution of ninja under Windows. I do not know, so if anyone has any ideas or ways to test this, please. Or perhaps if we need to limit this to certain versions of Windows, that seems plausible.
