### PR TITLE
Fix typo

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -2978,7 +2978,7 @@ TEST_F(BuildWithDepsLogTest, DepFileOKDepsLog) {
     ASSERT_EQ("", err);
 
     // Expect one new edge generating fo o.o, loading the depfile should
-    // note generate new edges.
+    // not generate new edges.
     ASSERT_EQ(1u, state.edges_.size());
     // Expect our edge to now have three inputs: foo.c and two headers.
     ASSERT_EQ(3u, edge->inputs_.size());


### PR DESCRIPTION
Amends a744eea2b6c9b37024b12e749e61170e5c87d171.

cc @digit-google 