### PR TITLE
[FIX] compile: gcc version > 11.3, treat -Wmaybe-uninitialized as error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,16 @@ if(BUILD_TESTING)
     if (NOT TARGET GTest::gtest)
       message(STATUS "Defining GTest::gtest alias to work-around bug in older release.")
       add_library(GTest::gtest ALIAS gtest)
+
+      # NOTE: gtest uninit some variables, gcc >= 1.11.3 may cause error on compile.
+      # Remove this comment and six lines below, once ninja deps gtest-1.11.0 or above.
+      if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "1.11.3")
+        check_cxx_compiler_flag(-Wno-maybe-uninitialized flag_no_maybe_uninit)
+        if (flag_no_maybe_uninit)
+          target_compile_options(gtest PRIVATE -Wno-maybe-uninitialized)
+        endif()
+      endif()
+
     endif()
   endif()
 


### PR DESCRIPTION
my gcc version
```bash
gcc (SUSE Linux) 13.2.1 20231130 [revision 741743c028dc00f27b9c8b1d5211c1f602f2fddd]
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE
```
compile ninja, 1 error occurs
```bash
ninja/build/_deps/googletest-src/googletest/src/gtest-death-test.cc:1301:24: error: ‘dummy’ may be used uninitialized [-Werror=maybe-uninitialized]
 1301 |   StackLowerThanAddress(&dummy, &result);
      |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```
just try to ignore this error