### PR TITLE
Fix cppcheck performance checks

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -18,7 +18,6 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-
 #include <functional>
 
 #if defined(__SVR4) && defined(__sun)
@@ -65,19 +64,22 @@ bool DryRunCommandRunner::StartCommand(Edge* edge) {
 }
 
 bool DryRunCommandRunner::WaitForCommand(Result* result) {
-  if (finished_.empty())
-    return false;
+   if (finished_.empty())
+     return false;
 
-  result->status = ExitSuccess;
-  result->edge = finished_.front();
-  finished_.pop();
-  return true;
+   result->status = ExitSuccess;
+   result->edge = finished_.front();
+   finished_.pop();
+   return true;
 }
 
 }  // namespace
 
 Plan::Plan(Builder* builder)
-    : builder_(builder), command_edges_(0), wanted_edges_(0) {}
+  : builder_(builder)
+  , command_edges_(0)
+  , wanted_edges_(0)
+{}
 
 void Plan::Reset() {
   command_edges_ = 0;
@@ -94,29 +96,28 @@ bool Plan::AddSubTarget(const Node* node, const Node* dependent, string* err,
                         set<Edge*>* dyndep_walk) {
   Edge* edge = node->in_edge();
   if (!edge) {
-    // Leaf node, this can be either a regular input from the manifest
-    // (e.g. a source file), or an implicit input from a depfile or dyndep
-    // file. In the first case, a dirty flag means the file is missing,
-    // and the build should stop. In the second, do not do anything here
-    // since there is no producing edge to add to the plan.
-    if (node->dirty() && !node->generated_by_dep_loader()) {
-      string referenced;
-      if (dependent)
-        referenced = ", needed by '" + dependent->path() + "',";
-      *err = "'" + node->path() + "'" + referenced +
-             " missing and no known rule to make it";
-    }
-    return false;
+     // Leaf node, this can be either a regular input from the manifest
+     // (e.g. a source file), or an implicit input from a depfile or dyndep
+     // file. In the first case, a dirty flag means the file is missing,
+     // and the build should stop. In the second, do not do anything here
+     // since there is no producing edge to add to the plan.
+     if (node->dirty() && !node->generated_by_dep_loader()) {
+       string referenced;
+       if (dependent)
+         referenced = ", needed by '" + dependent->path() + "',";
+       *err = "'" + node->path() + "'" + referenced +
+              " missing and no known rule to make it";
+     }
+     return false;
   }
 
   if (edge->outputs_ready())
     return false;  // Don't need to do anything.
 
   // If an entry in want_ does not already exist for edge, create an entry which
-  // maps to kWantNothing, indicating that we do not want to build this entry
-  // itself.
+  // maps to kWantNothing, indicating that we do not want to build this entry itself.
   pair<map<Edge*, Want>::iterator, bool> want_ins =
-      want_.insert(make_pair(edge, kWantNothing));
+    want_.insert(make_pair(edge, kWantNothing));
   Want& want = want_ins.first->second;
 
   if (dyndep_walk && want == kWantToFinish)
@@ -165,9 +166,8 @@ void Plan::ScheduleWork(map<Edge*, Want>::iterator want_e) {
   if (want_e->second == kWantToFinish) {
     // This edge has already been scheduled.  We can get here again if an edge
     // and one of its dependencies share an order-only input, or if a node
-    // duplicates an out edge (see
-    // https://github.com/ninja-build/ninja/pull/519). Avoid scheduling the work
-    // again.
+    // duplicates an out edge (see https://github.com/ninja-build/ninja/pull/519).
+    // Avoid scheduling the work again.
     return;
   }
   assert(want_e->second == kWantToStart);
@@ -266,9 +266,9 @@ bool Plan::CleanNode(DependencyScan* scan, Node* node, string* err) {
 
     // If all non-order-only inputs for this edge are now clean,
     // we might have changed the dirty state of the outputs.
-    vector<Node*>::iterator begin = (*oe)->inputs_.begin(),
-                            end =
-                                (*oe)->inputs_.end() - (*oe)->order_only_deps_;
+    vector<Node*>::iterator
+        begin = (*oe)->inputs_.begin(),
+        end = (*oe)->inputs_.end() - (*oe)->order_only_deps_;
 #if __cplusplus < 201703L
 #define MEM_FN mem_fun
 #else
@@ -286,8 +286,8 @@ bool Plan::CleanNode(DependencyScan* scan, Node* node, string* err) {
       // If the edge isn't dirty, clean the outputs and mark the edge as not
       // wanted.
       bool outputs_dirty = false;
-      if (!scan->RecomputeOutputsDirty(*oe, most_recent_input, &outputs_dirty,
-                                       err)) {
+      if (!scan->RecomputeOutputsDirty(*oe, most_recent_input,
+                                       &outputs_dirty, err)) {
         return false;
       }
       if (!outputs_dirty) {
@@ -341,9 +341,8 @@ bool Plan::DyndepsLoaded(DependencyScan* scan, const Node* node,
 
   // Walk dyndep-discovered portion of the graph to add it to the build plan.
   std::set<Edge*> dyndep_walk;
-  for (std::vector<DyndepFile::const_iterator>::iterator oei =
-           dyndep_roots.begin();
-       oei != dyndep_roots.end(); ++oei) {
+  for (std::vector<DyndepFile::const_iterator>::iterator
+       oei = dyndep_roots.begin(); oei != dyndep_roots.end(); ++oei) {
     DyndepFile::const_iterator oe = *oei;
     for (vector<Node*>::const_iterator i = oe->second.implicit_inputs_.begin();
          i != oe->second.implicit_inputs_.end(); ++i) {
@@ -364,8 +363,8 @@ bool Plan::DyndepsLoaded(DependencyScan* scan, const Node* node,
   }
 
   // See if any encountered edges are now ready.
-  for (set<Edge*>::iterator wi = dyndep_walk.begin(); wi != dyndep_walk.end();
-       ++wi) {
+  for (set<Edge*>::iterator wi = dyndep_walk.begin();
+       wi != dyndep_walk.end(); ++wi) {
     map<Edge*, Want>::iterator want_e = want_.find(*wi);
     if (want_e == want_.end())
       continue;
@@ -385,8 +384,8 @@ bool Plan::RefreshDyndepDependents(DependencyScan* scan, const Node* node,
 
   // Update the dirty state of all dependents and check if their edges
   // have become wanted.
-  for (set<Node*>::iterator i = dependents.begin(); i != dependents.end();
-       ++i) {
+  for (set<Node*>::iterator i = dependents.begin();
+       i != dependents.end(); ++i) {
     Node* n = *i;
 
     // Check if this dependent node is now dirty.  Also checks for new cycles.
@@ -399,7 +398,8 @@ bool Plan::RefreshDyndepDependents(DependencyScan* scan, const Node* node,
     for (std::vector<Node*>::iterator v = validation_nodes.begin();
          v != validation_nodes.end(); ++v) {
       if (Edge* in_edge = (*v)->in_edge()) {
-        if (!in_edge->outputs_ready() && !AddTarget(*v, err)) {
+        if (!in_edge->outputs_ready() &&
+            !AddTarget(*v, err)) {
           return false;
         }
       }
@@ -444,8 +444,7 @@ void Plan::UnmarkDependents(const Node* node, set<Node*>* dependents) {
 
 void Plan::Dump() const {
   printf("pending: %d\n", (int)want_.size());
-  for (map<Edge*, Want>::const_iterator e = want_.begin(); e != want_.end();
-       ++e) {
+  for (map<Edge*, Want>::const_iterator e = want_.begin(); e != want_.end(); ++e) {
     if (e->second != kWantNothing)
       printf("want ");
     e->first->Dump();
@@ -482,9 +481,9 @@ void RealCommandRunner::Abort() {
 bool RealCommandRunner::CanRunMore() const {
   size_t subproc_number =
       subprocs_.running_.size() + subprocs_.finished_.size();
-  return (int)subproc_number < config_.parallelism &&
-         ((subprocs_.running_.empty() || config_.max_load_average <= 0.0f) ||
-          GetLoadAverage() < config_.max_load_average);
+  return (int)subproc_number < config_.parallelism
+    && ((subprocs_.running_.empty() || config_.max_load_average <= 0.0f)
+        || GetLoadAverage() < config_.max_load_average);
 }
 
 bool RealCommandRunner::StartCommand(Edge* edge) {
@@ -597,7 +596,8 @@ bool Builder::AddTarget(Node* target, string* err) {
   for (std::vector<Node*>::iterator n = validation_nodes.begin();
        n != validation_nodes.end(); ++n) {
     if (Edge* validation_in_edge = (*n)->in_edge()) {
-      if (!validation_in_edge->outputs_ready() && !plan_.AddTarget(*n, err)) {
+      if (!validation_in_edge->outputs_ready() &&
+          !plan_.AddTarget(*n, err)) {
         return false;
       }
     }
@@ -867,8 +867,10 @@ bool Builder::FinishCommand(CommandRunner::Result* result, string* err) {
 }
 
 bool Builder::ExtractDeps(CommandRunner::Result* result,
-                          const string& deps_type, const string& deps_prefix,
-                          vector<Node*>* deps_nodes, string* err) {
+                          const string& deps_type,
+                          const string& deps_prefix,
+                          vector<Node*>* deps_nodes,
+                          string* err) {
   if (deps_type == "msvc") {
     CLParser parser;
     string output;

--- a/src/build.cc
+++ b/src/build.cc
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+
 #include <functional>
 
 #if defined(__SVR4) && defined(__sun)
@@ -64,22 +65,19 @@ bool DryRunCommandRunner::StartCommand(Edge* edge) {
 }
 
 bool DryRunCommandRunner::WaitForCommand(Result* result) {
-   if (finished_.empty())
-     return false;
+  if (finished_.empty())
+    return false;
 
-   result->status = ExitSuccess;
-   result->edge = finished_.front();
-   finished_.pop();
-   return true;
+  result->status = ExitSuccess;
+  result->edge = finished_.front();
+  finished_.pop();
+  return true;
 }
 
 }  // namespace
 
 Plan::Plan(Builder* builder)
-  : builder_(builder)
-  , command_edges_(0)
-  , wanted_edges_(0)
-{}
+    : builder_(builder), command_edges_(0), wanted_edges_(0) {}
 
 void Plan::Reset() {
   command_edges_ = 0;
@@ -96,28 +94,29 @@ bool Plan::AddSubTarget(const Node* node, const Node* dependent, string* err,
                         set<Edge*>* dyndep_walk) {
   Edge* edge = node->in_edge();
   if (!edge) {
-     // Leaf node, this can be either a regular input from the manifest
-     // (e.g. a source file), or an implicit input from a depfile or dyndep
-     // file. In the first case, a dirty flag means the file is missing,
-     // and the build should stop. In the second, do not do anything here
-     // since there is no producing edge to add to the plan.
-     if (node->dirty() && !node->generated_by_dep_loader()) {
-       string referenced;
-       if (dependent)
-         referenced = ", needed by '" + dependent->path() + "',";
-       *err = "'" + node->path() + "'" + referenced +
-              " missing and no known rule to make it";
-     }
-     return false;
+    // Leaf node, this can be either a regular input from the manifest
+    // (e.g. a source file), or an implicit input from a depfile or dyndep
+    // file. In the first case, a dirty flag means the file is missing,
+    // and the build should stop. In the second, do not do anything here
+    // since there is no producing edge to add to the plan.
+    if (node->dirty() && !node->generated_by_dep_loader()) {
+      string referenced;
+      if (dependent)
+        referenced = ", needed by '" + dependent->path() + "',";
+      *err = "'" + node->path() + "'" + referenced +
+             " missing and no known rule to make it";
+    }
+    return false;
   }
 
   if (edge->outputs_ready())
     return false;  // Don't need to do anything.
 
   // If an entry in want_ does not already exist for edge, create an entry which
-  // maps to kWantNothing, indicating that we do not want to build this entry itself.
+  // maps to kWantNothing, indicating that we do not want to build this entry
+  // itself.
   pair<map<Edge*, Want>::iterator, bool> want_ins =
-    want_.insert(make_pair(edge, kWantNothing));
+      want_.insert(make_pair(edge, kWantNothing));
   Want& want = want_ins.first->second;
 
   if (dyndep_walk && want == kWantToFinish)
@@ -166,8 +165,9 @@ void Plan::ScheduleWork(map<Edge*, Want>::iterator want_e) {
   if (want_e->second == kWantToFinish) {
     // This edge has already been scheduled.  We can get here again if an edge
     // and one of its dependencies share an order-only input, or if a node
-    // duplicates an out edge (see https://github.com/ninja-build/ninja/pull/519).
-    // Avoid scheduling the work again.
+    // duplicates an out edge (see
+    // https://github.com/ninja-build/ninja/pull/519). Avoid scheduling the work
+    // again.
     return;
   }
   assert(want_e->second == kWantToStart);
@@ -266,9 +266,9 @@ bool Plan::CleanNode(DependencyScan* scan, Node* node, string* err) {
 
     // If all non-order-only inputs for this edge are now clean,
     // we might have changed the dirty state of the outputs.
-    vector<Node*>::iterator
-        begin = (*oe)->inputs_.begin(),
-        end = (*oe)->inputs_.end() - (*oe)->order_only_deps_;
+    vector<Node*>::iterator begin = (*oe)->inputs_.begin(),
+                            end =
+                                (*oe)->inputs_.end() - (*oe)->order_only_deps_;
 #if __cplusplus < 201703L
 #define MEM_FN mem_fun
 #else
@@ -286,8 +286,8 @@ bool Plan::CleanNode(DependencyScan* scan, Node* node, string* err) {
       // If the edge isn't dirty, clean the outputs and mark the edge as not
       // wanted.
       bool outputs_dirty = false;
-      if (!scan->RecomputeOutputsDirty(*oe, most_recent_input,
-                                       &outputs_dirty, err)) {
+      if (!scan->RecomputeOutputsDirty(*oe, most_recent_input, &outputs_dirty,
+                                       err)) {
         return false;
       }
       if (!outputs_dirty) {
@@ -341,8 +341,9 @@ bool Plan::DyndepsLoaded(DependencyScan* scan, const Node* node,
 
   // Walk dyndep-discovered portion of the graph to add it to the build plan.
   std::set<Edge*> dyndep_walk;
-  for (std::vector<DyndepFile::const_iterator>::iterator
-       oei = dyndep_roots.begin(); oei != dyndep_roots.end(); ++oei) {
+  for (std::vector<DyndepFile::const_iterator>::iterator oei =
+           dyndep_roots.begin();
+       oei != dyndep_roots.end(); ++oei) {
     DyndepFile::const_iterator oe = *oei;
     for (vector<Node*>::const_iterator i = oe->second.implicit_inputs_.begin();
          i != oe->second.implicit_inputs_.end(); ++i) {
@@ -363,8 +364,8 @@ bool Plan::DyndepsLoaded(DependencyScan* scan, const Node* node,
   }
 
   // See if any encountered edges are now ready.
-  for (set<Edge*>::iterator wi = dyndep_walk.begin();
-       wi != dyndep_walk.end(); ++wi) {
+  for (set<Edge*>::iterator wi = dyndep_walk.begin(); wi != dyndep_walk.end();
+       ++wi) {
     map<Edge*, Want>::iterator want_e = want_.find(*wi);
     if (want_e == want_.end())
       continue;
@@ -384,8 +385,8 @@ bool Plan::RefreshDyndepDependents(DependencyScan* scan, const Node* node,
 
   // Update the dirty state of all dependents and check if their edges
   // have become wanted.
-  for (set<Node*>::iterator i = dependents.begin();
-       i != dependents.end(); ++i) {
+  for (set<Node*>::iterator i = dependents.begin(); i != dependents.end();
+       ++i) {
     Node* n = *i;
 
     // Check if this dependent node is now dirty.  Also checks for new cycles.
@@ -398,8 +399,7 @@ bool Plan::RefreshDyndepDependents(DependencyScan* scan, const Node* node,
     for (std::vector<Node*>::iterator v = validation_nodes.begin();
          v != validation_nodes.end(); ++v) {
       if (Edge* in_edge = (*v)->in_edge()) {
-        if (!in_edge->outputs_ready() &&
-            !AddTarget(*v, err)) {
+        if (!in_edge->outputs_ready() && !AddTarget(*v, err)) {
           return false;
         }
       }
@@ -444,7 +444,8 @@ void Plan::UnmarkDependents(const Node* node, set<Node*>* dependents) {
 
 void Plan::Dump() const {
   printf("pending: %d\n", (int)want_.size());
-  for (map<Edge*, Want>::const_iterator e = want_.begin(); e != want_.end(); ++e) {
+  for (map<Edge*, Want>::const_iterator e = want_.begin(); e != want_.end();
+       ++e) {
     if (e->second != kWantNothing)
       printf("want ");
     e->first->Dump();
@@ -481,9 +482,9 @@ void RealCommandRunner::Abort() {
 bool RealCommandRunner::CanRunMore() const {
   size_t subproc_number =
       subprocs_.running_.size() + subprocs_.finished_.size();
-  return (int)subproc_number < config_.parallelism
-    && ((subprocs_.running_.empty() || config_.max_load_average <= 0.0f)
-        || GetLoadAverage() < config_.max_load_average);
+  return (int)subproc_number < config_.parallelism &&
+         ((subprocs_.running_.empty() || config_.max_load_average <= 0.0f) ||
+          GetLoadAverage() < config_.max_load_average);
 }
 
 bool RealCommandRunner::StartCommand(Edge* edge) {
@@ -515,18 +516,19 @@ bool RealCommandRunner::WaitForCommand(Result* result) {
   return true;
 }
 
-Builder::Builder(State* state, const BuildConfig& config,
-                 BuildLog* build_log, DepsLog* deps_log,
-                 DiskInterface* disk_interface, Status *status,
-                 int64_t start_time_millis)
-    : state_(state), config_(config), plan_(this), status_(status),
-      start_time_millis_(start_time_millis), disk_interface_(disk_interface),
-      scan_(state, build_log, deps_log, disk_interface,
-            &config_.depfile_parser_options) {
-  lock_file_path_ = ".ninja_lock";
-  string build_dir = state_->bindings_.LookupVariable("builddir");
-  if (!build_dir.empty())
-    lock_file_path_ = build_dir + "/" + lock_file_path_;
+Builder::Builder(State* const state, const BuildConfig& config,
+                 BuildLog* const build_log, DepsLog* const deps_log,
+                 DiskInterface* const disk_interface, Status* const status,
+                 const int64_t start_time_millis)
+    : state_{ state }, config_{ config }, plan_{ this }, status_{ status },
+      start_time_millis_{ start_time_millis }, lock_file_path_{ ".ninja_lock" },
+      disk_interface_{ disk_interface },
+      scan_{ state, build_log, deps_log, disk_interface,
+             &config_.depfile_parser_options } {
+  const auto build_dir = this->state_->bindings_.LookupVariable("builddir");
+  if (!build_dir.empty()) {
+    this->lock_file_path_ = build_dir + "/" + this->lock_file_path_;
+  }
 }
 
 Builder::~Builder() {
@@ -595,8 +597,7 @@ bool Builder::AddTarget(Node* target, string* err) {
   for (std::vector<Node*>::iterator n = validation_nodes.begin();
        n != validation_nodes.end(); ++n) {
     if (Edge* validation_in_edge = (*n)->in_edge()) {
-      if (!validation_in_edge->outputs_ready() &&
-          !plan_.AddTarget(*n, err)) {
+      if (!validation_in_edge->outputs_ready() && !plan_.AddTarget(*n, err)) {
         return false;
       }
     }
@@ -866,10 +867,8 @@ bool Builder::FinishCommand(CommandRunner::Result* result, string* err) {
 }
 
 bool Builder::ExtractDeps(CommandRunner::Result* result,
-                          const string& deps_type,
-                          const string& deps_prefix,
-                          vector<Node*>* deps_nodes,
-                          string* err) {
+                          const string& deps_type, const string& deps_prefix,
+                          vector<Node*>* deps_nodes, string* err) {
   if (deps_type == "msvc") {
     CLParser parser;
     string output;

--- a/src/util.cc
+++ b/src/util.cc
@@ -15,12 +15,12 @@
 #include "util.h"
 
 #ifdef __CYGWIN__
-#include <windows.h>
 #include <io.h>
-#elif defined( _WIN32)
 #include <windows.h>
+#elif defined(_WIN32)
 #include <io.h>
 #include <share.h>
+#include <windows.h>
 #endif
 
 #include <assert.h>
@@ -34,8 +34,8 @@
 #include <sys/types.h>
 
 #ifndef _WIN32
-#include <unistd.h>
 #include <sys/time.h>
+#include <unistd.h>
 #endif
 
 #include <vector>
@@ -43,14 +43,16 @@
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #elif defined(__SVR4) && defined(__sun)
-#include <unistd.h>
 #include <sys/loadavg.h>
+#include <unistd.h>
 #elif defined(_AIX) && !defined(__PASE__)
 #include <libperfstat.h>
 #elif defined(linux) || defined(__GLIBC__)
 #include <sys/sysinfo.h>
+
 #include <fstream>
 #include <map>
+
 #include "string_piece_util.h"
 #endif
 
@@ -292,12 +294,12 @@ void CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits) {
 
   for (char* c = start; c < start + *len; ++c) {
     switch (*c) {
-      case '\\':
-        bits |= bits_mask;
-        *c = '/';
-        NINJA_FALLTHROUGH;
-      case '/':
-        bits_mask <<= 1;
+    case '\\':
+      bits |= bits_mask;
+      *c = '/';
+      NINJA_FALLTHROUGH;
+    case '/':
+      bits_mask <<= 1;
     }
   }
 
@@ -308,42 +310,47 @@ void CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits) {
 }
 
 static inline bool IsKnownShellSafeCharacter(char ch) {
-  if ('A' <= ch && ch <= 'Z') return true;
-  if ('a' <= ch && ch <= 'z') return true;
-  if ('0' <= ch && ch <= '9') return true;
+  if ('A' <= ch && ch <= 'Z')
+    return true;
+  if ('a' <= ch && ch <= 'z')
+    return true;
+  if ('0' <= ch && ch <= '9')
+    return true;
 
   switch (ch) {
-    case '_':
-    case '+':
-    case '-':
-    case '.':
-    case '/':
-      return true;
-    default:
-      return false;
+  case '_':
+  case '+':
+  case '-':
+  case '.':
+  case '/':
+    return true;
+  default:
+    return false;
   }
 }
 
 static inline bool IsKnownWin32SafeCharacter(char ch) {
   switch (ch) {
-    case ' ':
-    case '"':
-      return false;
-    default:
-      return true;
+  case ' ':
+  case '"':
+    return false;
+  default:
+    return true;
   }
 }
 
 static inline bool StringNeedsShellEscaping(const string& input) {
   for (size_t i = 0; i < input.size(); ++i) {
-    if (!IsKnownShellSafeCharacter(input[i])) return true;
+    if (!IsKnownShellSafeCharacter(input[i]))
+      return true;
   }
   return false;
 }
 
 static inline bool StringNeedsWin32Escaping(const string& input) {
   for (size_t i = 0; i < input.size(); ++i) {
-    if (!IsKnownWin32SafeCharacter(input[i])) return true;
+    if (!IsKnownWin32SafeCharacter(input[i]))
+      return true;
   }
   return false;
 }
@@ -374,7 +381,6 @@ void GetShellEscapedString(const string& input, string* result) {
   result->push_back(kQuote);
 }
 
-
 void GetWin32EscapedString(const string& input, string* result) {
   assert(result);
   if (!StringNeedsWin32Escaping(input)) {
@@ -391,18 +397,18 @@ void GetWin32EscapedString(const string& input, string* result) {
   for (string::const_iterator it = input.begin(), end = input.end(); it != end;
        ++it) {
     switch (*it) {
-      case kBackslash:
-        ++consecutive_backslash_count;
-        break;
-      case kQuote:
-        result->append(span_begin, it);
-        result->append(consecutive_backslash_count + 1, kBackslash);
-        span_begin = it;
-        consecutive_backslash_count = 0;
-        break;
-      default:
-        consecutive_backslash_count = 0;
-        break;
+    case kBackslash:
+      ++consecutive_backslash_count;
+      break;
+    case kQuote:
+      result->append(span_begin, it);
+      result->append(consecutive_backslash_count + 1, kBackslash);
+      span_begin = it;
+      consecutive_backslash_count = 0;
+      break;
+    default:
+      consecutive_backslash_count = 0;
+      break;
     }
   }
   result->append(span_begin, input.end());
@@ -485,13 +491,12 @@ void SetCloseOnExec(int fd) {
       perror("fcntl(F_SETFD)");
   }
 #else
-  HANDLE hd = (HANDLE) _get_osfhandle(fd);
-  if (! SetHandleInformation(hd, HANDLE_FLAG_INHERIT, 0)) {
+  HANDLE hd = (HANDLE)_get_osfhandle(fd);
+  if (!SetHandleInformation(hd, HANDLE_FLAG_INHERIT, 0)) {
     fprintf(stderr, "SetHandleInformation(): %s", GetLastErrorString().c_str());
   }
 #endif  // ! _WIN32
 }
-
 
 const char* SpellcheckStringV(const string& text,
                               const vector<const char*>& words) {
@@ -500,10 +505,10 @@ const char* SpellcheckStringV(const string& text,
 
   int min_distance = kMaxValidEditDistance + 1;
   const char* result = NULL;
-  for (vector<const char*>::const_iterator i = words.begin();
-       i != words.end(); ++i) {
-    int distance = EditDistance(*i, text, kAllowReplacements,
-                                kMaxValidEditDistance);
+  for (vector<const char*>::const_iterator i = words.begin(); i != words.end();
+       ++i) {
+    int distance =
+        EditDistance(*i, text, kAllowReplacements, kMaxValidEditDistance);
     if (distance < min_distance) {
       min_distance = distance;
       result = *i;
@@ -530,16 +535,10 @@ string GetLastErrorString() {
   DWORD err = GetLastError();
 
   char* msg_buf;
-  FormatMessageA(
-        FORMAT_MESSAGE_ALLOCATE_BUFFER |
-        FORMAT_MESSAGE_FROM_SYSTEM |
-        FORMAT_MESSAGE_IGNORE_INSERTS,
-        NULL,
-        err,
-        MAKELANGID(LANG_ENGLISH, SUBLANG_DEFAULT),
-        (char*)&msg_buf,
-        0,
-        NULL);
+  FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                     FORMAT_MESSAGE_IGNORE_INSERTS,
+                 NULL, err, MAKELANGID(LANG_ENGLISH, SUBLANG_DEFAULT),
+                 (char*)&msg_buf, 0, NULL);
   string msg = msg_buf;
   LocalFree(msg_buf);
   return msg;
@@ -571,8 +570,11 @@ string StripAnsiEscapeCodes(const string& in) {
     }
 
     // Only strip CSIs for now.
-    if (i + 1 >= in.size()) break;
-    if (in[i + 1] != '[') continue;  // Not a CSI.
+    if (i + 1 >= in.size())
+      break;
+    if (in[i + 1] != '[')
+      // Not a CSI.
+      continue;
     i += 2;
 
     // Skip everything up to and including the next [a-zA-Z].
@@ -740,14 +742,16 @@ int GetProcessorCount() {
   // Need to use GetLogicalProcessorInformationEx to get real core count on
   // machines with >64 cores. See https://stackoverflow.com/a/31209344/21475
   DWORD len = 0;
-  if (!GetLogicalProcessorInformationEx(RelationProcessorCore, nullptr, &len)
-        && GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+  if (!GetLogicalProcessorInformationEx(RelationProcessorCore, nullptr, &len) &&
+      GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
     std::vector<char> buf(len);
     int cores = 0;
-    if (GetLogicalProcessorInformationEx(RelationProcessorCore,
-          reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
-            buf.data()), &len)) {
-      for (DWORD i = 0; i < len; ) {
+    if (GetLogicalProcessorInformationEx(
+            RelationProcessorCore,
+            reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
+                buf.data()),
+            &len)) {
+      for (DWORD i = 0; i < len;) {
         auto info = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
             buf.data() + i);
         if (info->Relationship == RelationProcessorCore &&
@@ -792,7 +796,7 @@ int GetProcessorCount() {
   cpuset_t mask;
   CPU_ZERO(&mask);
   if (cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, sizeof(mask),
-    &mask) == 0) {
+                         &mask) == 0) {
     return CPU_COUNT(&mask);
   }
 #elif defined(CPU_COUNT)
@@ -801,15 +805,17 @@ int GetProcessorCount() {
     schedCount = CPU_COUNT(&set);
   }
 #endif
-  if (cgroupCount >= 0 && schedCount >= 0) return std::min(cgroupCount, schedCount);
-  if (cgroupCount < 0 && schedCount < 0) return sysconf(_SC_NPROCESSORS_ONLN);
+  if (cgroupCount >= 0 && schedCount >= 0)
+    return std::min(cgroupCount, schedCount);
+  if (cgroupCount < 0 && schedCount < 0)
+    return sysconf(_SC_NPROCESSORS_ONLN);
   return std::max(cgroupCount, schedCount);
 #endif
 }
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-static double CalculateProcessorLoad(uint64_t idle_ticks, uint64_t total_ticks)
-{
+static double CalculateProcessorLoad(uint64_t idle_ticks,
+                                     uint64_t total_ticks) {
   static uint64_t previous_idle_ticks = 0;
   static uint64_t previous_total_ticks = 0;
   static double previous_load = -0.0;
@@ -830,7 +836,7 @@ static double CalculateProcessorLoad(uint64_t idle_ticks, uint64_t total_ticks)
     double load_since_last_call = 1.0 - idle_to_total_ratio;
 
     // Filter/smooth result when possible.
-    if(previous_load > 0) {
+    if (previous_load > 0) {
       load = 0.9 * previous_load + 0.1 * load_since_last_call;
     } else {
       load = load_since_last_call;
@@ -844,10 +850,9 @@ static double CalculateProcessorLoad(uint64_t idle_ticks, uint64_t total_ticks)
   return load;
 }
 
-static uint64_t FileTimeToTickCount(const FILETIME & ft)
-{
+static uint64_t FileTimeToTickCount(const FILETIME& ft) {
   uint64_t high = (((uint64_t)(ft.dwHighDateTime)) << 32);
-  uint64_t low  = ft.dwLowDateTime;
+  uint64_t low = ft.dwLowDateTime;
   return (high | low);
 }
 
@@ -896,7 +901,7 @@ double GetLoadAverage() {
 }
 #elif defined(__HAIKU__)
 double GetLoadAverage() {
-    return -0.0f;
+  return -0.0f;
 }
 #else
 double GetLoadAverage() {
@@ -908,23 +913,31 @@ double GetLoadAverage() {
   }
   return loadavg[0];
 }
-#endif // _WIN32
+#endif  // _WIN32
 
-string ElideMiddle(const string& str, size_t width) {
-  switch (width) {
-      case 0: return "";
-      case 1: return ".";
-      case 2: return "..";
-      case 3: return "...";
+auto ElideMiddle(const std::string& str, const std::size_t width)
+    -> std::string {
+  if (str.size() <= width) {
+    return str;
   }
-  const int kMargin = 3;  // Space for "...".
-  string result = str;
-  if (result.size() > width) {
-    size_t elide_size = (width - kMargin) / 2;
-    result = result.substr(0, elide_size)
-      + "..."
-      + result.substr(result.size() - elide_size, elide_size);
+
+  // Space for "...".
+  static constexpr auto kMargin = 3;
+  static constexpr char ellipsis[kMargin + 1] = "...";
+
+  if (width <= kMargin) {
+    return std::string{ ellipsis, width };
   }
+
+  const auto elide_size = (width - kMargin) / 2;
+
+  auto result = std::string{};
+  result.reserve(width);
+
+  result.append(str, 0, elide_size);
+  result.append(ellipsis, kMargin);
+  result.append(str, str.size() - elide_size, elide_size);
+
   return result;
 }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -15,12 +15,12 @@
 #include "util.h"
 
 #ifdef __CYGWIN__
-#include <io.h>
 #include <windows.h>
-#elif defined(_WIN32)
+#include <io.h>
+#elif defined( _WIN32)
+#include <windows.h>
 #include <io.h>
 #include <share.h>
-#include <windows.h>
 #endif
 
 #include <assert.h>
@@ -34,8 +34,8 @@
 #include <sys/types.h>
 
 #ifndef _WIN32
-#include <sys/time.h>
 #include <unistd.h>
+#include <sys/time.h>
 #endif
 
 #include <vector>
@@ -43,16 +43,14 @@
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
 #elif defined(__SVR4) && defined(__sun)
-#include <sys/loadavg.h>
 #include <unistd.h>
+#include <sys/loadavg.h>
 #elif defined(_AIX) && !defined(__PASE__)
 #include <libperfstat.h>
 #elif defined(linux) || defined(__GLIBC__)
 #include <sys/sysinfo.h>
-
 #include <fstream>
 #include <map>
-
 #include "string_piece_util.h"
 #endif
 
@@ -294,12 +292,12 @@ void CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits) {
 
   for (char* c = start; c < start + *len; ++c) {
     switch (*c) {
-    case '\\':
-      bits |= bits_mask;
-      *c = '/';
-      NINJA_FALLTHROUGH;
-    case '/':
-      bits_mask <<= 1;
+      case '\\':
+        bits |= bits_mask;
+        *c = '/';
+        NINJA_FALLTHROUGH;
+      case '/':
+        bits_mask <<= 1;
     }
   }
 
@@ -310,47 +308,42 @@ void CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits) {
 }
 
 static inline bool IsKnownShellSafeCharacter(char ch) {
-  if ('A' <= ch && ch <= 'Z')
-    return true;
-  if ('a' <= ch && ch <= 'z')
-    return true;
-  if ('0' <= ch && ch <= '9')
-    return true;
+  if ('A' <= ch && ch <= 'Z') return true;
+  if ('a' <= ch && ch <= 'z') return true;
+  if ('0' <= ch && ch <= '9') return true;
 
   switch (ch) {
-  case '_':
-  case '+':
-  case '-':
-  case '.':
-  case '/':
-    return true;
-  default:
-    return false;
+    case '_':
+    case '+':
+    case '-':
+    case '.':
+    case '/':
+      return true;
+    default:
+      return false;
   }
 }
 
 static inline bool IsKnownWin32SafeCharacter(char ch) {
   switch (ch) {
-  case ' ':
-  case '"':
-    return false;
-  default:
-    return true;
+    case ' ':
+    case '"':
+      return false;
+    default:
+      return true;
   }
 }
 
 static inline bool StringNeedsShellEscaping(const string& input) {
   for (size_t i = 0; i < input.size(); ++i) {
-    if (!IsKnownShellSafeCharacter(input[i]))
-      return true;
+    if (!IsKnownShellSafeCharacter(input[i])) return true;
   }
   return false;
 }
 
 static inline bool StringNeedsWin32Escaping(const string& input) {
   for (size_t i = 0; i < input.size(); ++i) {
-    if (!IsKnownWin32SafeCharacter(input[i]))
-      return true;
+    if (!IsKnownWin32SafeCharacter(input[i])) return true;
   }
   return false;
 }
@@ -381,6 +374,7 @@ void GetShellEscapedString(const string& input, string* result) {
   result->push_back(kQuote);
 }
 
+
 void GetWin32EscapedString(const string& input, string* result) {
   assert(result);
   if (!StringNeedsWin32Escaping(input)) {
@@ -397,18 +391,18 @@ void GetWin32EscapedString(const string& input, string* result) {
   for (string::const_iterator it = input.begin(), end = input.end(); it != end;
        ++it) {
     switch (*it) {
-    case kBackslash:
-      ++consecutive_backslash_count;
-      break;
-    case kQuote:
-      result->append(span_begin, it);
-      result->append(consecutive_backslash_count + 1, kBackslash);
-      span_begin = it;
-      consecutive_backslash_count = 0;
-      break;
-    default:
-      consecutive_backslash_count = 0;
-      break;
+      case kBackslash:
+        ++consecutive_backslash_count;
+        break;
+      case kQuote:
+        result->append(span_begin, it);
+        result->append(consecutive_backslash_count + 1, kBackslash);
+        span_begin = it;
+        consecutive_backslash_count = 0;
+        break;
+      default:
+        consecutive_backslash_count = 0;
+        break;
     }
   }
   result->append(span_begin, input.end());
@@ -491,12 +485,13 @@ void SetCloseOnExec(int fd) {
       perror("fcntl(F_SETFD)");
   }
 #else
-  HANDLE hd = (HANDLE)_get_osfhandle(fd);
-  if (!SetHandleInformation(hd, HANDLE_FLAG_INHERIT, 0)) {
+  HANDLE hd = (HANDLE) _get_osfhandle(fd);
+  if (! SetHandleInformation(hd, HANDLE_FLAG_INHERIT, 0)) {
     fprintf(stderr, "SetHandleInformation(): %s", GetLastErrorString().c_str());
   }
 #endif  // ! _WIN32
 }
+
 
 const char* SpellcheckStringV(const string& text,
                               const vector<const char*>& words) {
@@ -505,10 +500,10 @@ const char* SpellcheckStringV(const string& text,
 
   int min_distance = kMaxValidEditDistance + 1;
   const char* result = NULL;
-  for (vector<const char*>::const_iterator i = words.begin(); i != words.end();
-       ++i) {
-    int distance =
-        EditDistance(*i, text, kAllowReplacements, kMaxValidEditDistance);
+  for (vector<const char*>::const_iterator i = words.begin();
+       i != words.end(); ++i) {
+    int distance = EditDistance(*i, text, kAllowReplacements,
+                                kMaxValidEditDistance);
     if (distance < min_distance) {
       min_distance = distance;
       result = *i;
@@ -535,10 +530,16 @@ string GetLastErrorString() {
   DWORD err = GetLastError();
 
   char* msg_buf;
-  FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                     FORMAT_MESSAGE_IGNORE_INSERTS,
-                 NULL, err, MAKELANGID(LANG_ENGLISH, SUBLANG_DEFAULT),
-                 (char*)&msg_buf, 0, NULL);
+  FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL,
+        err,
+        MAKELANGID(LANG_ENGLISH, SUBLANG_DEFAULT),
+        (char*)&msg_buf,
+        0,
+        NULL);
   string msg = msg_buf;
   LocalFree(msg_buf);
   return msg;
@@ -570,11 +571,8 @@ string StripAnsiEscapeCodes(const string& in) {
     }
 
     // Only strip CSIs for now.
-    if (i + 1 >= in.size())
-      break;
-    if (in[i + 1] != '[')
-      // Not a CSI.
-      continue;
+    if (i + 1 >= in.size()) break;
+    if (in[i + 1] != '[') continue;  // Not a CSI.
     i += 2;
 
     // Skip everything up to and including the next [a-zA-Z].
@@ -742,16 +740,14 @@ int GetProcessorCount() {
   // Need to use GetLogicalProcessorInformationEx to get real core count on
   // machines with >64 cores. See https://stackoverflow.com/a/31209344/21475
   DWORD len = 0;
-  if (!GetLogicalProcessorInformationEx(RelationProcessorCore, nullptr, &len) &&
-      GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+  if (!GetLogicalProcessorInformationEx(RelationProcessorCore, nullptr, &len)
+        && GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
     std::vector<char> buf(len);
     int cores = 0;
-    if (GetLogicalProcessorInformationEx(
-            RelationProcessorCore,
-            reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
-                buf.data()),
-            &len)) {
-      for (DWORD i = 0; i < len;) {
+    if (GetLogicalProcessorInformationEx(RelationProcessorCore,
+          reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
+            buf.data()), &len)) {
+      for (DWORD i = 0; i < len; ) {
         auto info = reinterpret_cast<PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX>(
             buf.data() + i);
         if (info->Relationship == RelationProcessorCore &&
@@ -796,7 +792,7 @@ int GetProcessorCount() {
   cpuset_t mask;
   CPU_ZERO(&mask);
   if (cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, sizeof(mask),
-                         &mask) == 0) {
+    &mask) == 0) {
     return CPU_COUNT(&mask);
   }
 #elif defined(CPU_COUNT)
@@ -805,17 +801,15 @@ int GetProcessorCount() {
     schedCount = CPU_COUNT(&set);
   }
 #endif
-  if (cgroupCount >= 0 && schedCount >= 0)
-    return std::min(cgroupCount, schedCount);
-  if (cgroupCount < 0 && schedCount < 0)
-    return sysconf(_SC_NPROCESSORS_ONLN);
+  if (cgroupCount >= 0 && schedCount >= 0) return std::min(cgroupCount, schedCount);
+  if (cgroupCount < 0 && schedCount < 0) return sysconf(_SC_NPROCESSORS_ONLN);
   return std::max(cgroupCount, schedCount);
 #endif
 }
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-static double CalculateProcessorLoad(uint64_t idle_ticks,
-                                     uint64_t total_ticks) {
+static double CalculateProcessorLoad(uint64_t idle_ticks, uint64_t total_ticks)
+{
   static uint64_t previous_idle_ticks = 0;
   static uint64_t previous_total_ticks = 0;
   static double previous_load = -0.0;
@@ -836,7 +830,7 @@ static double CalculateProcessorLoad(uint64_t idle_ticks,
     double load_since_last_call = 1.0 - idle_to_total_ratio;
 
     // Filter/smooth result when possible.
-    if (previous_load > 0) {
+    if(previous_load > 0) {
       load = 0.9 * previous_load + 0.1 * load_since_last_call;
     } else {
       load = load_since_last_call;
@@ -850,9 +844,10 @@ static double CalculateProcessorLoad(uint64_t idle_ticks,
   return load;
 }
 
-static uint64_t FileTimeToTickCount(const FILETIME& ft) {
+static uint64_t FileTimeToTickCount(const FILETIME & ft)
+{
   uint64_t high = (((uint64_t)(ft.dwHighDateTime)) << 32);
-  uint64_t low = ft.dwLowDateTime;
+  uint64_t low  = ft.dwLowDateTime;
   return (high | low);
 }
 
@@ -901,7 +896,7 @@ double GetLoadAverage() {
 }
 #elif defined(__HAIKU__)
 double GetLoadAverage() {
-  return -0.0f;
+    return -0.0f;
 }
 #else
 double GetLoadAverage() {
@@ -913,10 +908,9 @@ double GetLoadAverage() {
   }
   return loadavg[0];
 }
-#endif  // _WIN32
+#endif // _WIN32
 
-auto ElideMiddle(const std::string& str, const std::size_t width)
-    -> std::string {
+std::string ElideMiddle(const std::string& str, const std::size_t width) {
   if (str.size() <= width) {
     return str;
   }


### PR DESCRIPTION
Also clang-formatted the edited files.

Edit:

```
$ cppcheck --version
Cppcheck 2.12.0
$ cppcheck --enable=performance -f --std=c++11 .

ninja/src/build.cc:526:3: performance: Variable 'lock_file_path_' is assigned in constructor body. Consider performing initialization in initialization list. [useInitializationList]
  lock_file_path_ = ".ninja_lock";
  ^

ninja/src/util.cc:924:14: performance: Ineffective call of function 'substr' because a prefix of the string is assigned to itself. Use replace() instead. [uselessCallsSubstr]
    result = result.substr(0, elide_size)
             ^
```

For the latter, after reading what it would be with `result.replace(...)`, it seemed better to limit allocations and copies by reserving the length `width` and appending the necessary strings.

Used `git clang-format` rather than `clang-format` entire files.