### PR TITLE
correction to #2360

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,9 +255,9 @@ if(BUILD_TESTING)
 
       # NOTE: gtest uninit some variables, gcc >= 1.11.3 may cause error on compile.
       # Remove this comment and six lines below, once ninja deps gtest-1.11.0 or above.
-      if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "1.11.3")
-        check_cxx_compiler_flag(-Wno-maybe-uninitialized flag_no_maybe_uninit)
-        if (flag_no_maybe_uninit)
+      if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "1.11.3")
+        check_cxx_compiler_flag(-Wmaybe-uninitialized flag_maybe_uninit)
+        if (flag_maybe_uninit)
           target_compile_options(gtest PRIVATE -Wno-maybe-uninitialized)
         endif()
       endif()


### PR DESCRIPTION
in general, flags check have to be to the non-no option. Updates use of deprecated CMake command.

```cmake
check_cxx_compiler_flag(-Wno-i-dont-have-this-flag x)
```

"x" will always be true. However, this behaves as expected

```cmake
check_cxx_compiler_flag(-Wi-dont-have-this-flag x)
```