### PR TITLE
added missing include guards in order to support easy amalgamation

### DIFF
--- a/src/includes_normalize.h
+++ b/src/includes_normalize.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef INCLUDES_NORMALIZE_H_
+#define INCLUDES_NORMALIZE_H_
+
 #include <string>
 #include <vector>
 
@@ -38,3 +41,5 @@ struct IncludesNormalize {
   std::string relative_to_;
   std::vector<StringPiece> split_relative_to_;
 };
+
+#endif  // INCLUDES_NORMALIZE_H_

--- a/src/msvc_helper.h
+++ b/src/msvc_helper.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef MSVC_HELPER_H_
+#define MSVC_HELPER_H_
+
 #include <string>
 
 std::string EscapeForDepfile(const std::string& path);
@@ -30,3 +33,5 @@ struct CLWrapper {
 
   void* env_block_;
 };
+
+#endif  // MSVC_HELPER_H_


### PR DESCRIPTION
These changes make it easy to build an amalgamated `ninja.cc` that can be used to bootstrap `ninja` with just a working C++ compiler, without the need for any third-party tools like `cmake` or `python`.

## *nix

```bash
c++ -O2 src/ninja_amalgamated.cc -o ninja
```

## osx-cross

```bash
x86_64-apple-darwin19-c++ -O2 src/ninja_amalgamated.cc -o ninja
```

## mingw

```bash
x86_64-w64-mingw32-c++ -O2 src/ninja_amalgamated.cc -o ninja.exe
```

## msvc

```bash
cl.exe /nologo /Ox /GR- src\ninja_amalgamated.cc /out:ninja.exe
```