### PR TITLE
Gracefully handle outdated .ninja_log during '-t recompact'

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -127,6 +127,29 @@ build a: cat
         self.assertEqual(run('', flags='-t recompact'), '')
         self.assertEqual(run('', flags='-t restat'), '')
 
+    def test_issue_2048(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, 'build.ninja'), 'w'):
+                pass
+
+            with open(os.path.join(d, '.ninja_log'), 'w') as f:
+                f.write('# ninja log v4\n')
+
+            try:
+                output = subprocess.check_output([NINJA_PATH, '-t', 'recompact'],
+                                                 cwd=d,
+                                                 env=default_env,
+                                                 stderr=subprocess.STDOUT,
+                                                 text=True
+                                                 )
+
+                self.assertEqual(
+                    output.strip(),
+                    "ninja: warning: build log version is too old; starting over"
+                )
+            except subprocess.CalledProcessError as err:
+                self.fail("non-zero exit code with: " + err.output)
+
     def test_status(self):
         self.assertEqual(run(''), 'ninja: no work to do.\n')
         self.assertEqual(run('', pipe=True), 'ninja: no work to do.\n')

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -291,9 +291,9 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
       if (invalid_log_version) {
         fclose(file);
         unlink(path.c_str());
-        // Don't report this as a failure.  An empty build log will cause
+        // Don't report this as a failure. A missing build log will cause
         // us to rebuild the outputs anyway.
-        return LOAD_SUCCESS;
+        return LOAD_NOT_FOUND;
       }
     }
 


### PR DESCRIPTION
Fixes #2048

I ran into a similar issue when migrating existing workspaces from ninja 1.9.0 to the latest revision from Git.

This change will cause `NinjaMain::OpenBuildLog()` to not call `build_log_.Recompact()` after `build_log_.Load()` just deleted that file because it contained an invalid log version.