### PR TITLE
Support empty depfiles.

### DIFF
--- a/src/depfile_parser.cc
+++ b/src/depfile_parser.cc
@@ -54,6 +54,7 @@ bool DepfileParser::Parse(string* content, string* err) {
   bool have_target = false;
   bool parsing_targets = true;
   bool poisoned_input = false;
+  bool is_empty = true;
   while (in < end) {
     bool have_newline = false;
     // out: current output point (typically same as in, but can fall behind
@@ -335,6 +336,7 @@ yy32:
     }
 
     if (len > 0) {
+      is_empty = false;
       StringPiece piece = StringPiece(filename, len);
       // If we've seen this as an input before, skip it.
       std::vector<StringPiece>::iterator pos = std::find(ins_.begin(), ins_.end(), piece);
@@ -363,7 +365,7 @@ yy32:
       poisoned_input = false;
     }
   }
-  if (!have_target) {
+  if (!have_target && !is_empty) {
     *err = "expected ':' in depfile";
     return false;
   }

--- a/src/depfile_parser.in.cc
+++ b/src/depfile_parser.in.cc
@@ -53,6 +53,7 @@ bool DepfileParser::Parse(string* content, string* err) {
   bool have_target = false;
   bool parsing_targets = true;
   bool poisoned_input = false;
+  bool is_empty = true;
   while (in < end) {
     bool have_newline = false;
     // out: current output point (typically same as in, but can fall behind
@@ -171,6 +172,7 @@ bool DepfileParser::Parse(string* content, string* err) {
     }
 
     if (len > 0) {
+      is_empty = false;
       StringPiece piece = StringPiece(filename, len);
       // If we've seen this as an input before, skip it.
       std::vector<StringPiece>::iterator pos = std::find(ins_.begin(), ins_.end(), piece);
@@ -199,7 +201,7 @@ bool DepfileParser::Parse(string* content, string* err) {
       poisoned_input = false;
     }
   }
-  if (!have_target) {
+  if (!have_target && !is_empty) {
     *err = "expected ':' in depfile";
     return false;
   }

--- a/src/depfile_parser_test.cc
+++ b/src/depfile_parser_test.cc
@@ -378,3 +378,24 @@ TEST_F(DepfileParserTest, BuggyMP) {
                      "z:\n", &err));
   ASSERT_EQ("inputs may not also have inputs", err);
 }
+
+TEST_F(DepfileParserTest, EmptyFile) {
+  std::string err;
+  EXPECT_TRUE(Parse("", &err));
+  ASSERT_EQ(0u, parser_.outs_.size());
+  ASSERT_EQ(0u, parser_.ins_.size());
+}
+
+TEST_F(DepfileParserTest, EmptyLines) {
+  std::string err;
+  EXPECT_TRUE(Parse("\n\n", &err));
+  ASSERT_EQ(0u, parser_.outs_.size());
+  ASSERT_EQ(0u, parser_.ins_.size());
+}
+
+TEST_F(DepfileParserTest, MissingColon) {
+  // The file is not empty but is missing a colon separator.
+  std::string err;
+  EXPECT_FALSE(Parse("foo.o foo.c\n", &err));
+  EXPECT_EQ("expected ':' in depfile", err);
+}


### PR DESCRIPTION
Some tools generate completely empty depfiles when there are no implicit inputs. This patch modifies the depfile parser to support them. Fixes #2357