### PR TITLE
lexer: allow TABS for indentation

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -861,7 +861,13 @@ one_word_with_no_space = foo$
 Other whitespace is only significant if it's at the beginning of a
 line.  If a line is indented more than the previous one, it's
 considered part of its parent's scope; if it is indented less than the
-previous one, it closes the previous scope.
+previous one, it closes the previous scope. Note that the physical line that is
+a line continuation is not considered as a separate line for the scope
+determination purposes.
+
+_Available since Ninja 1.13._
+Tab character can be used for indentation. Earlier Ninja versions allow only
+space character to be used for such purpose.
 
 [[ref_toplevel]]
 Top-level variables

--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -191,6 +191,30 @@ out1
 out2
 ''')
 
+    def test_tabs_indent(self):
+        content = '''
+rule exec
+<TAB>command = $cmd
+
+var_hello = hell$
+<TAB>o
+
+build foo: exec
+<TAB>cmd = touch foo
+
+build bar: exec $
+<TAB>foo
+<TAB>cmd = touch bar
+
+build $var_hello: exec
+<TAB>cmd = touch $var_hello
+
+build baz: exec $
+<TAB>bar $var_hello
+<TAB>cmd = touch baz
+'''.replace('<TAB>', '\t')
+        run(content)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/lexer.in.cc
+++ b/src/lexer.in.cc
@@ -104,12 +104,9 @@ const char* Lexer::TokenErrorHint(Token expected) {
 
 string Lexer::DescribeLastError() {
   if (last_token_) {
-    switch (last_token_[0]) {
-    case '\t':
-      return "tabs are not allowed, use spaces";
-    }
+	return "lexing error <last token:"+string(last_token_)+">";
   }
-  return "lexing error";
+  return "lexing error (EOF?)";
 }
 
 void Lexer::UnreadToken() {
@@ -133,10 +130,10 @@ Lexer::Token Lexer::ReadToken() {
     simple_varname = [a-zA-Z0-9_-]+;
     varname = [a-zA-Z0-9_.-]+;
 
-    [ ]*"#"[^\000\n]*"\n" { continue; }
-    [ ]*"\r\n" { token = NEWLINE;  break; }
-    [ ]*"\n"   { token = NEWLINE;  break; }
-    [ ]+       { token = INDENT;   break; }
+    [ \t]*"#"[^\000\n]*"\n" { continue; }
+    [ \t]*"\r\n" { token = NEWLINE;  break; }
+    [ \t]*"\n"   { token = NEWLINE;  break; }
+    [ \t]+       { token = INDENT;   break; }
     "build"    { token = BUILD;    break; }
     "pool"     { token = POOL;     break; }
     "rule"     { token = RULE;     break; }
@@ -175,7 +172,7 @@ void Lexer::EatWhitespace() {
   for (;;) {
     ofs_ = p;
     /*!re2c
-    [ ]+    { continue; }
+    [ \t]+  { continue; }
     "$\r\n" { continue; }
     "$\n"   { continue; }
     nul     { break; }
@@ -241,10 +238,10 @@ bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
       eval->AddText(StringPiece(" ", 1));
       continue;
     }
-    "$\r\n"[ ]* {
+    "$\r\n"[ \t]* {
       continue;
     }
-    "$\n"[ ]* {
+    "$\n"[ \t]* {
       continue;
     }
     "${"varname"}" {


### PR DESCRIPTION
Allow TAB character to be used for indentation.

This is useful to have TAB character used as indentation, especially when parts of build.ninja are hand-written as HEREDOCs in otherwise TAB-indented file (either mandated by style for other part of project, or required by language itself).

Changing lexer is easy thanks to the use of re2c, syntax is perhaps a bit too permissive now, but that is job of the parser to reject use of mixed indentation.

Let's stop complaining that:
ninja: error: build.ninja:3: expected 'command =' line when it is exactly:
	command = cc $cflags -c $in -o $out

Closes #1598
Signed-of-by: Przemek Kitszel <pkitszel@gmail.com>