### PR TITLE
Fix cleanded with dyndeps

### DIFF
--- a/src/clean.cc
+++ b/src/clean.cc
@@ -127,6 +127,7 @@ int Cleaner::CleanAll(bool generator) {
 int Cleaner::CleanDead(const BuildLog::Entries& entries) {
   Reset();
   PrintHeader();
+  LoadDyndeps();
   for (BuildLog::Entries::const_iterator i = entries.begin(); i != entries.end(); ++i) {
     Node* n = state_->LookupNode(i->first);
     // Detecting stale outputs works as follows:

--- a/src/clean.cc
+++ b/src/clean.cc
@@ -293,7 +293,8 @@ void Cleaner::LoadDyndeps() {
   // Load dyndep files that exist, before they are cleaned.
   for (vector<Edge*>::iterator e = state_->edges_.begin();
        e != state_->edges_.end(); ++e) {
-    if (Node* dyndep = (*e)->dyndep_) {
+    Node* dyndep;
+    if ((dyndep = (*e)->dyndep_) && dyndep->dyndep_pending()) {
       // Capture and ignore errors loading the dyndep file.
       // We clean as much of the graph as we know.
       std::string err;


### PR DESCRIPTION
Correctly account for dyndep files when cleaning dead, so that dynamic outputs aren't considered dead when they are not.

This is basically the same as #2215. I've used the commit messages that @bradking suggested in that PR for these commits.