### PR TITLE
Implement type hints in remaining python files

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -24,15 +24,19 @@ import os
 import shlex
 import subprocess
 import sys
+from typing import Optional, Union, Dict, List, Any, TYPE_CHECKING
 
 sourcedir = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(sourcedir, 'misc'))
-import ninja_syntax
+if TYPE_CHECKING:
+    import misc.ninja_syntax as ninja_syntax
+else:
+    import ninja_syntax
 
 
 class Platform(object):
     """Represents a host/target platform and its specific build attributes."""
-    def __init__(self, platform):
+    def __init__(self, platform: Optional[str]) -> None:
         self._platform = platform
         if self._platform is not None:
             return
@@ -63,55 +67,55 @@ class Platform(object):
             self._platform = 'dragonfly'
 
     @staticmethod
-    def known_platforms():
+    def known_platforms() -> List[str]:
       return ['linux', 'darwin', 'freebsd', 'openbsd', 'solaris', 'sunos5',
               'mingw', 'msvc', 'gnukfreebsd', 'bitrig', 'netbsd', 'aix',
               'dragonfly']
 
-    def platform(self):
-        return self._platform
+    def platform(self) -> str:
+        return self._platform  # type: ignore # Incompatible return value type
 
-    def is_linux(self):
+    def is_linux(self) -> bool:
         return self._platform == 'linux'
 
-    def is_mingw(self):
+    def is_mingw(self) -> bool:
         return self._platform == 'mingw'
 
-    def is_msvc(self):
+    def is_msvc(self) -> bool:
         return self._platform == 'msvc'
 
-    def msvc_needs_fs(self):
+    def msvc_needs_fs(self) -> bool:
         popen = subprocess.Popen(['cl', '/nologo', '/help'],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         out, err = popen.communicate()
         return b'/FS' in out
 
-    def is_windows(self):
+    def is_windows(self) -> bool:
         return self.is_mingw() or self.is_msvc()
 
-    def is_solaris(self):
+    def is_solaris(self) -> bool:
         return self._platform == 'solaris'
 
-    def is_aix(self):
+    def is_aix(self) -> bool:
         return self._platform == 'aix'
 
-    def is_os400_pase(self):
-        return self._platform == 'os400' or os.uname().sysname.startswith('OS400')
+    def is_os400_pase(self) -> bool:
+        return self._platform == 'os400' or os.uname().sysname.startswith('OS400')  # type: ignore # Module has no attribute "uname"
 
-    def uses_usr_local(self):
+    def uses_usr_local(self) -> bool:
         return self._platform in ('freebsd', 'openbsd', 'bitrig', 'dragonfly', 'netbsd')
 
-    def supports_ppoll(self):
+    def supports_ppoll(self) -> bool:
         return self._platform in ('freebsd', 'linux', 'openbsd', 'bitrig',
                                   'dragonfly')
 
-    def supports_ninja_browse(self):
+    def supports_ninja_browse(self) -> bool:
         return (not self.is_windows()
                 and not self.is_solaris()
                 and not self.is_aix())
 
-    def can_rebuild_in_place(self):
+    def can_rebuild_in_place(self) -> bool:
         return not (self.is_windows() or self.is_aix())
 
 class Bootstrap:
@@ -122,37 +126,43 @@ class Bootstrap:
     It also proxies all calls to an underlying ninja_syntax.Writer, to
     behave like non-bootstrap mode.
     """
-    def __init__(self, writer, verbose=False):
+    def __init__(self, writer: ninja_syntax.Writer, verbose: bool = False) -> None:
         self.writer = writer
         self.verbose = verbose
         # Map of variable name => expanded variable value.
-        self.vars = {}
+        self.vars: Dict[str, str] = {}
         # Map of rule name => dict of rule attributes.
-        self.rules = {
+        self.rules: Dict[str, Dict[str, Any]] = {
             'phony': {}
         }
 
-    def comment(self, text):
+    def comment(self, text: str) -> None:
         return self.writer.comment(text)
 
-    def newline(self):
+    def newline(self) -> None:
         return self.writer.newline()
 
-    def variable(self, key, val):
+    def variable(self, key: str, val: str) -> None:
         # In bootstrap mode, we have no ninja process to catch /showIncludes
         # output.
         self.vars[key] = self._expand(val).replace('/showIncludes', '')
         return self.writer.variable(key, val)
 
-    def rule(self, name, **kwargs):
+    def rule(self, name: str, **kwargs: Any) -> None:
         self.rules[name] = kwargs
         return self.writer.rule(name, **kwargs)
 
-    def build(self, outputs, rule, inputs=None, **kwargs):
+    def build(
+        self,
+        outputs: Union[str, List[str]],
+        rule: str,
+        inputs: Optional[Union[str, List[str]]] = None,
+        **kwargs: Any
+    ) -> List[str]:
         ruleattr = self.rules[rule]
         cmd = ruleattr.get('command')
         if cmd is None:  # A phony rule, for example.
-            return
+            return  # type: ignore # Return value expected
 
         # Implement just enough of Ninja variable expansion etc. to
         # make the bootstrap build work.
@@ -167,23 +177,23 @@ class Bootstrap:
 
         return self.writer.build(outputs, rule, inputs, **kwargs)
 
-    def default(self, paths):
+    def default(self, paths: Union[str, List[str]]) -> None:
         return self.writer.default(paths)
 
-    def _expand_paths(self, paths):
+    def _expand_paths(self, paths: Optional[Union[str, List[str]]]) -> str:
         """Expand $vars in an array of paths, e.g. from a 'build' block."""
         paths = ninja_syntax.as_list(paths)
         return ' '.join(map(self._shell_escape, (map(self._expand, paths))))
 
-    def _expand(self, str, local_vars={}):
+    def _expand(self, str: str, local_vars: Dict[str, str] = {}) -> str:
         """Expand $vars in a string."""
         return ninja_syntax.expand(str, self.vars, local_vars)
 
-    def _shell_escape(self, path):
+    def _shell_escape(self, path: str) -> str:
         """Quote paths containing spaces."""
         return '"%s"' % path if ' ' in path else path
 
-    def _run_command(self, cmdline):
+    def _run_command(self, cmdline: str) -> None:
         """Run a subcommand, quietly.  Prints the full command on error."""
         try:
             if self.verbose:
@@ -233,7 +243,7 @@ else:
 
 BUILD_FILENAME = 'build.ninja'
 ninja_writer = ninja_syntax.Writer(open(BUILD_FILENAME, 'w'))
-n = ninja_writer
+n: Union[ninja_syntax.Writer, Bootstrap] = ninja_writer
 
 if options.bootstrap:
     # Make the build directory.
@@ -244,7 +254,7 @@ if options.bootstrap:
     # Wrap ninja_writer with the Bootstrapper, which also executes the
     # commands.
     print('bootstrapping ninja...')
-    n = Bootstrap(n, verbose=options.verbose)
+    n = Bootstrap(n, verbose=options.verbose)  # type: ignore # Incompatible types in assignment
 
 n.comment('This file is used to build ninja itself.')
 n.comment('It is generated by ' + os.path.basename(__file__) + '.')
@@ -272,17 +282,17 @@ if platform.is_msvc():
     CXX = 'cl'
     objext = '.obj'
 
-def src(filename):
+def src(filename: str) -> str:
     return os.path.join('$root', 'src', filename)
-def built(filename):
+def built(filename: str) -> str:
     return os.path.join('$builddir', filename)
-def doc(filename):
+def doc(filename: str) -> str:
     return os.path.join('$root', 'doc', filename)
-def cc(name, **kwargs):
+def cc(name: str, **kwargs: Any) -> List[str]:
     return n.build(built(name + objext), 'cxx', src(name + '.c'), **kwargs)
-def cxx(name, **kwargs):
+def cxx(name: str, **kwargs: Any) -> List[str]:
     return n.build(built(name + objext), 'cxx', src(name + '.cc'), **kwargs)
-def binary(name):
+def binary(name: str) -> str:
     if platform.is_windows():
         exe = name + '.exe'
         n.build(name, 'phony', exe)
@@ -302,7 +312,7 @@ if platform.is_msvc():
 else:
     n.variable('ar', configure_env.get('AR', 'ar'))
 
-def search_system_path(file_name):
+def search_system_path(file_name: str) -> Optional[str]:  # type: ignore # Missing return statement
   """Find a file in the system path."""
   for dir in os.environ['path'].split(';'):
     path = os.path.join(dir, file_name)
@@ -404,7 +414,7 @@ if platform.supports_ninja_browse():
 # Search for generated headers relative to build dir.
 cflags.append('-I.')
 
-def shell_escape(str):
+def shell_escape(str: str) -> str:
     """Escape str such that it's interpreted as a single argument by
     the shell."""
 
@@ -481,7 +491,7 @@ if platform.supports_ninja_browse():
     n.newline()
 
 n.comment('the depfile parser and ninja lexers are generated using re2c.')
-def has_re2c():
+def has_re2c() -> bool:
     try:
         proc = subprocess.Popen(['re2c', '-V'], stdout=subprocess.PIPE)
         return int(proc.communicate()[0], 10) >= 1503
@@ -672,7 +682,7 @@ if host.is_linux():
 
 n.build('all', 'phony', all_targets)
 
-n.close()
+n.close()  # type: ignore # Item "Bootstrap" of "Writer | Bootstrap" has no attribute "close"
 print('wrote %s.' % BUILD_FILENAME)
 
 if options.bootstrap:

--- a/misc/ci.py
+++ b/misc/ci.py
@@ -12,7 +12,7 @@ ignores = [
 
 error_count = 0
 
-def error(path, msg):
+def error(path: str, msg: str) -> None:
 	global error_count
 	error_count += 1
 	print('\x1b[1;31m{}\x1b[0;31m{}\x1b[0m'.format(path, msg))

--- a/misc/measure.py
+++ b/misc/measure.py
@@ -20,10 +20,11 @@
 import time
 import subprocess
 import sys
+from typing import Union, List
 
 devnull = open('/dev/null', 'w')
 
-def run(cmd, repeat=10):
+def run(cmd: Union[str, List[str]], repeat: int = 10) -> None:
     print('sampling:', end=' ')
     sys.stdout.flush()
 

--- a/misc/ninja_syntax_test.py
+++ b/misc/ninja_syntax_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import unittest
+from typing import Dict
 
 try:
     from StringIO import StringIO
@@ -28,16 +29,16 @@ LONGWORDWITHSPACES = 'a'*5 + '$ ' + 'a'*5
 INDENT = '    '
 
 class TestLineWordWrap(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.out = StringIO()
         self.n = ninja_syntax.Writer(self.out, width=8)
 
-    def test_single_long_word(self):
+    def test_single_long_word(self) -> None:
         # We shouldn't wrap a single long word.
         self.n._line(LONGWORD)
         self.assertEqual(LONGWORD + '\n', self.out.getvalue())
 
-    def test_few_long_words(self):
+    def test_few_long_words(self) -> None:
         # We should wrap a line where the second word is overlong.
         self.n._line(' '.join(['x', LONGWORD, 'y']))
         self.assertEqual(' $\n'.join(['x',
@@ -45,13 +46,13 @@ class TestLineWordWrap(unittest.TestCase):
                                       INDENT + 'y']) + '\n',
                          self.out.getvalue())
 
-    def test_comment_wrap(self):
+    def test_comment_wrap(self) -> None:
         # Filenames should not be wrapped
         self.n.comment('Hello /usr/local/build-tools/bin')
         self.assertEqual('# Hello\n# /usr/local/build-tools/bin\n',
                          self.out.getvalue())
 
-    def test_short_words_indented(self):
+    def test_short_words_indented(self) -> None:
         # Test that indent is taking into account when breaking subsequent lines.
         # The second line should not be '    to tree', as that's longer than the
         # test layout width of 8.
@@ -63,7 +64,7 @@ line_one $
 ''',
                          self.out.getvalue())
 
-    def test_few_long_words_indented(self):
+    def test_few_long_words_indented(self) -> None:
         # Check wrapping in the presence of indenting.
         self.n._line(' '.join(['x', LONGWORD, 'y']), indent=1)
         self.assertEqual(' $\n'.join(['  ' + 'x',
@@ -71,14 +72,14 @@ line_one $
                                       '  ' + INDENT + 'y']) + '\n',
                          self.out.getvalue())
 
-    def test_escaped_spaces(self):
+    def test_escaped_spaces(self) -> None:
         self.n._line(' '.join(['x', LONGWORDWITHSPACES, 'y']))
         self.assertEqual(' $\n'.join(['x',
                                       INDENT + LONGWORDWITHSPACES,
                                       INDENT + 'y']) + '\n',
                          self.out.getvalue())
 
-    def test_fit_many_words(self):
+    def test_fit_many_words(self) -> None:
         self.n = ninja_syntax.Writer(self.out, width=78)
         self.n._line('command = cd ../../chrome; python ../tools/grit/grit/format/repack.py ../out/Debug/obj/chrome/chrome_dll.gen/repack/theme_resources_large.pak ../out/Debug/gen/chrome/theme_resources_large.pak', 1)
         self.assertEqual('''\
@@ -88,7 +89,7 @@ line_one $
 ''',
                          self.out.getvalue())
 
-    def test_leading_space(self):
+    def test_leading_space(self) -> None:
         self.n = ninja_syntax.Writer(self.out, width=14)  # force wrapping
         self.n.variable('foo', ['', '-bar', '-somethinglong'], 0)
         self.assertEqual('''\
@@ -97,7 +98,7 @@ foo = -bar $
 ''',
                          self.out.getvalue())
 
-    def test_embedded_dollar_dollar(self):
+    def test_embedded_dollar_dollar(self) -> None:
         self.n = ninja_syntax.Writer(self.out, width=15)  # force wrapping
         self.n.variable('foo', ['a$$b', '-somethinglong'], 0)
         self.assertEqual('''\
@@ -106,7 +107,7 @@ foo = a$$b $
 ''',
                          self.out.getvalue())
 
-    def test_two_embedded_dollar_dollars(self):
+    def test_two_embedded_dollar_dollars(self) -> None:
         self.n = ninja_syntax.Writer(self.out, width=17)  # force wrapping
         self.n.variable('foo', ['a$$b', '-somethinglong'], 0)
         self.assertEqual('''\
@@ -115,7 +116,7 @@ foo = a$$b $
 ''',
                          self.out.getvalue())
 
-    def test_leading_dollar_dollar(self):
+    def test_leading_dollar_dollar(self) -> None:
         self.n = ninja_syntax.Writer(self.out, width=14)  # force wrapping
         self.n.variable('foo', ['$$b', '-somethinglong'], 0)
         self.assertEqual('''\
@@ -124,7 +125,7 @@ foo = $$b $
 ''',
                          self.out.getvalue())
 
-    def test_trailing_dollar_dollar(self):
+    def test_trailing_dollar_dollar(self) -> None:
         self.n = ninja_syntax.Writer(self.out, width=14)  # force wrapping
         self.n.variable('foo', ['a$$', '-somethinglong'], 0)
         self.assertEqual('''\
@@ -134,11 +135,11 @@ foo = a$$ $
                          self.out.getvalue())
 
 class TestBuild(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.out = StringIO()
         self.n = ninja_syntax.Writer(self.out)
 
-    def test_variables_dict(self):
+    def test_variables_dict(self) -> None:
         self.n.build('out', 'cc', 'in', variables={'name': 'value'})
         self.assertEqual('''\
 build out: cc in
@@ -146,7 +147,7 @@ build out: cc in
 ''',
                          self.out.getvalue())
 
-    def test_variables_list(self):
+    def test_variables_list(self) -> None:
         self.n.build('out', 'cc', 'in', variables=[('name', 'value')])
         self.assertEqual('''\
 build out: cc in
@@ -154,7 +155,7 @@ build out: cc in
 ''',
                          self.out.getvalue())
 
-    def test_implicit_outputs(self):
+    def test_implicit_outputs(self) -> None:
         self.n.build('o', 'cc', 'i', implicit_outputs='io')
         self.assertEqual('''\
 build o | io: cc i
@@ -162,29 +163,29 @@ build o | io: cc i
                          self.out.getvalue())
 
 class TestExpand(unittest.TestCase):
-    def test_basic(self):
+    def test_basic(self) -> None:
         vars = {'x': 'X'}
         self.assertEqual('foo', ninja_syntax.expand('foo', vars))
 
-    def test_var(self):
+    def test_var(self) -> None:
         vars = {'xyz': 'XYZ'}
         self.assertEqual('fooXYZ', ninja_syntax.expand('foo$xyz', vars))
 
-    def test_vars(self):
+    def test_vars(self) -> None:
         vars = {'x': 'X', 'y': 'YYY'}
         self.assertEqual('XYYY', ninja_syntax.expand('$x$y', vars))
 
-    def test_space(self):
-        vars = {}
+    def test_space(self) -> None:
+        vars: Dict[str, str] = {}
         self.assertEqual('x y z', ninja_syntax.expand('x$ y$ z', vars))
 
-    def test_locals(self):
+    def test_locals(self) -> None:
         vars = {'x': 'a'}
         local_vars = {'x': 'b'}
         self.assertEqual('a', ninja_syntax.expand('$x', vars))
         self.assertEqual('b', ninja_syntax.expand('$x', vars, local_vars))
 
-    def test_double(self):
+    def test_double(self) -> None:
         self.assertEqual('a b$c', ninja_syntax.expand('a$ b$$c', {}))
 
 if __name__ == '__main__':

--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from typing import Dict
 
 default_env = dict(os.environ)
 default_env.pop('NINJA_STATUS', None)
@@ -18,7 +19,12 @@ default_env.pop('CLICOLOR_FORCE', None)
 default_env['TERM'] = ''
 NINJA_PATH = os.path.abspath('./ninja')
 
-def run(build_ninja, flags='', pipe=False, env=default_env):
+def run(
+    build_ninja: str,
+    flags: str = '',
+    pipe: bool = False,
+    env: Dict[str, str] = default_env,
+) -> str:
     with tempfile.TemporaryDirectory() as d:
         with open(os.path.join(d, 'build.ninja'), 'w') as f:
             f.write(build_ninja)
@@ -54,7 +60,7 @@ class Output(unittest.TestCase):
         '',
     ))
 
-    def test_issue_1418(self):
+    def test_issue_1418(self) -> None:
         self.assertEqual(run(
 '''rule echo
   command = sleep $delay && echo $out
@@ -75,7 +81,7 @@ b
 a
 ''')
 
-    def test_issue_1214(self):
+    def test_issue_1214(self) -> None:
         print_red = '''rule echo
   command = printf '\x1b[31mred\x1b[0m'
   description = echo $out
@@ -109,7 +115,7 @@ red
 \x1b[31mred\x1b[0m
 ''')
 
-    def test_issue_1966(self):
+    def test_issue_1966(self) -> None:
         self.assertEqual(run(
 '''rule cat
   command = cat $rspfile $rspfile > $out
@@ -122,12 +128,12 @@ build a: cat
 ''')
 
 
-    def test_pr_1685(self):
+    def test_pr_1685(self) -> None:
         # Running those tools without .ninja_deps and .ninja_log shouldn't fail.
         self.assertEqual(run('', flags='-t recompact'), '')
         self.assertEqual(run('', flags='-t restat'), '')
 
-    def test_issue_2048(self):
+    def test_issue_2048(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             with open(os.path.join(d, 'build.ninja'), 'w'):
                 pass
@@ -150,25 +156,25 @@ build a: cat
             except subprocess.CalledProcessError as err:
                 self.fail("non-zero exit code with: " + err.output)
 
-    def test_status(self):
+    def test_status(self) -> None:
         self.assertEqual(run(''), 'ninja: no work to do.\n')
         self.assertEqual(run('', pipe=True), 'ninja: no work to do.\n')
         self.assertEqual(run('', flags='--quiet'), '')
 
-    def test_ninja_status_default(self):
+    def test_ninja_status_default(self) -> None:
         'Do we show the default status by default?'
         self.assertEqual(run(Output.BUILD_SIMPLE_ECHO), '[1/1] echo a\x1b[K\ndo thing\n')
 
-    def test_ninja_status_quiet(self):
+    def test_ninja_status_quiet(self) -> None:
         'Do we suppress the status information when --quiet is specified?'
         output = run(Output.BUILD_SIMPLE_ECHO, flags='--quiet')
         self.assertEqual(output, 'do thing\n')
 
-    def test_entering_directory_on_stdout(self):
+    def test_entering_directory_on_stdout(self) -> None:
         output = run(Output.BUILD_SIMPLE_ECHO, flags='-C$PWD', pipe=True)
         self.assertEqual(output.splitlines()[0][:25], "ninja: Entering directory")
 
-    def test_tool_inputs(self):
+    def test_tool_inputs(self) -> None:
         plan = '''
 rule cat
   command = cat $in $out

--- a/src/browse.py
+++ b/src/browse.py
@@ -24,8 +24,8 @@ try:
     import http.server as httpserver
     import socketserver
 except ImportError:
-    import BaseHTTPServer as httpserver
-    import SocketServer as socketserver
+    import BaseHTTPServer as httpserver  # type: ignore # Name "httpserver" already defined
+    import SocketServer as socketserver  # type: ignore # Name "socketserver" already defined
 import argparse
 import os
 import socket
@@ -37,10 +37,11 @@ if sys.version_info >= (3, 2):
 else:
     from cgi import escape
 try:
-    from urllib.request import unquote
+    from urllib.request import unquote  # type: ignore # Module "urllib.request" has no attribute "unquote"
 except ImportError:
     from urllib2 import unquote
 from collections import namedtuple
+from typing import Tuple, Any
 
 Node = namedtuple('Node', ['inputs', 'rule', 'target', 'outputs'])
 
@@ -57,15 +58,15 @@ Node = namedtuple('Node', ['inputs', 'rule', 'target', 'outputs'])
 # This means there's no single view that shows you all inputs and outputs
 # of an edge.  But I think it's less confusing than alternatives.
 
-def match_strip(line, prefix):
+def match_strip(line: str, prefix: str) -> Tuple[bool, str]:
     if not line.startswith(prefix):
         return (False, line)
     return (True, line[len(prefix):])
 
-def html_escape(text):
+def html_escape(text: str) -> str:
     return escape(text, quote=True)
 
-def parse(text):
+def parse(text: str) -> Node:
     lines = iter(text.split('\n'))
 
     target = None
@@ -102,7 +103,7 @@ def parse(text):
 
     return Node(inputs, rule, target, outputs)
 
-def create_page(body):
+def create_page(body: str) -> str:
     return '''<!DOCTYPE html>
 <style>
 body {
@@ -130,7 +131,7 @@ tt {
 </style>
 ''' + body
 
-def generate_html(node):
+def generate_html(node: Node) -> str:
     document = ['<h1><tt>%s</tt></h1>' % html_escape(node.target)]
 
     if node.inputs:
@@ -156,14 +157,14 @@ def generate_html(node):
 
     return '\n'.join(document)
 
-def ninja_dump(target):
+def ninja_dump(target: str) -> Tuple[str, str, int]:
     cmd = [args.ninja_command, '-f', args.f, '-t', 'query', target]
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             universal_newlines=True)
     return proc.communicate() + (proc.returncode,)
 
 class RequestHandler(httpserver.BaseHTTPRequestHandler):
-    def do_GET(self):
+    def do_GET(self) -> None:
         assert self.path[0] == '/'
         target = unquote(self.path[1:])
 
@@ -190,7 +191,7 @@ class RequestHandler(httpserver.BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(create_page(page_body).encode('utf-8'))
 
-    def log_message(self, format, *args):
+    def log_message(self, format: str, *args: Any) -> None:
         pass  # Swallow console spam.
 
 parser = argparse.ArgumentParser(prog='ninja -t browse')


### PR DESCRIPTION
Last type hinting PR went off without a hitch, so I bit the bullet and implemented the rest. Once again, no actual code is changed; however, I had to add some `# type: ignore # <message>` comments to suppress type warnings/errors that would've required code changes.