### PR TITLE
Properly support for Windows long file paths through Unicode Win32 API calls.

### DIFF
--- a/src/build_log.h
+++ b/src/build_log.h
@@ -15,9 +15,12 @@
 #ifndef NINJA_BUILD_LOG_H_
 #define NINJA_BUILD_LOG_H_
 
-#include <string>
 #include <stdio.h>
 
+#include <memory>
+#include <string>
+
+#include "disk_interface.h"
 #include "hash_map.h"
 #include "load_status.h"
 #include "timestamp.h"
@@ -41,7 +44,10 @@ struct BuildLogUser {
 /// 2) timing information, perhaps for generating reports
 /// 3) restat information
 struct BuildLog {
-  BuildLog();
+  /// Constructor takes a reference to an existing DiskInterface instance.
+  BuildLog(DiskInterface& disk_interface);
+
+  /// Destructor.
   ~BuildLog();
 
   /// Prepares writing to the log file without actually opening it - that will
@@ -87,21 +93,25 @@ struct BuildLog {
                  std::string* err);
 
   /// Restat all outputs in the log
-  bool Restat(StringPiece path, const DiskInterface& disk_interface,
-              int output_count, char** outputs, std::string* err);
+  bool Restat(StringPiece path, int output_count, char** outputs,
+              std::string* err);
 
   typedef ExternalStringHashMap<LogEntry*>::Type Entries;
   const Entries& entries() const { return entries_; }
 
  private:
+  /// Default destructor is private and never implemented.
+  BuildLog() = delete;
+
   /// Should be called before using log_file_. When false is returned, errno
   /// will be set.
   bool OpenForWriteIfNeeded();
 
+  DiskInterface* disk_interface_ = nullptr;
   Entries entries_;
-  FILE* log_file_;
+  FILE* log_file_ = nullptr;
   std::string log_file_path_;
-  bool needs_recompaction_;
+  bool needs_recompaction_ = false;
 };
 
 #endif // NINJA_BUILD_LOG_H_

--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -35,7 +35,8 @@ struct NoDeadPaths : public BuildLogUser {
 };
 
 bool WriteTestData(string* err) {
-  BuildLog log;
+  SystemDiskInterface disk_interface;
+  BuildLog log(disk_interface);
 
   NoDeadPaths no_dead_paths;
   if (!log.OpenForWrite(kTestFilename, no_dead_paths, err))
@@ -109,9 +110,10 @@ int main() {
     return 1;
   }
 
+  SystemDiskInterface disk_interface;
   {
     // Read once to warm up disk cache.
-    BuildLog log;
+    BuildLog log(disk_interface);
     if (log.Load(kTestFilename, &err) == LOAD_ERROR) {
       fprintf(stderr, "Failed to read test data: %s\n", err.c_str());
       return 1;
@@ -120,7 +122,7 @@ int main() {
   const int kNumRepetitions = 5;
   for (int i = 0; i < kNumRepetitions; ++i) {
     int64_t start = GetTimeMillis();
-    BuildLog log;
+    BuildLog log(disk_interface);
     if (log.Load(kTestFilename, &err) == LOAD_ERROR) {
       fprintf(stderr, "Failed to read test data: %s\n", err.c_str());
       return 1;

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -228,26 +228,8 @@ TEST_F(BuildLogTest, DuplicateVersionHeader) {
   ASSERT_NO_FATAL_FAILURE(AssertHash("command2", e->command_hash));
 }
 
-struct TestDiskInterface : public DiskInterface {
-  virtual TimeStamp Stat(const string& path, string* err) const {
-    return 4;
-  }
-  virtual bool WriteFile(const string& path, const string& contents) {
-    assert(false);
-    return true;
-  }
-  virtual bool MakeDir(const string& path) {
-    assert(false);
-    return false;
-  }
-  virtual Status ReadFile(const string& path, string* contents, string* err) {
-    assert(false);
-    return NotFound;
-  }
-  virtual int RemoveFile(const string& path) {
-    assert(false);
-    return 0;
-  }
+struct TestDiskInterface : public NullDiskInterface {
+  TimeStamp Stat(const string& path, string* err) const override { return 4; }
 };
 
 TEST_F(BuildLogTest, Restat) {

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -36,12 +36,14 @@ const char kTestFilename[] = "BuildLogTest-tempfile";
 struct BuildLogTest : public StateTestWithBuiltinRules, public BuildLogUser {
   virtual void SetUp() {
     // In case a crashing test left a stale file behind.
-    unlink(kTestFilename);
+    disk_interface_.RemoveFile(kTestFilename);
   }
-  virtual void TearDown() {
-    unlink(kTestFilename);
-  }
+  virtual void TearDown() { disk_interface_.RemoveFile(kTestFilename); }
   virtual bool IsPathDead(StringPiece s) const { return false; }
+
+  BuildLog CreateBuildLog() { return BuildLog(disk_interface_); }
+
+  SystemDiskInterface disk_interface_;
 };
 
 TEST_F(BuildLogTest, WriteRead) {
@@ -49,7 +51,7 @@ TEST_F(BuildLogTest, WriteRead) {
 "build out: cat mid\n"
 "build mid: cat in\n");
 
-  BuildLog log1;
+  BuildLog log1(disk_interface_);
   string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
@@ -57,7 +59,7 @@ TEST_F(BuildLogTest, WriteRead) {
   log1.RecordCommand(state_.edges_[1], 20, 25);
   log1.Close();
 
-  BuildLog log2;
+  BuildLog log2(disk_interface_);
   EXPECT_TRUE(log2.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
 
@@ -76,7 +78,7 @@ TEST_F(BuildLogTest, FirstWriteAddsSignature) {
   const char kExpectedVersion[] = "# ninja log vX\n";
   const size_t kVersionPos = strlen(kExpectedVersion) - 2;  // Points at 'X'.
 
-  BuildLog log;
+  BuildLog log(disk_interface_);
   string contents, err;
 
   EXPECT_TRUE(log.OpenForWrite(kTestFilename, *this, &err));
@@ -103,7 +105,7 @@ TEST_F(BuildLogTest, FirstWriteAddsSignature) {
 }
 
 TEST_F(BuildLogTest, DoubleEntry) {
-  FILE* f = fopen(kTestFilename, "wb");
+  FILE* f = disk_interface_.OpenFile(kTestFilename, "wb");
   fprintf(f, "# ninja log v7\n");
   fprintf(f, "0\t1\t2\tout\t%" PRIx64 "\n",
       BuildLog::LogEntry::HashCommand("command abc"));
@@ -112,7 +114,7 @@ TEST_F(BuildLogTest, DoubleEntry) {
   fclose(f);
 
   string err;
-  BuildLog log;
+  BuildLog log(disk_interface_);
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
 
@@ -127,7 +129,7 @@ TEST_F(BuildLogTest, Truncate) {
 "build mid: cat in\n");
 
   {
-    BuildLog log1;
+    BuildLog log1(disk_interface_);
     string err;
     EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
     ASSERT_EQ("", err);
@@ -147,7 +149,7 @@ TEST_F(BuildLogTest, Truncate) {
   // For all possible truncations of the input file, assert that we don't
   // crash when parsing.
   for (off_t size = statbuf.st_size; size > 0; --size) {
-    BuildLog log2;
+    BuildLog log2(disk_interface_);
     string err;
     EXPECT_TRUE(log2.OpenForWrite(kTestFilename, *this, &err));
     ASSERT_EQ("", err);
@@ -157,33 +159,33 @@ TEST_F(BuildLogTest, Truncate) {
 
     ASSERT_TRUE(Truncate(kTestFilename, size, &err));
 
-    BuildLog log3;
+    BuildLog log3(disk_interface_);
     err.clear();
     ASSERT_TRUE(log3.Load(kTestFilename, &err) == LOAD_SUCCESS || !err.empty());
   }
 }
 
 TEST_F(BuildLogTest, ObsoleteOldVersion) {
-  FILE* f = fopen(kTestFilename, "wb");
+  FILE* f = disk_interface_.OpenFile(kTestFilename, "wb");
   fprintf(f, "# ninja log v3\n");
   fprintf(f, "123 456 0 out command\n");
   fclose(f);
 
   string err;
-  BuildLog log;
+  BuildLog log(disk_interface_);
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_NE(err.find("version"), string::npos);
 }
 
 TEST_F(BuildLogTest, SpacesInOutput) {
-  FILE* f = fopen(kTestFilename, "wb");
+  FILE* f = disk_interface_.OpenFile(kTestFilename, "wb");
   fprintf(f, "# ninja log v7\n");
   fprintf(f, "123\t456\t456\tout with space\t%" PRIx64 "\n",
       BuildLog::LogEntry::HashCommand("command"));
   fclose(f);
 
   string err;
-  BuildLog log;
+  BuildLog log(disk_interface_);
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
 
@@ -199,7 +201,7 @@ TEST_F(BuildLogTest, DuplicateVersionHeader) {
   // Old versions of ninja accidentally wrote multiple version headers to the
   // build log on Windows. This shouldn't crash, and the second version header
   // should be ignored.
-  FILE* f = fopen(kTestFilename, "wb");
+  FILE* f = disk_interface_.OpenFile(kTestFilename, "wb");
   fprintf(f, "# ninja log v7\n");
   fprintf(f, "123\t456\t456\tout\t%" PRIx64 "\n",
       BuildLog::LogEntry::HashCommand("command"));
@@ -209,7 +211,7 @@ TEST_F(BuildLogTest, DuplicateVersionHeader) {
   fclose(f);
 
   string err;
-  BuildLog log;
+  BuildLog log(disk_interface_);
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
 
@@ -228,31 +230,42 @@ TEST_F(BuildLogTest, DuplicateVersionHeader) {
   ASSERT_NO_FATAL_FAILURE(AssertHash("command2", e->command_hash));
 }
 
-struct TestDiskInterface : public NullDiskInterface {
-  TimeStamp Stat(const string& path, string* err) const override { return 4; }
+struct TestDiskInterface : public RealDiskInterface {
+  void EnableMockTimestamps() { enable_mock_ = true; }
+
+  TimeStamp Stat(const string& path, string* err) const override {
+    if (enable_mock_)
+      return 4;
+    else
+      return this->RealDiskInterface::Stat(path, err);
+  }
+
+ private:
+  bool enable_mock_ = false;
 };
 
 TEST_F(BuildLogTest, Restat) {
-  FILE* f = fopen(kTestFilename, "wb");
+  FILE* f = disk_interface_.OpenFile(kTestFilename, "wb");
   fprintf(f, "# ninja log v7\n"
              "1\t2\t3\tout\tcommand\n");
   fclose(f);
   std::string err;
-  BuildLog log;
+  TestDiskInterface testDiskInterface;
+  BuildLog log(testDiskInterface);
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
   BuildLog::LogEntry* e = log.LookupByOutput("out");
   ASSERT_EQ(3, e->mtime);
 
-  TestDiskInterface testDiskInterface;
   char out2[] = { 'o', 'u', 't', '2', 0 };
   char* filter2[] = { out2 };
-  EXPECT_TRUE(log.Restat(kTestFilename, testDiskInterface, 1, filter2, &err));
+  testDiskInterface.EnableMockTimestamps();
+  EXPECT_TRUE(log.Restat(kTestFilename, 1, filter2, &err));
   ASSERT_EQ("", err);
   e = log.LookupByOutput("out");
   ASSERT_EQ(3, e->mtime); // unchanged, since the filter doesn't match
 
-  EXPECT_TRUE(log.Restat(kTestFilename, testDiskInterface, 0, NULL, &err));
+  EXPECT_TRUE(log.Restat(kTestFilename, 0, NULL, &err));
   ASSERT_EQ("", err);
   e = log.LookupByOutput("out");
   ASSERT_EQ(4, e->mtime);
@@ -261,7 +274,7 @@ TEST_F(BuildLogTest, Restat) {
 TEST_F(BuildLogTest, VeryLongInputLine) {
   // Ninja's build log buffer is currently 256kB. Lines longer than that are
   // silently ignored, but don't affect parsing of other lines.
-  FILE* f = fopen(kTestFilename, "wb");
+  FILE* f = disk_interface_.OpenFile(kTestFilename, "wb");
   fprintf(f, "# ninja log v7\n");
   fprintf(f, "123\t456\t456\tout\tcommand start");
   for (size_t i = 0; i < (512 << 10) / strlen(" more_command"); ++i)
@@ -272,7 +285,7 @@ TEST_F(BuildLogTest, VeryLongInputLine) {
   fclose(f);
 
   string err;
-  BuildLog log;
+  BuildLog log(disk_interface_);
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
 
@@ -291,7 +304,7 @@ TEST_F(BuildLogTest, MultiTargetEdge) {
   AssertParse(&state_,
 "build out out.d: cat\n");
 
-  BuildLog log;
+  BuildLog log(disk_interface_);
   log.RecordCommand(state_.edges_[0], 21, 22);
 
   ASSERT_EQ(2u, log.entries().size());
@@ -316,7 +329,7 @@ TEST_F(BuildLogRecompactTest, Recompact) {
 "build out: cat in\n"
 "build out2: cat in\n");
 
-  BuildLog log1;
+  BuildLog log1(disk_interface_);
   string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
@@ -328,7 +341,7 @@ TEST_F(BuildLogRecompactTest, Recompact) {
   log1.Close();
 
   // Load...
-  BuildLog log2;
+  BuildLog log2(disk_interface_);
   EXPECT_TRUE(log2.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
   ASSERT_EQ(2u, log2.entries().size());
@@ -339,7 +352,7 @@ TEST_F(BuildLogRecompactTest, Recompact) {
   log2.Close();
 
   // "out2" is dead, it should've been removed.
-  BuildLog log3;
+  BuildLog log3(disk_interface_);
   EXPECT_TRUE(log2.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
   ASSERT_EQ(1u, log2.entries().size());

--- a/src/deps_log.h
+++ b/src/deps_log.h
@@ -15,11 +15,13 @@
 #ifndef NINJA_DEPS_LOG_H_
 #define NINJA_DEPS_LOG_H_
 
+#include <stdio.h>
+
+#include <memory>
 #include <string>
 #include <vector>
 
-#include <stdio.h>
-
+#include "disk_interface.h"
 #include "load_status.h"
 #include "timestamp.h"
 
@@ -66,7 +68,13 @@ struct State;
 /// wins, allowing updates to just be appended to the file.  A separate
 /// repacking step can run occasionally to remove dead records.
 struct DepsLog {
-  DepsLog() : needs_recompaction_(false), file_(NULL) {}
+  /// No default constructor.
+  DepsLog() = delete;
+
+  /// Constructor takes a DiskInterface reference.
+  DepsLog(DiskInterface& disk_interface);
+
+  /// Destructor
   ~DepsLog();
 
   // Writing (build-time) interface.
@@ -115,8 +123,10 @@ struct DepsLog {
   /// be set.
   bool OpenForWriteIfNeeded();
 
-  bool needs_recompaction_;
-  FILE* file_;
+  DiskInterface* disk_interface_ = nullptr;
+
+  bool needs_recompaction_ = false;
+  FILE* file_ = nullptr;
   std::string file_path_;
 
   /// Maps id -> Node.

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -27,6 +27,7 @@
 #include <direct.h>  // _mkdir
 #include <windows.h>
 
+#include <cwctype>
 #include <sstream>
 #else
 #include <unistd.h>

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -354,6 +354,17 @@ FILE* SystemDiskInterface::OpenFile(const std::string& path, const char* mode) {
 #endif  // !_WIN32
 }
 
+bool SystemDiskInterface::RenameFile(const std::string& from,
+                                     const std::string& to) {
+#ifdef _WIN32
+  std::wstring wide_from = UTF8ToWin32Unicode(from);
+  std::wstring wide_to = UTF8ToWin32Unicode(to);
+  return !_wrename(wide_from.c_str(), wide_to.c_str());
+#else   // !_WIN32
+  return !rename(from.c_str(), to.c_str());
+#endif  // !_WIN32
+}
+
 #ifdef _WIN32
 bool SystemDiskInterface::AreLongPathsEnabled(void) const {
   return long_paths_enabled_;
@@ -393,6 +404,14 @@ FILE* NullDiskInterface::OpenFile(const std::string& path, const char* mode) {
   (void)path;
   (void)mode;
   return nullptr;
+}
+
+bool NullDiskInterface::RenameFile(const std::string& from,
+                                   const std::string& to) {
+  assert(false);
+  (void)from;
+  (void)to;
+  return false;
 }
 
 void RealDiskInterface::AllowStatCache(bool allow) {

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -344,6 +344,16 @@ int SystemDiskInterface::RemoveFile(const string& path) {
   return 0;
 }
 
+FILE* SystemDiskInterface::OpenFile(const std::string& path, const char* mode) {
+#ifdef _WIN32
+  std::wstring wide_path = UTF8ToWin32Unicode(path);
+  std::wstring wide_mode = UTF8ToWin32Unicode(mode);
+  return _wfopen(wide_path.c_str(), wide_mode.c_str());
+#else   // !_WIN32
+  return fopen(path.c_str(), mode);
+#endif  // !_WIN32
+}
+
 #ifdef _WIN32
 bool SystemDiskInterface::AreLongPathsEnabled(void) const {
   return long_paths_enabled_;
@@ -376,6 +386,13 @@ FileReader::Status NullDiskInterface::ReadFile(const std::string& path,
 int NullDiskInterface::RemoveFile(const std::string& path) {
   assert(false);
   return 0;
+}
+
+FILE* NullDiskInterface::OpenFile(const std::string& path, const char* mode) {
+  assert(false);
+  (void)path;
+  (void)mode;
+  return nullptr;
 }
 
 void RealDiskInterface::AllowStatCache(bool allow) {

--- a/src/disk_interface.h
+++ b/src/disk_interface.h
@@ -117,10 +117,10 @@ struct RealDiskInterface : public SystemDiskInterface {
   /// Whether stat information can be cached.
   bool use_cache_ = false;
 
-  typedef std::map<std::string, TimeStamp> DirCache;
+  typedef std::map<std::wstring, TimeStamp> DirCache;
   // TODO: Neither a map nor a hashmap seems ideal here.  If the statcache
   // works out, come up with a better data structure.
-  typedef std::map<std::string, DirCache> Cache;
+  typedef std::map<std::wstring, DirCache> Cache;
   mutable Cache cache_;
 #endif  // _WIN32
 };

--- a/src/disk_interface.h
+++ b/src/disk_interface.h
@@ -65,6 +65,14 @@ struct DiskInterface: public FileReader {
   /// Open new C standard i/o FILE instance for |path|.
   virtual FILE* OpenFile(const std::string& path, const char* mode) = 0;
 
+  /// Rename a file. Return true on success, or false/errno on failure.
+  /// NOTE: On Win32, this fails with EEXIST if the destination file already
+  /// exists (contrary to the Win32 documentation which states that the error
+  /// should be EACCES). On Posix, an existing file is always replaced
+  /// (unless trying to rename a file to an existing directory, or a
+  /// directory to a file or a non-empty one directory).
+  virtual bool RenameFile(const std::string& from, const std::string& to) = 0;
+
   /// Create all the parent directories for path; like mkdir -p
   /// `basename path`.
   bool MakeDirs(const std::string& path);
@@ -81,6 +89,7 @@ struct SystemDiskInterface : public DiskInterface {
                   std::string* err) override;
   int RemoveFile(const std::string& path) override;
   FILE* OpenFile(const std::string& path, const char* mode) override;
+  bool RenameFile(const std::string& from, const std::string& to) override;
 
 #ifdef _WIN32
   /// Whether long paths are enabled.  Only has an effect on Windows.
@@ -105,6 +114,7 @@ struct NullDiskInterface : public DiskInterface {
                   std::string* err) override;
   int RemoveFile(const std::string& path) override;
   FILE* OpenFile(const std::string& path, const char* mode) override;
+  bool RenameFile(const std::string& from, const std::string& to) override;
 };
 
 /// Implementation of SystemDiskInterface that speeds up Stat() calls by using

--- a/src/disk_interface.h
+++ b/src/disk_interface.h
@@ -62,6 +62,9 @@ struct DiskInterface: public FileReader {
   ///          -1 if an error occurs.
   virtual int RemoveFile(const std::string& path) = 0;
 
+  /// Open new C standard i/o FILE instance for |path|.
+  virtual FILE* OpenFile(const std::string& path, const char* mode) = 0;
+
   /// Create all the parent directories for path; like mkdir -p
   /// `basename path`.
   bool MakeDirs(const std::string& path);
@@ -77,6 +80,7 @@ struct SystemDiskInterface : public DiskInterface {
   Status ReadFile(const std::string& path, std::string* contents,
                   std::string* err) override;
   int RemoveFile(const std::string& path) override;
+  FILE* OpenFile(const std::string& path, const char* mode) override;
 
 #ifdef _WIN32
   /// Whether long paths are enabled.  Only has an effect on Windows.
@@ -100,6 +104,7 @@ struct NullDiskInterface : public DiskInterface {
   Status ReadFile(const std::string& path, std::string* contents,
                   std::string* err) override;
   int RemoveFile(const std::string& path) override;
+  FILE* OpenFile(const std::string& path, const char* mode) override;
 };
 
 /// Implementation of SystemDiskInterface that speeds up Stat() calls by using

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -171,7 +171,8 @@ TEST_F(DiskInterfaceTest, StatCache) {
   EXPECT_GT(disk_.Stat("subdir/subsubdir", &err), 1);
   EXPECT_EQ("", err);
 
-#ifndef _MSC_VER // TODO: Investigate why. Also see https://github.com/ninja-build/ninja/pull/1423
+#ifndef _WIN32  // TODO: Investigate why. Also see
+                // https://github.com/ninja-build/ninja/pull/1423
   EXPECT_EQ(disk_.Stat("subdir", &err),
             disk_.Stat("subdir/.", &err));
   EXPECT_EQ("", err);

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -257,28 +257,11 @@ TEST_F(DiskInterfaceTest, RemoveDirectory) {
   EXPECT_EQ(1, disk_.RemoveFile("does not exist"));
 }
 
-struct StatTest : public StateTestWithBuiltinRules,
-                  public DiskInterface {
+struct StatTest : public StateTestWithBuiltinRules, public NullDiskInterface {
   StatTest() : scan_(&state_, NULL, NULL, this, NULL, NULL) {}
 
   // DiskInterface implementation.
-  virtual TimeStamp Stat(const string& path, string* err) const;
-  virtual bool WriteFile(const string& path, const string& contents) {
-    assert(false);
-    return true;
-  }
-  virtual bool MakeDir(const string& path) {
-    assert(false);
-    return false;
-  }
-  virtual Status ReadFile(const string& path, string* contents, string* err) {
-    assert(false);
-    return NotFound;
-  }
-  virtual int RemoveFile(const string& path) {
-    assert(false);
-    return 0;
-  }
+  TimeStamp Stat(const string& path, string* err) const override;
 
   DependencyScan scan_;
   map<string, TimeStamp> mtimes_;

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -258,6 +258,108 @@ TEST_F(DiskInterfaceTest, RemoveDirectory) {
   EXPECT_EQ(1, disk_.RemoveFile("does not exist"));
 }
 
+TEST_F(DiskInterfaceTest, OpenFile) {
+  // Scoped FILE pointer, ensure instance is closed
+  // when test exits, even in case of failure.
+  struct ScopedFILE {
+    ScopedFILE(FILE* f) : f_(f) {}
+    ~ScopedFILE() { Close(); }
+
+    void Close() {
+      if (f_) {
+        fclose(f_);
+        f_ = nullptr;
+      }
+    }
+
+    FILE* get() const { return f_; }
+
+    explicit operator bool() const { return !!f_; }
+
+    FILE* f_;
+  };
+
+  const char kFileName[] = "file-to-open";
+  std::string kContent = "something to write to a file\n";
+
+  // disk_.WriteFile() opens the FILE instance in binary mode, which
+  // will not convert the final \n into \r\n on Windows. However,
+  // disk_.OpenFile() can write in text mode which will do the
+  // translation on this platform.
+  ASSERT_TRUE(disk_.WriteFile(kFileName, kContent));
+  std::string kExpected = "something to write to a file\n";
+#ifdef _WIN32
+  std::string kExpectedText = "something to write to a file\r\n";
+#else
+  std::string kExpectedText = "something to write to a file\n";
+#endif
+
+  std::string contents;
+  std::string err;
+  ASSERT_EQ(FileReader::Okay, disk_.ReadFile(kFileName, &contents, &err))
+      << err;
+  ASSERT_EQ(contents, kExpected);
+
+  // Read a file.
+  {
+    ScopedFILE f(disk_.OpenFile(kFileName, "rb"));
+    ASSERT_TRUE(f);
+    ASSERT_EQ(fseek(f.get(), 0, SEEK_END), 0) << strerror(errno);
+    long file_size_long = ftell(f.get());
+    ASSERT_GE(file_size_long, 0) << strerror(errno);
+
+    size_t file_size = static_cast<size_t>(file_size_long);
+    ASSERT_EQ(file_size, kExpected.size());
+    ASSERT_EQ(fseek(f.get(), 0, SEEK_SET), 0) << strerror(errno);
+
+    contents.clear();
+    contents.resize(file_size);
+    ASSERT_EQ(fread(const_cast<char*>(contents.data()), file_size, 1, f.get()),
+              1)
+        << strerror(errno);
+    ASSERT_EQ(contents, kExpected);
+  }
+
+  // Write a file opened file disk_.OpenFile() in binary mode, then verify its
+  // content.
+  const char kFileToWrite[] = "file-to-write";
+  {
+    ScopedFILE f(disk_.OpenFile(kFileToWrite, "wb"));
+    ASSERT_TRUE(f) << strerror(errno);
+    ASSERT_EQ(fwrite(kContent.data(), kContent.size(), 1, f.get()), 1);
+  }
+
+  contents.clear();
+  ASSERT_EQ(FileReader::Okay, disk_.ReadFile(kFileToWrite, &contents, &err))
+      << err;
+  ASSERT_EQ(contents, kContent);
+
+  // Write a file opened file disk_.OpenFile() in text mode, then verify its
+  // content.
+  {
+    ScopedFILE f(disk_.OpenFile(kFileToWrite, "wt"));
+    ASSERT_TRUE(f) << strerror(errno);
+    ASSERT_EQ(fwrite(kContent.data(), kContent.size(), 1, f.get()), 1);
+  }
+
+  contents.clear();
+  ASSERT_EQ(FileReader::Okay, disk_.ReadFile(kFileToWrite, &contents, &err))
+      << err;
+  ASSERT_EQ(contents, kExpectedText);
+
+  // Append to the same file, in text mode too.
+  {
+    ScopedFILE f(disk_.OpenFile(kFileToWrite, "at"));
+    ASSERT_TRUE(f) << strerror(errno);
+    ASSERT_EQ(fwrite(kContent.data(), kContent.size(), 1, f.get()), 1);
+  }
+  std::string expected = kExpectedText + kExpectedText;
+  contents.clear();
+  ASSERT_EQ(FileReader::Okay, disk_.ReadFile(kFileToWrite, &contents, &err))
+      << err;
+  ASSERT_EQ(contents, expected);
+}
+
 struct StatTest : public StateTestWithBuiltinRules, public NullDiskInterface {
   StatTest() : scan_(&state_, NULL, NULL, this, NULL, NULL) {}
 

--- a/src/includes_normalize_test.cc
+++ b/src/includes_normalize_test.cc
@@ -109,10 +109,8 @@ TEST(IncludesNormalize, LongInvalidPath) {
   // Too long, won't be canonicalized. Ensure doesn't crash.
   string result, err;
   IncludesNormalize normalizer(".");
-  EXPECT_FALSE(
-      normalizer.Normalize(kLongInputString, &result, &err));
-  EXPECT_EQ("path too long", err);
-
+  EXPECT_TRUE(normalizer.Normalize(kLongInputString, &result, &err));
+  EXPECT_EQ("", err);
 
   // Construct max size path having cwd prefix.
   // kExactlyMaxPath = "$cwd\\a\\aaaa...aaaa\0";
@@ -153,17 +151,18 @@ TEST(IncludesNormalize, ShortRelativeButTooLongAbsolutePath) {
 
   // Construct max size path having cwd prefix.
   // kExactlyMaxPath = "aaaa\\aaaa...aaaa\0";
-  char kExactlyMaxPath[_MAX_PATH + 1];
-  for (int i = 0; i < _MAX_PATH; ++i) {
-    if (i < _MAX_PATH - 1 && i % 10 == 4)
+  const size_t kMaxPathSize = _MAX_PATH * 2;
+  char kExactlyMaxPath[kMaxPathSize + 1];
+  for (int i = 0; i < kMaxPathSize; ++i) {
+    if (i < kMaxPathSize - 1 && i % 10 == 4)
       kExactlyMaxPath[i] = '\\';
     else
       kExactlyMaxPath[i] = 'a';
   }
-  kExactlyMaxPath[_MAX_PATH] = '\0';
-  EXPECT_EQ(strlen(kExactlyMaxPath), _MAX_PATH);
+  kExactlyMaxPath[kMaxPathSize] = '\0';
+  EXPECT_EQ(strlen(kExactlyMaxPath), kMaxPathSize);
 
-  // Make sure a path that's exactly _MAX_PATH long fails with a proper error.
-  EXPECT_FALSE(normalizer.Normalize(kExactlyMaxPath, &result, &err));
-  EXPECT_TRUE(err.find("GetFullPathName") != string::npos);
+  // Make sure a path that's larger than _MAX_PATH long does not fail.
+  EXPECT_TRUE(normalizer.Normalize(kExactlyMaxPath, &result, &err));
+  EXPECT_EQ("", err);
 }

--- a/src/missing_deps_test.cc
+++ b/src/missing_deps_test.cc
@@ -88,7 +88,8 @@ struct MissingDependencyScannerTest : public testing::Test {
   MissingDependencyTestDelegate delegate_;
   Rule generator_rule_;
   Rule compile_rule_;
-  DepsLog deps_log_;
+  SystemDiskInterface disk_interface_;
+  DepsLog deps_log_{ disk_interface_ };
   State state_;
   VirtualFileSystem filesystem_;
   MissingDependencyScanner scanner_;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -87,9 +87,9 @@ struct Options {
 /// The Ninja main() loads up a series of data structures; various tools need
 /// to poke into these, so store them as fields on an object.
 struct NinjaMain : public BuildLogUser {
-  NinjaMain(const char* ninja_command, const BuildConfig& config) :
-      ninja_command_(ninja_command), config_(config),
-      start_time_millis_(GetTimeMillis()) {}
+  NinjaMain(const char* ninja_command, const BuildConfig& config)
+      : ninja_command_(ninja_command), config_(config),
+        build_log_(disk_interface_), start_time_millis_(GetTimeMillis()) {}
 
   /// Command line used to run Ninja.
   const char* ninja_command_;
@@ -1133,7 +1133,7 @@ int NinjaMain::ToolRestat(const Options* options, int argc, char* argv[]) {
     err.clear();
   }
 
-  bool success = build_log_.Restat(log_path, disk_interface_, argc, argv, &err);
+  bool success = build_log_.Restat(log_path, argc, argv, &err);
   if (!success) {
     Error("failed recompaction: %s", err.c_str());
     return EXIT_FAILURE;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -89,7 +89,8 @@ struct Options {
 struct NinjaMain : public BuildLogUser {
   NinjaMain(const char* ninja_command, const BuildConfig& config)
       : ninja_command_(ninja_command), config_(config),
-        build_log_(disk_interface_), start_time_millis_(GetTimeMillis()) {}
+        build_log_(disk_interface_), deps_log_(disk_interface_),
+        start_time_millis_(GetTimeMillis()) {}
 
   /// Command line used to run Ninja.
   const char* ninja_command_;

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -39,15 +39,13 @@ Subprocess::~Subprocess() {
 }
 
 HANDLE Subprocess::SetupPipe(HANDLE ioport) {
-  char pipe_name[100];
-  snprintf(pipe_name, sizeof(pipe_name),
-           "\\\\.\\pipe\\ninja_pid%lu_sp%p", GetCurrentProcessId(), this);
+  wchar_t pipe_name[100];
+  _snwprintf(pipe_name, sizeof(pipe_name) / sizeof(pipe_name[0]),
+             L"\\\\.\\pipe\\ninja_pid%lu_sp%p", GetCurrentProcessId(), this);
 
-  pipe_ = ::CreateNamedPipeA(pipe_name,
-                             PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED,
-                             PIPE_TYPE_BYTE,
-                             PIPE_UNLIMITED_INSTANCES,
-                             0, 0, INFINITE, NULL);
+  pipe_ = ::CreateNamedPipeW(
+      pipe_name, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED, PIPE_TYPE_BYTE,
+      PIPE_UNLIMITED_INSTANCES, 0, 0, INFINITE, NULL);
   if (pipe_ == INVALID_HANDLE_VALUE)
     Win32Fatal("CreateNamedPipe");
 
@@ -62,7 +60,7 @@ HANDLE Subprocess::SetupPipe(HANDLE ioport) {
 
   // Get the write end of the pipe as a handle inheritable across processes.
   HANDLE output_write_handle =
-      CreateFileA(pipe_name, GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+      CreateFileW(pipe_name, GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
   HANDLE output_write_child;
   if (!DuplicateHandle(GetCurrentProcess(), output_write_handle,
                        GetCurrentProcess(), &output_write_child,
@@ -83,15 +81,14 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
   security_attributes.bInheritHandle = TRUE;
   // Must be inheritable so subprocesses can dup to children.
   HANDLE nul =
-      CreateFileA("NUL", GENERIC_READ,
+      CreateFileW(L"NUL", GENERIC_READ,
                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                   &security_attributes, OPEN_EXISTING, 0, NULL);
   if (nul == INVALID_HANDLE_VALUE)
     Fatal("couldn't open nul");
 
-  STARTUPINFOA startup_info;
-  memset(&startup_info, 0, sizeof(startup_info));
-  startup_info.cb = sizeof(STARTUPINFO);
+  STARTUPINFOW startup_info = {};
+  startup_info.cb = sizeof(STARTUPINFOW);
   if (!use_console_) {
     startup_info.dwFlags = STARTF_USESTDHANDLES;
     startup_info.hStdInput = nul;
@@ -107,11 +104,13 @@ bool Subprocess::Start(SubprocessSet* set, const string& command) {
   // Ninja handles ctrl-c, except for subprocesses in console pools.
   DWORD process_flags = use_console_ ? 0 : CREATE_NEW_PROCESS_GROUP;
 
+  // NOTE: CreateProcessW() modifies the input string.
   // Do not prepend 'cmd /c' on Windows, this breaks command
   // lines greater than 8,191 chars.
-  if (!CreateProcessA(NULL, (char*)command.c_str(), NULL, NULL,
-                      /* inherit handles */ TRUE, process_flags,
-                      NULL, NULL,
+  std::wstring wide_command = UTF8ToWin32Unicode(command);
+  if (!CreateProcessW(NULL, const_cast<wchar_t*>(wide_command.data()), NULL,
+                      NULL,
+                      /* inherit handles */ TRUE, process_flags, NULL, NULL,
                       &startup_info, &process_info)) {
     DWORD error = GetLastError();
     if (error == ERROR_FILE_NOT_FOUND) {

--- a/src/test.h
+++ b/src/test.h
@@ -68,6 +68,10 @@ struct VirtualFileSystem : public NullDiskInterface {
                   std::string* err) override;
   int RemoveFile(const std::string& path) override;
 
+  // NOTE: This implementation does not support write or append mode!
+  // It will assert() in debug builds, and return NULL/EINVAL otherwise.
+  FILE* OpenFile(const std::string& path, const char* mode) override;
+
   /// An entry for a single in-memory file.
   struct Entry {
     int mtime;

--- a/src/test.h
+++ b/src/test.h
@@ -48,7 +48,7 @@ void VerifyGraph(const State& state);
 /// An implementation of DiskInterface that uses an in-memory representation
 /// of disk state.  It also logs file accesses and directory creations
 /// so it can be used by tests to verify disk access patterns.
-struct VirtualFileSystem : public DiskInterface {
+struct VirtualFileSystem : public NullDiskInterface {
   VirtualFileSystem() : now_(1) {}
 
   /// "Create" a file with contents.
@@ -61,12 +61,12 @@ struct VirtualFileSystem : public DiskInterface {
   }
 
   // DiskInterface
-  virtual TimeStamp Stat(const std::string& path, std::string* err) const;
-  virtual bool WriteFile(const std::string& path, const std::string& contents);
-  virtual bool MakeDir(const std::string& path);
-  virtual Status ReadFile(const std::string& path, std::string* contents,
-                          std::string* err);
-  virtual int RemoveFile(const std::string& path);
+  TimeStamp Stat(const std::string& path, std::string* err) const override;
+  bool WriteFile(const std::string& path, const std::string& contents) override;
+  bool MakeDir(const std::string& path) override;
+  Status ReadFile(const std::string& path, std::string* contents,
+                  std::string* err) override;
+  int RemoveFile(const std::string& path) override;
 
   /// An entry for a single in-memory file.
   struct Entry {

--- a/src/util.cc
+++ b/src/util.cc
@@ -416,8 +416,10 @@ int ReadFile(const string& path, string* contents, string* err) {
   // This makes a ninja run on a set of 1500 manifest files about 4% faster
   // than using the generic fopen code below.
   err->clear();
-  HANDLE f = ::CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL,
-                           OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, NULL);
+  std::wstring native_path = UTF8ToWin32Unicode(path);
+  HANDLE f =
+      ::CreateFileW(native_path.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL,
+                    OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, NULL);
   if (f == INVALID_HANDLE_VALUE) {
     err->assign(GetLastErrorString());
     return -ENOENT;

--- a/src/util.cc
+++ b/src/util.cc
@@ -950,3 +950,38 @@ bool Truncate(const string& path, size_t size, string* err) {
   }
   return true;
 }
+
+#ifdef _WIN32
+std::wstring UTF8ToWin32Unicode(const std::string& path) {
+  std::wstring result;
+  if (!path.empty()) {
+    int path_len_int = static_cast<int>(path.size());
+    int len =
+        MultiByteToWideChar(CP_UTF8, 0, path.c_str(), path_len_int, nullptr, 0);
+    if (len <= 0)
+      Win32Fatal("Invalid file path", path.c_str());
+
+    result.resize(static_cast<size_t>(len));
+    MultiByteToWideChar(CP_UTF8, 0, path.c_str(), path_len_int,
+                        const_cast<wchar_t*>(result.data()), len);
+  }
+  return result;
+}
+
+std::string Win32UnicodeToUTF8(const std::wstring& path) {
+  std::string result;
+  if (!path.empty()) {
+    int path_len_int = static_cast<int>(path.size());
+    int len = WideCharToMultiByte(CP_UTF8, 0, path.c_str(), path_len_int,
+                                  nullptr, 0, nullptr, nullptr);
+    if (len <= 0)
+      Win32Fatal("Invalid native file path");
+
+    result.resize(static_cast<size_t>(len));
+    (void)WideCharToMultiByte(CP_UTF8, 0, path.c_str(), path_len_int,
+                              const_cast<char*>(result.data()), len, nullptr,
+                              nullptr);
+  }
+  return result;
+}
+#endif  // _WIN32

--- a/src/util.h
+++ b/src/util.h
@@ -122,6 +122,12 @@ bool Truncate(const std::string& path, size_t size, std::string* err);
 /// Convert the value returned by GetLastError() into a string.
 std::string GetLastErrorString();
 
+/// Convert UTF-8 path string to Win32 native path.
+std::wstring UTF8ToWin32Unicode(const std::string& path);
+
+/// Convert Win32 native path to UTF-8 path string.
+std::string Win32UnicodeToUTF8(const std::wstring& path);
+
 /// Calls Fatal() with a function name and GetLastErrorString.
 NORETURN void Win32Fatal(const char* function, const char* hint = NULL);
 #endif

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -502,3 +502,37 @@ TEST(StripAnsiEscapeCodes, StripColors) {
   EXPECT_EQ("affixmgr.cxx:286:15: warning: using the result... [-Wparentheses]",
             stripped);
 }
+
+#ifdef _WIN32
+TEST(UTF8ToWin32Unicode, UTF8ToWin32Unicode) {
+  static const struct {
+    const char* input;
+    const wchar_t* expected;
+  } kData[] = {
+    { "foo", L"foo" },
+    { "foo/bar", L"foo/bar" },
+    { "\x62\xc3\xa9\x62\xc3\xa9", L"\u0062\u00e9\u0062\u00e9" },  // bébé
+  };
+  for (const auto& data : kData) {
+    std::string input = data.input;
+    std::wstring expected = data.expected;
+    EXPECT_EQ(expected, UTF8ToWin32Unicode(input)) << input;
+  }
+}
+
+TEST(Win32UnicodeToUTF8, Win32UnicodeToUTF8) {
+  static const struct {
+    const wchar_t* input;
+    const char* expected;
+  } kData[] = {
+    { L"foo", "foo" },
+    { L"foo/bar", "foo/bar" },
+    { L"\u0062\u00e9\u0062\u00e9", "\x62\xc3\xa9\x62\xc3\xa9" },  // bébé
+  };
+  for (const auto& data : kData) {
+    std::wstring input = data.input;
+    std::string expected = data.expected;
+    EXPECT_EQ(expected, Win32UnicodeToUTF8(input)) << input;
+  }
+}
+#endif  // _WIN32


### PR DESCRIPTION
This is an attempt to properly support Windows long file paths by only using Win32 Unicode API calls, and getting rid of the ANSI ones (some of which are still plagued by MAX_PATH limitations, even when long paths support is enabled on the machine).

This is achieved in the following ways (see individual commits for details):

- Add `UTF8ToWin32Unicode()` and `Win32UnicodeToUTF8()` functions to util.h

- For simplicity, introduce SystemDiskInterface and NullDiskInterface, and make RealDiskInterface a derived class of SystemDiskInterface that adds a caching layer.
(this opens the door to other caching implementations on Posix).

- Augment the `DiskInterface` API to add `RenameFile()` and `OpenFile()` methods to ... rename a file (just like `rename() / _rename()`), and open an stdio FILE instance (just like `fopen()`).

- Modify the DiskInterface implementation to only use Unicode Win32 APIs.

- Modify sources that rely on direct calls to `fopen()`, `unlink()`, `rename()` to use a DiskInterface instance. This requires injecting such an instance in the constructors of BuildLog and DepsLog btw.

- Modify other misc Win32-specific sources to use Win32 Unicode API calls directly (e.g. subprocess-win32.cc)

NOTE: VirtualFileSystem::OpenFile() only supports read access for now. Unlike its real SystemDiskInterface implementation, it doesn't perform \r\n to \n conversion on Windows (do we really want this?). That is why many tests (e.g. build_log_test.cc) do not use it, but rely on a real DiskInterface instance. This can be fixed by another PR after this one.

This should fix issue #1900 once and for all (crossing fingers here :-))