### PR TITLE
fix: add missing const

### DIFF
--- a/src/build_log.h
+++ b/src/build_log.h
@@ -65,7 +65,7 @@ struct BuildLog {
     static uint64_t HashCommand(StringPiece command);
 
     // Used by tests.
-    bool operator==(const LogEntry& o) {
+    bool operator==(const LogEntry& o) const {
       return output == o.output && command_hash == o.command_hash &&
           start_time == o.start_time && end_time == o.end_time &&
           mtime == o.mtime;


### PR DESCRIPTION
Fixes the following build warning:
```
[29/67] Building CXX object CMakeFiles/ninja_test.dir/src/build_log_test.cc.o
../src/build_log_test.cc:70:19: warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'BuildLog::LogEntry' and 'BuildLog::LogEntry') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
  ASSERT_TRUE(*e1 == *e2);
              ~~~ ^  ~~~
```

But nowadays the [Hidden friend idiom](https://www.modernescpp.com/index.php/argument-dependent-lookup-and-hidden-friends/) would be preferred for comparison operators.

