### PR TITLE
fix: add explict braces to avoid ambiguous else

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1363,8 +1363,9 @@ void TestPhonyUseCase(BuildTest* t, int i) {
     // Build number 1
     EXPECT_TRUE(builder_.AddTarget("test" + ci, &err));
     ASSERT_EQ("", err);
-    if (!builder_.AlreadyUpToDate())
+    if (!builder_.AlreadyUpToDate()) {
       EXPECT_TRUE(builder_.Build(&err));
+    }
     ASSERT_EQ("", err);
 
     // Touch the input file


### PR DESCRIPTION
Fix to address the following compiler warning:

../src/build_test.cc: In function 'void TestPhonyUseCase(BuildTest*, int)': ../src/build_test.cc:1366:8: warning: suggest explicit braces to avoid ambiguous 'else' [-Wdangling-else]
 1366 |     if (!builder_.AlreadyUpToDate())
      |        ^