### PR TITLE
util: Fix compiling with Android NDK

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -47,7 +47,7 @@
 #include <sys/loadavg.h>
 #elif defined(_AIX) && !defined(__PASE__)
 #include <libperfstat.h>
-#elif defined(linux) || defined(__GLIBC__)
+#elif defined(__linux__) || defined(__GLIBC__)
 #include <sys/sysinfo.h>
 #include <fstream>
 #include <map>
@@ -589,7 +589,7 @@ string StripAnsiEscapeCodes(const string& in) {
   return stripped;
 }
 
-#if defined(linux) || defined(__GLIBC__)
+#if defined(__linux__) || defined(__GLIBC__)
 std::pair<int64_t, bool> readCount(const std::string& path) {
   std::ifstream file(path.c_str());
   if (!file.is_open())
@@ -789,7 +789,7 @@ int GetProcessorCount() {
 #else
   int cgroupCount = -1;
   int schedCount = -1;
-#if defined(linux) || defined(__GLIBC__)
+#if defined(__linux__) || defined(__GLIBC__)
   cgroupCount = ParseCPUFromCGroup();
 #endif
   // The number of exposed processors might not represent the actual number of


### PR DESCRIPTION

    This change fixes the following compiler error.
    
    util.cc:899:18: error: variable has incomplete type 'struct sysinfo'
      struct sysinfo si;
                     ^
    
    C++ compiler does not define 'linux` macro with -std=c++11 which was
    added in a4c24a33c1ed32d9d51c8df763ec6ad574587d02 commit. So, 'linux`
    is replaced with '__linux__`. See the difference in following output.
    
    $ clang++ -xc++ -dM -E - < /dev/null | grep linux
    > #define __gnu_linux__ 1
    > #define __linux 1
    > #define __linux__ 1
    > #define linux 1
    
    $ clang++ -xc++ -std=c++11 -dM -E - < /dev/null | grep linux
    > #define __gnu_linux__ 1
    > #define __linux 1
    > #define __linux__ 1
