### PR TITLE
Set CMake policy CMP0135 to fix gtest warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,12 @@ endif()
 
 include(CTest)
 if(BUILD_TESTING)
+
+  # Can be removed if cmake min version is >=3.24
+  if (POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+  endif()
+
   find_package(GTest)
   if(NOT GTest_FOUND)
     include(FetchContent)


### PR DESCRIPTION
Partial fix for #2412 - remove warning about [DOWNLOAD_EXTRACT_TIMESTAMP](https://cmake.org/cmake/help/latest/policy/CMP0135.html) when building tests and downloading gtest, by using newer cmake behaviour. This sets "timestamps of all extracted contents to the time of the extraction" rather than the "timestamps in the archive".

Can be removed once cmake_minimum_version >=3.24

Fixes/removes this:
```
CMake Warning (dev) at /usr/local/share/cmake-3.29/Modules/FetchContent.cmake:1352 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  CMakeLists.txt:233 (FetchContent_Declare)
This warning is for project developers.  Use -Wno-dev to suppress it.
```