### PR TITLE
Correct: [[fallthrough]] and [[noreturn]]

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -26,27 +26,26 @@
 #include <string>
 #include <vector>
 
-#ifdef _MSC_VER
-#define NORETURN __declspec(noreturn)
+#if !defined(__has_cpp_attribute)
+#  define __has_cpp_attribute(x)  0
+#endif
+
+#if __has_cpp_attribute(noreturn)
+#  define NORETURN [[noreturn]]
 #else
-#define NORETURN __attribute__((noreturn))
+#  define NORETURN  // nothing for old compilers
 #endif
 
 /// Log a fatal message and exit.
 NORETURN void Fatal(const char* msg, ...);
 
 // Have a generic fall-through for different versions of C/C++.
-#if defined(__cplusplus) && __cplusplus >= 201703L
-#define NINJA_FALLTHROUGH [[fallthrough]]
-#elif defined(__cplusplus) && __cplusplus >= 201103L && defined(__clang__)
-#define NINJA_FALLTHROUGH [[clang::fallthrough]]
-#elif defined(__cplusplus) && __cplusplus >= 201103L && defined(__GNUC__) && \
-    __GNUC__ >= 7
-#define NINJA_FALLTHROUGH [[gnu::fallthrough]]
-#elif defined(__GNUC__) && __GNUC__ >= 7 // gcc 7
-#define NINJA_FALLTHROUGH __attribute__ ((fallthrough))
-#else // C++11 on gcc 6, and all other cases
-#define NINJA_FALLTHROUGH
+#if __has_cpp_attribute(fallthrough)
+#  define NINJA_FALLTHROUGH [[fallthrough]]
+#elif defined(__clang__)
+#  define NINJA_FALLTHROUGH [[clang::fallthrough]]
+#else
+#  define NINJA_FALLTHROUGH // nothing
 #endif
 
 /// Log a warning message.


### PR DESCRIPTION
previously, the top `[[fallthrough]]` logic path was never followed as intended. Since GCC >= 7 has this, the workaround logic was not needed for most cases. 

Likewise for `[[noreturn]]`, the vast majority of compilers have it for several years already.

Both attributes fallback to empty in case of very old or less common compiler.

tested with GCC 7, Clang 12, Clang 16, Intel oneAPI, NVIDIA HPC SDK etc. to not emit any new warnings.