### PR TITLE
Update GTest to 1.12.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,13 +271,12 @@ if(BUILD_TESTING)
   if(WIN32)
     target_sources(ninja_test PRIVATE src/includes_normalize_test.cc src/msvc_helper_test.cc
       windows/ninja.manifest)
-  endif()
-  find_package(Threads REQUIRED)
-  target_link_libraries(ninja_test PRIVATE libninja libninja-re2c GTest::gtest Threads::Threads)
-  if (MSVC)
+
     # Silence warnings about using unlink rather than _unlink
     target_compile_definitions(ninja_test PRIVATE _CRT_NONSTDC_NO_DEPRECATE)
   endif()
+  find_package(Threads REQUIRED)
+  target_link_libraries(ninja_test PRIVATE libninja libninja-re2c GTest::gtest Threads::Threads)
 
   foreach(perftest
     build_log_perftest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,8 +272,10 @@ if(BUILD_TESTING)
     target_sources(ninja_test PRIVATE src/includes_normalize_test.cc src/msvc_helper_test.cc
       windows/ninja.manifest)
 
-    # Silence warnings about using unlink rather than _unlink
-    target_compile_definitions(ninja_test PRIVATE _CRT_NONSTDC_NO_DEPRECATE)
+    if(MSVC)
+      # Silence warnings about using unlink rather than _unlink
+      target_compile_definitions(ninja_test PRIVATE _CRT_NONSTDC_NO_DEPRECATE)
+    endif()
   endif()
   find_package(Threads REQUIRED)
   target_link_libraries(ninja_test PRIVATE libninja libninja-re2c GTest::gtest Threads::Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ check_ipo_supported(RESULT lto_supported OUTPUT error)
 
 if(lto_supported)
 	message(STATUS "IPO / LTO enabled")
+	set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
 	set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
 else()
 	message(STATUS "IPO / LTO not supported: <${error}>")
@@ -227,42 +228,21 @@ endif()
 
 include(CTest)
 if(BUILD_TESTING)
+
+  # Can be removed if cmake min version is >=3.24
+  if (POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+  endif()
+
   find_package(GTest)
   if(NOT GTest_FOUND)
     include(FetchContent)
     FetchContent_Declare(
       googletest
-      URL https://github.com/google/googletest/archive/release-1.10.0.tar.gz
-      URL_HASH SHA1=9c89be7df9c5e8cb0bc20b3c4b39bf7e82686770
+      URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz
+      URL_HASH SHA256=81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2
     )
     FetchContent_MakeAvailable(googletest)
-
-    # Before googletest-1.11.0, the CMake files provided by the source archive
-    # did not define the GTest::gtest target, only the gtest one, so define
-    # an alias when needed to ensure the rest of this file works with all
-    # GoogleTest releases.
-    #
-    # Note that surprisingly, this is not needed when using GTEST_ROOT to
-    # point to a local installation, because this one contains CMake-generated
-    # files that contain the right target definition, and which will be
-    # picked up by the find_package(GTest) file above.
-    #
-    # This comment and the four lines below can be removed once Ninja only
-    # depends on release-1.11.0 or above.
-    if (NOT TARGET GTest::gtest)
-      message(STATUS "Defining GTest::gtest alias to work-around bug in older release.")
-      add_library(GTest::gtest ALIAS gtest)
-
-      # NOTE: gtest uninit some variables, gcc >= 1.11.3 may cause error on compile.
-      # Remove this comment and six lines below, once ninja deps gtest-1.11.0 or above.
-      if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "1.11.3")
-        check_cxx_compiler_flag(-Wmaybe-uninitialized flag_maybe_uninit)
-        if (flag_maybe_uninit)
-          target_compile_options(gtest PRIVATE -Wno-maybe-uninitialized)
-        endif()
-      endif()
-
-    endif()
   endif()
 
   # Tests all build into ninja_test executable.
@@ -294,6 +274,10 @@ if(BUILD_TESTING)
   endif()
   find_package(Threads REQUIRED)
   target_link_libraries(ninja_test PRIVATE libninja libninja-re2c GTest::gtest Threads::Threads)
+  if (MSVC)
+    # Silence warnings about using unlink rather than _unlink
+    target_compile_definitions(ninja_test PRIVATE _CRT_NONSTDC_NO_DEPRECATE)
+  endif()
 
   foreach(perftest
     build_log_perftest


### PR DESCRIPTION
Follow up to #2418
1.12.1 as last GTest version supporting c++11
Fix LTO warnings for GTest (we already check if lto is supported)
Fix ninja_test msvc warnings about use of `unlink` rather than `_unlink`