### PR TITLE
RealDiskInterface: Do *not* set locale to an empty string

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -161,8 +161,6 @@ bool DiskInterface::MakeDirs(const string& path) {
 RealDiskInterface::RealDiskInterface() 
 #ifdef _WIN32
 : use_cache_(false), long_paths_enabled_(false) {
-  setlocale(LC_ALL, "");
-
   // Probe ntdll.dll for RtlAreLongPathsEnabled, and call it if it exists.
   HINSTANCE ntdll_lib = ::GetModuleHandleW(L"ntdll");
   if (ntdll_lib) {


### PR DESCRIPTION
It causes the cursor handling to be extremely slow on MinGW.

Added in #2321.

Fixes #2435.

(cherry picked from commit 3d1a5fa9ab4a38fd5c2004820907158e1e774858)