### PR TITLE
manifest_parser.cc: Fix three minor memory leaks

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -313,8 +313,10 @@ bool ManifestParser::ParseEdge(string* err) {
   while (has_indent_token) {
     string key;
     EvalString val;
-    if (!ParseLet(&key, &val, err))
+    if (!ParseLet(&key, &val, err)) {
+      delete env;
       return false;
+    }
 
     env->AddBinding(key, val.Evaluate(env_));
     has_indent_token = lexer_.PeekToken(Lexer::INDENT);


### PR DESCRIPTION
Add missing delete in case of an error to prevent
memory leaks.
Found by clang tidy (clang-analyzer-cplusplus.NewDeleteLeaks)