### PR TITLE
Remove global `explanations_` variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,7 @@ if(BUILD_TESTING)
     src/disk_interface_test.cc
     src/dyndep_parser_test.cc
     src/edit_distance_test.cc
+    src/explanations_test.cc
     src/graph_test.cc
     src/json_test.cc
     src/lexer_test.cc

--- a/configure.py
+++ b/configure.py
@@ -638,6 +638,7 @@ if gtest_src_dir:
         'disk_interface_test',
         'dyndep_parser_test',
         'edit_distance_test',
+        'explanations_test',
         'graph_test',
         'json_test',
         'lexer_test',

--- a/src/build.h
+++ b/src/build.h
@@ -22,14 +22,15 @@
 #include <vector>
 
 #include "depfile_parser.h"
-#include "graph.h"
 #include "exit_status.h"
+#include "graph.h"
 #include "util.h"  // int64_t
 
 struct BuildLog;
 struct Builder;
 struct DiskInterface;
 struct Edge;
+struct Explanations;
 struct Node;
 struct State;
 struct Status;
@@ -186,9 +187,8 @@ struct BuildConfig {
 
 /// Builder wraps the build process: starting commands, updating status.
 struct Builder {
-  Builder(State* state, const BuildConfig& config,
-          BuildLog* build_log, DepsLog* deps_log,
-          DiskInterface* disk_interface, Status* status,
+  Builder(State* state, const BuildConfig& config, BuildLog* build_log,
+          DepsLog* deps_log, DiskInterface* disk_interface, Status* status,
           int64_t start_time_millis);
   ~Builder();
 
@@ -242,6 +242,10 @@ struct Builder {
 
   std::string lock_file_path_;
   DiskInterface* disk_interface_;
+
+  // Only create an Explanations class if '-d explain' is used.
+  std::unique_ptr<Explanations> explanations_;
+
   DependencyScan scan_;
 
   // Unimplemented copy ctor and operator= ensure we don't copy the auto_ptr.

--- a/src/debug_flags.cc
+++ b/src/debug_flags.cc
@@ -26,21 +26,3 @@ bool g_keep_depfile = false;
 bool g_keep_rsp = false;
 
 bool g_experimental_statcache = true;
-
-// Reasons each Node needs rebuilding, for "-d explain".
-typedef std::map<const Node*, std::vector<std::string> > Explanations;
-static Explanations explanations_;
-
-void record_explanation(const Node* node, std::string explanation) {
-  explanations_[node].push_back(explanation);
-}
-
-void print_explanations(FILE *stream, const Edge* edge) {
-  for (std::vector<Node*>::const_iterator o = edge->outputs_.begin();
-       o != edge->outputs_.end(); ++o) {
-    for (std::vector<std::string>::iterator s = explanations_[*o].begin();
-         s != explanations_[*o].end(); ++s) {
-      fprintf(stream, "ninja explain: %s\n", (*s).c_str());
-    }
-  }
-}

--- a/src/debug_flags.h
+++ b/src/debug_flags.h
@@ -17,20 +17,10 @@
 
 #include <stdio.h>
 
-#define EXPLAIN(node, fmt, ...) {                                       \
-  if (g_explaining) {                                                   \
-    char buf[1024];                                                     \
-    snprintf(buf, 1024, fmt, __VA_ARGS__);                              \
-    record_explanation(node, buf);                                      \
-  }                                                                     \
-}
-
 struct Edge;
 struct Node;
 
 extern bool g_explaining;
-void record_explanation(const Node* node, std::string reason);
-void print_explanations(FILE *stream, const Edge* node);
 
 extern bool g_keep_depfile;
 

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -259,7 +259,7 @@ TEST_F(DiskInterfaceTest, RemoveDirectory) {
 
 struct StatTest : public StateTestWithBuiltinRules,
                   public DiskInterface {
-  StatTest() : scan_(&state_, NULL, NULL, this, NULL) {}
+  StatTest() : scan_(&state_, NULL, NULL, this, NULL, NULL) {}
 
   // DiskInterface implementation.
   virtual TimeStamp Stat(const string& path, string* err) const;

--- a/src/dyndep.cc
+++ b/src/dyndep.cc
@@ -20,6 +20,7 @@
 #include "debug_flags.h"
 #include "disk_interface.h"
 #include "dyndep_parser.h"
+#include "explanations.h"
 #include "graph.h"
 #include "state.h"
 #include "util.h"
@@ -37,7 +38,8 @@ bool DyndepLoader::LoadDyndeps(Node* node, DyndepFile* ddf,
   node->set_dyndep_pending(false);
 
   // Load the dyndep information from the file.
-  EXPLAIN(node, "loading dyndep file '%s'", node->path().c_str());
+  explanations_.Record(node, "loading dyndep file '%s'", node->path().c_str());
+
   if (!LoadDyndepFile(node, ddf, err))
     return false;
 

--- a/src/dyndep.h
+++ b/src/dyndep.h
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include "explanations.h"
+
 struct DiskInterface;
 struct Edge;
 struct Node;
@@ -42,8 +44,10 @@ struct DyndepFile: public std::map<Edge*, Dyndeps> {};
 /// DyndepLoader loads dynamically discovered dependencies, as
 /// referenced via the "dyndep" attribute in build files.
 struct DyndepLoader {
-  DyndepLoader(State* state, DiskInterface* disk_interface)
-      : state_(state), disk_interface_(disk_interface) {}
+  DyndepLoader(State* state, DiskInterface* disk_interface,
+               Explanations* explanations = nullptr)
+      : state_(state), disk_interface_(disk_interface),
+        explanations_(explanations) {}
 
   /// Load a dyndep file from the given node's path and update the
   /// build graph with the new information.  One overload accepts
@@ -59,6 +63,7 @@ struct DyndepLoader {
 
   State* state_;
   DiskInterface* disk_interface_;
+  mutable OptionalExplanations explanations_;
 };
 
 #endif  // NINJA_DYNDEP_LOADER_H_

--- a/src/explanations.h
+++ b/src/explanations.h
@@ -1,0 +1,89 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/// A class used to record a list of explanation strings associated
+/// with a given 'item' pointer. This is used to implement the
+/// `-d explain` feature.
+struct Explanations {
+ public:
+  /// Record an explanation for |item| if this instance is enabled.
+  void Record(const void* item, const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    RecordArgs(item, fmt, args);
+    va_end(args);
+  }
+
+  /// Same as Record(), but uses a va_list to pass formatting arguments.
+  void RecordArgs(const void* item, const char* fmt, va_list args) {
+    char buffer[1024];
+    vsnprintf(buffer, sizeof(buffer), fmt, args);
+    map_[item].emplace_back(buffer);
+  }
+
+  /// Lookup the explanations recorded for |item|, and append them
+  /// to |*out|, if any.
+  void LookupAndAppend(const void* item, std::vector<std::string>* out) {
+    auto it = map_.find(item);
+    if (it == map_.end())
+      return;
+
+    for (const auto& explanation : it->second)
+      out->push_back(explanation);
+  }
+
+ private:
+  bool enabled_ = false;
+  std::unordered_map<const void*, std::vector<std::string>> map_;
+};
+
+/// Convenience wrapper for an Explanations pointer, which can be null
+/// if no explanations need to be recorded.
+struct OptionalExplanations {
+  OptionalExplanations(Explanations* explanations)
+      : explanations_(explanations) {}
+
+  void Record(const void* item, const char* fmt, ...) {
+    if (explanations_) {
+      va_list args;
+      va_start(args, fmt);
+      explanations_->RecordArgs(item, fmt, args);
+      va_end(args);
+    }
+  }
+
+  void RecordArgs(const void* item, const char* fmt, va_list args) {
+    if (explanations_)
+      explanations_->RecordArgs(item, fmt, args);
+  }
+
+  void LookupAndAppend(const void* item, std::vector<std::string>* out) {
+    if (explanations_)
+      explanations_->LookupAndAppend(item, out);
+  }
+
+  Explanations* ptr() const { return explanations_; }
+
+ private:
+  Explanations* explanations_;
+};

--- a/src/explanations_test.cc
+++ b/src/explanations_test.cc
@@ -1,0 +1,97 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "explanations.h"
+
+#include "test.h"
+
+namespace {
+
+const void* MakeItem(size_t v) {
+  return reinterpret_cast<const void*>(v);
+}
+
+}  // namespace
+
+TEST(Explanations, Explanations) {
+  Explanations exp;
+
+  exp.Record(MakeItem(1), "first explanation");
+  exp.Record(MakeItem(1), "second explanation");
+  exp.Record(MakeItem(2), "third explanation");
+  exp.Record(MakeItem(2), "fourth %s", "explanation");
+
+  std::vector<std::string> list;
+
+  exp.LookupAndAppend(MakeItem(0), &list);
+  ASSERT_TRUE(list.empty());
+
+  exp.LookupAndAppend(MakeItem(1), &list);
+  ASSERT_EQ(2u, list.size());
+  EXPECT_EQ(list[0], "first explanation");
+  EXPECT_EQ(list[1], "second explanation");
+
+  exp.LookupAndAppend(MakeItem(2), &list);
+  ASSERT_EQ(4u, list.size());
+  EXPECT_EQ(list[0], "first explanation");
+  EXPECT_EQ(list[1], "second explanation");
+  EXPECT_EQ(list[2], "third explanation");
+  EXPECT_EQ(list[3], "fourth explanation");
+}
+
+TEST(Explanations, OptionalExplanationsNonNull) {
+  Explanations parent;
+  OptionalExplanations exp(&parent);
+
+  exp.Record(MakeItem(1), "first explanation");
+  exp.Record(MakeItem(1), "second explanation");
+  exp.Record(MakeItem(2), "third explanation");
+  exp.Record(MakeItem(2), "fourth %s", "explanation");
+
+  std::vector<std::string> list;
+
+  exp.LookupAndAppend(MakeItem(0), &list);
+  ASSERT_TRUE(list.empty());
+
+  exp.LookupAndAppend(MakeItem(1), &list);
+  ASSERT_EQ(2u, list.size());
+  EXPECT_EQ(list[0], "first explanation");
+  EXPECT_EQ(list[1], "second explanation");
+
+  exp.LookupAndAppend(MakeItem(2), &list);
+  ASSERT_EQ(4u, list.size());
+  EXPECT_EQ(list[0], "first explanation");
+  EXPECT_EQ(list[1], "second explanation");
+  EXPECT_EQ(list[2], "third explanation");
+  EXPECT_EQ(list[3], "fourth explanation");
+}
+
+TEST(Explanations, OptionalExplanationsWithNullPointer) {
+  OptionalExplanations exp(nullptr);
+
+  exp.Record(MakeItem(1), "first explanation");
+  exp.Record(MakeItem(1), "second explanation");
+  exp.Record(MakeItem(2), "third explanation");
+  exp.Record(MakeItem(2), "fourth %s", "explanation");
+
+  std::vector<std::string> list;
+  exp.LookupAndAppend(MakeItem(0), &list);
+  ASSERT_TRUE(list.empty());
+
+  exp.LookupAndAppend(MakeItem(1), &list);
+  ASSERT_TRUE(list.empty());
+
+  exp.LookupAndAppend(MakeItem(2), &list);
+  ASSERT_TRUE(list.empty());
+}

--- a/src/graph.h
+++ b/src/graph.h
@@ -16,13 +16,14 @@
 #define NINJA_GRAPH_H_
 
 #include <algorithm>
+#include <queue>
 #include <set>
 #include <string>
 #include <vector>
-#include <queue>
 
 #include "dyndep.h"
 #include "eval_env.h"
+#include "explanations.h"
 #include "timestamp.h"
 #include "util.h"
 
@@ -283,9 +284,11 @@ typedef std::set<Edge*, EdgeCmp> EdgeSet;
 struct ImplicitDepLoader {
   ImplicitDepLoader(State* state, DepsLog* deps_log,
                     DiskInterface* disk_interface,
-                    DepfileParserOptions const* depfile_parser_options)
+                    DepfileParserOptions const* depfile_parser_options,
+                    Explanations* explanations)
       : state_(state), disk_interface_(disk_interface), deps_log_(deps_log),
-        depfile_parser_options_(depfile_parser_options) {}
+        depfile_parser_options_(depfile_parser_options),
+        explanations_(explanations) {}
 
   /// Load implicit dependencies for \a edge.
   /// @return false on error (without filling \a err if info is just missing
@@ -319,6 +322,7 @@ struct ImplicitDepLoader {
   DiskInterface* disk_interface_;
   DepsLog* deps_log_;
   DepfileParserOptions const* depfile_parser_options_;
+  OptionalExplanations explanations_;
 };
 
 
@@ -327,11 +331,12 @@ struct ImplicitDepLoader {
 struct DependencyScan {
   DependencyScan(State* state, BuildLog* build_log, DepsLog* deps_log,
                  DiskInterface* disk_interface,
-                 DepfileParserOptions const* depfile_parser_options)
-      : build_log_(build_log),
-        disk_interface_(disk_interface),
-        dep_loader_(state, deps_log, disk_interface, depfile_parser_options),
-        dyndep_loader_(state, disk_interface) {}
+                 DepfileParserOptions const* depfile_parser_options,
+                 Explanations* explanations)
+      : build_log_(build_log), disk_interface_(disk_interface),
+        dep_loader_(state, deps_log, disk_interface, depfile_parser_options,
+                    explanations),
+        dyndep_loader_(state, disk_interface), explanations_(explanations) {}
 
   /// Update the |dirty_| state of the given nodes by transitively inspecting
   /// their input edges.
@@ -375,10 +380,13 @@ struct DependencyScan {
   bool RecomputeOutputDirty(const Edge* edge, const Node* most_recent_input,
                             const std::string& command, Node* output);
 
+  void RecordExplanation(const Node* node, const char* fmt, ...);
+
   BuildLog* build_log_;
   DiskInterface* disk_interface_;
   ImplicitDepLoader dep_loader_;
   DyndepLoader dyndep_loader_;
+  OptionalExplanations explanations_;
 };
 
 // Implements a less comparison for edges by priority, where highest

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #include "graph.h"
-#include "build.h"
 
+#include "build.h"
 #include "test.h"
 
 using namespace std;
 
 struct GraphTest : public StateTestWithBuiltinRules {
-  GraphTest() : scan_(&state_, NULL, NULL, &fs_, NULL) {}
+  GraphTest() : scan_(&state_, NULL, NULL, &fs_, NULL, NULL) {}
 
   VirtualFileSystem fs_;
   DependencyScan scan_;

--- a/src/missing_deps.cc
+++ b/src/missing_deps.cc
@@ -33,9 +33,9 @@ struct NodeStoringImplicitDepLoader : public ImplicitDepLoader {
   NodeStoringImplicitDepLoader(
       State* state, DepsLog* deps_log, DiskInterface* disk_interface,
       DepfileParserOptions const* depfile_parser_options,
-      std::vector<Node*>* dep_nodes_output)
+      Explanations* explanations, std::vector<Node*>* dep_nodes_output)
       : ImplicitDepLoader(state, deps_log, disk_interface,
-                          depfile_parser_options),
+                          depfile_parser_options, explanations),
         dep_nodes_output_(dep_nodes_output) {}
 
  protected:
@@ -98,7 +98,8 @@ void MissingDependencyScanner::ProcessNode(Node* node) {
     DepfileParserOptions parser_opts;
     std::vector<Node*> depfile_deps;
     NodeStoringImplicitDepLoader dep_loader(state_, deps_log_, disk_interface_,
-                                            &parser_opts, &depfile_deps);
+                                            &parser_opts, nullptr,
+                                            &depfile_deps);
     std::string err;
     dep_loader.LoadDeps(edge, &err);
     if (!depfile_deps.empty())

--- a/src/status.h
+++ b/src/status.h
@@ -19,6 +19,7 @@
 
 struct BuildConfig;
 struct Edge;
+struct Explanations;
 
 /// Abstract interface to object that tracks the status of a build:
 /// completion fraction, printing updates.
@@ -32,6 +33,11 @@ struct Status {
                                  const std::string& output) = 0;
   virtual void BuildStarted() = 0;
   virtual void BuildFinished() = 0;
+
+  /// Set the Explanations instance to use to report explanations,
+  /// argument can be nullptr if no explanations need to be printed
+  /// (which is the default).
+  virtual void SetExplanations(Explanations*) = 0;
 
   virtual void Info(const char* msg, ...) = 0;
   virtual void Warning(const char* msg, ...) = 0;

--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -417,12 +417,6 @@ void StatusPrinter::PrintStatus(const Edge* edge, int64_t time_millis) {
         fprintf(stderr, "ninja explain: %s\n", exp.c_str());
       }
     }
-  } else {
-    // DEPRECATED: Remove this code path once record_explanations() is
-    // no longer used by Ninja.
-    if (g_explaining) {
-      print_explanations(stderr, edge);
-    }
   }
 
   if (config_.verbosity == BuildConfig::QUIET

--- a/src/status_printer.h
+++ b/src/status_printer.h
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <queue>
 
+#include "explanations.h"
 #include "line_printer.h"
 #include "status.h"
 
@@ -48,6 +49,11 @@ struct StatusPrinter : Status {
   /// @param status The status of the edge.
   std::string FormatProgressStatus(const char* progress_status_format,
                                    int64_t time_millis) const;
+
+  /// Set the |explanations_| pointer. Used to implement `-d explain`.
+  void SetExplanations(Explanations* explanations) override {
+    explanations_ = explanations;
+  }
 
  private:
   void PrintStatus(const Edge* edge, int64_t time_millis);
@@ -82,6 +88,9 @@ struct StatusPrinter : Status {
 
   /// Prints progress output.
   LinePrinter printer_;
+
+  /// An optional Explaantions pointer, used to implement `-d explain`.
+  Explanations* explanations_ = nullptr;
 
   /// The custom progress status format to use.
   const char* progress_status_format_;


### PR DESCRIPTION
This is a followup for PR #2067 which cleans up the code base by removing the global variable, which was updated by calling record_explanation() from random places of the code. See [the comments on the original commits](https://github.com/ninja-build/ninja/pull/2067/commits/8e6c741a4b6c4f5cab4695016be2b0a8183bab83#r814232149) for the reasons to do so.

This does not change behavior in any way.

This also helps expose the extra coupling that the PR introduced, e.g. the StatusPrinter instance now needs to access the map of recorded explanations, so a new `Status::SetExplanations()` method must be added to the base `Status` virtual class to pass an appropriate pointer.

This could be avoided by ensuring the explanations are printed slightly earlier / later by the Builder class, but for now this will keep everything consistent.
