### PR TITLE
Flush stdout before calling _setmode on windows

### DIFF
--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -236,12 +236,14 @@ void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
 
 #ifdef _WIN32
     // Fix extra CR being added on Windows, writing out CR CR LF (#773)
-    _setmode(_fileno(stdout), _O_BINARY);  // Begin Windows extra CR fix
+    fflush(stdout);  // Begin Windows extra CR fix
+    _setmode(_fileno(stdout), _O_BINARY);
 #endif
 
     printer_.PrintOnNewLine(final_output);
 
 #ifdef _WIN32
+    fflush(stdout);
     _setmode(_fileno(stdout), _O_TEXT);  // End Windows extra CR fix
 #endif
   }


### PR DESCRIPTION
This fixes a partial regression of #773, where line endings in subprocess output are printed as CR CR LF on windows. The problem can be seen with the following build file:

```ninja
rule MYRULE
  command = cmd /C echo hello

build foo: MYRULE
```
Using `cat` from MinGW:
```bash
$ ninja.exe | cat -v
[1/1] cmd /C echo hello^M
hello^M^M
```
Note the double `^M`s.

I've bisected this to #2085, which enabled stdout buffering on windows. When `_setmode` is called, it seems that any buffered content also has the new mode applied to it (not the mode that was set when that content was written). Therefore, the buffer should be flushed before calling `_setmode`. This is described under the "Remarks" section here:

https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setmode

> If you write data to a file stream, explicitly flush the code by using [fflush](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fflush?view=msvc-170) before you use _setmode to change the mode. If you do not flush the code, you might get unexpected behavior.