### PR TITLE
cmake: disable min() and max() macros in windows.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,11 @@ if(WIN32)
 	# so that build environments which lack a C compiler, but have a C++
 	# compiler may build ninja.
 	set_source_files_properties(src/getopt.c PROPERTIES LANGUAGE CXX)
+
+	# windows.h defines min() and max() which conflict with std::min()
+	# and std::max(), which both might be used in sources. Avoid compile
+	# errors by telling windows.h to not define those two.
+	add_compile_definitions(NOMINMAX)
 else()
 	target_sources(libninja PRIVATE src/subprocess-posix.cc)
 	if(CMAKE_SYSTEM_NAME STREQUAL "OS400" OR CMAKE_SYSTEM_NAME STREQUAL "AIX")


### PR DESCRIPTION
Using std::min() and/or std::max() in sources where windows.h has been include fails with

    error C2589: '(': illegal token on right side of '::' [D:\a\ninja\ninja\build\libninja.vcxproj]
    error C2062: type 'unknown-type' unexpected [D:\a\ninja\ninja\build\libninja.vcxproj]
    error C2059: syntax error: ')' [D:\a\ninja\ninja\build\libninja.vcxproj]
    error C2589: '(': illegal token on right side of '::' [D:\a\ninja\ninja\build\libninja.vcxproj]
    error C2059: syntax error: ')' [D:\a\ninja\ninja\build\libninja.vcxproj]

Avoid this by defining NOMINMAX for windows builds, which causes the windows.h header to skip defining those two macros.