### PR TITLE
Implement GNU jobserver posix client support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,10 @@ if(WIN32)
 	# errors by telling windows.h to not define those two.
 	add_compile_definitions(NOMINMAX)
 else()
-	target_sources(libninja PRIVATE src/subprocess-posix.cc)
+	target_sources(libninja PRIVATE
+		src/jobserver-posix.cc
+		src/subprocess-posix.cc
+	)
 	if(CMAKE_SYSTEM_NAME STREQUAL "OS400" OR CMAKE_SYSTEM_NAME STREQUAL "AIX")
 		target_sources(libninja PRIVATE src/getopt.c)
 		# Build getopt.c, which can be compiled as either C or C++, as C++

--- a/configure.py
+++ b/configure.py
@@ -564,6 +564,7 @@ if platform.is_windows():
         objs += cxx('minidump-win32', variables=cxxvariables)
     objs += cc('getopt')
 else:
+    objs += cxx('jobserver-posix')
     objs += cxx('subprocess-posix')
 if platform.is_aix():
     objs += cc('getopt')

--- a/src/build.h
+++ b/src/build.h
@@ -24,6 +24,7 @@
 #include "depfile_parser.h"
 #include "exit_status.h"
 #include "graph.h"
+#include "jobserver.h"
 #include "util.h"  // int64_t
 
 struct BuildLog;
@@ -161,6 +162,7 @@ struct CommandRunner {
   virtual bool WaitForCommand(Result* result) = 0;
 
   virtual std::vector<Edge*> GetActiveEdges() { return std::vector<Edge*>(); }
+  virtual void ClearJobTokens(const std::vector<Edge*>&) {}
   virtual void Abort() {}
 };
 
@@ -187,9 +189,9 @@ struct BuildConfig {
 
 /// Builder wraps the build process: starting commands, updating status.
 struct Builder {
-  Builder(State* state, const BuildConfig& config, BuildLog* build_log,
-          DepsLog* deps_log, DiskInterface* disk_interface, Status* status,
-          int64_t start_time_millis);
+  Builder(State* state, const BuildConfig& config, Jobserver* jobserver,
+          BuildLog* build_log, DepsLog* deps_log, DiskInterface* disk_interface,
+          Status* status, int64_t start_time_millis);
   ~Builder();
 
   /// Clean up after interrupted commands by deleting output files.
@@ -224,6 +226,7 @@ struct Builder {
 
   State* state_;
   const BuildConfig& config_;
+  Jobserver* jobserver_;
   Plan plan_;
   std::unique_ptr<CommandRunner> command_runner_;
   Status* status_;

--- a/src/graph.h
+++ b/src/graph.h
@@ -227,6 +227,7 @@ struct Edge {
   bool deps_loaded_ = false;
   bool deps_missing_ = false;
   bool generated_by_dep_loader_ = false;
+  unsigned char job_token_ = '\0';
   TimeStamp command_start_time_ = 0;
 
   const Rule& rule() const { return *rule_; }

--- a/src/jobserver-posix.cc
+++ b/src/jobserver-posix.cc
@@ -1,0 +1,160 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "jobserver.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cassert>
+#include <cstring>
+
+#include "util.h"
+
+// Declare complete type for static constants in class.
+constexpr char const Jobserver::kAuthKey[];
+constexpr char const Jobserver::kFdsKey[];
+constexpr char const Jobserver::kFifoKey[];
+
+PosixJobserverClient::PosixJobserverClient() {
+  assert(!Enabled());
+
+  // Set name, type of pipe, and if non-parallel from MAKEFLAGS.
+  Parse();
+
+  const char* jobserver = jobserver_name_.c_str();
+
+  // Warn if jobserver type is unknown (neither fifo nor pipe).
+  if (!jobserver_fifo_ && sscanf(jobserver, "%d,%d", &rfd_, &wfd_) != 2)
+    if (!jobserver_name_.empty())
+      Warning("invalid jobserver auth: '%s'", jobserver);
+
+  // Open FDs to the pipe if needed, read must be non-blocking.
+  // If passed FDs are blocking on read, force non-parallel build.
+  if (jobserver_fifo_) {
+    rfd_ = open(jobserver + strlen(kFifoKey), O_RDONLY | O_NONBLOCK);
+    wfd_ = open(jobserver + strlen(kFifoKey), O_WRONLY);
+  } else if (Enabled() && (fcntl(rfd_, F_GETFL) & O_NONBLOCK) == 0) {
+    jobserver_closed_ = true;
+  }
+
+  // Exit on failure to open FDs, build non-parallel for invalid passed FDs.
+  if (Enabled())
+    Info("using jobserver: %s", jobserver);
+  else if (jobserver_fifo_ && (rfd_ == -1 || wfd_ == -1))
+    Fatal("failed to open jobserver: %s: %s", jobserver, strerror(errno));
+  else if (!jobserver_name_.empty())
+    jobserver_closed_ = true;
+
+  // Signal that we have initialized but do not have a token yet.
+  if (Enabled())
+    token_count_ = -1;
+}
+
+void PosixJobserverClient::Parse() {
+  // Return early if no makeflags are passed in the environment.
+  const char* makeflags = std::getenv("MAKEFLAGS");
+  if (makeflags == nullptr || strlen(makeflags) == 0)
+    return;
+
+  std::string::size_type flag_char = 0;
+  std::string flag;
+  std::vector<std::string> flags;
+
+  // Tokenize string to characters in flag, then words in flags.
+  while (flag_char < strlen(makeflags)) {
+    while (flag_char < strlen(makeflags) &&
+           !isblank(static_cast<unsigned char>(makeflags[flag_char]))) {
+      flag.push_back(static_cast<unsigned char>(makeflags[flag_char]));
+      flag_char++;
+    }
+
+    if (!flag.empty())
+      flags.push_back(flag);
+
+    flag.clear();
+    flag_char++;
+  }
+
+  // --jobserver-auth=<val>
+  for (size_t n = 0; n < flags.size(); n++)
+    if (flags[n].find(kAuthKey) == 0)
+      flag = flags[n].substr(strlen(kAuthKey));
+
+  // --jobserver-fds=<val>
+  if (flag.empty())
+    for (size_t n = 0; n < flags.size(); n++)
+      if (flags[n].find(kFdsKey) == 0)
+        flag = flags[n].substr(strlen(kFdsKey));
+
+  // -j 1
+  if (flag.empty())
+    for (size_t n = 0; n < flags.size(); n++)
+      if (flags[n].find("-j") == 0)
+        jobserver_closed_ = true;
+
+  // Check for fifo pipe.
+  if (flag.find(kFifoKey) == 0)
+    jobserver_fifo_ = true;
+
+  jobserver_name_.assign(flag);
+}
+
+bool PosixJobserverClient::Enabled() const {
+  return (rfd_ >= 0 && wfd_ >= 0) || jobserver_closed_;
+}
+
+unsigned char PosixJobserverClient::Acquire() {
+  unsigned char token = '\0';
+
+  // The first token is implicitly handed to a process.
+  // Fallback to non-parallel if jobserver-capable parent has no pipe.
+  if (token_count_ <= 0 || jobserver_closed_) {
+    token_count_ = 1;
+    return token;
+  }
+
+  int ret = read(rfd_, &token, 1);
+  if (ret < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+    jobserver_closed_ = true;
+    if (!jobserver_fifo_)
+      Warning("pipe closed: %d (mark the command as recursive)", rfd_);
+    else
+      Fatal("failed to read from jobserver: %d: %s", rfd_, strerror(errno));
+  }
+
+  if (ret > 0)
+    token_count_++;
+
+  return token;
+}
+
+void PosixJobserverClient::Release(unsigned char* token) {
+  if (token_count_ < 0)
+    token_count_ = 0;
+  if (token_count_ > 0)
+    token_count_--;
+
+  // The first token is implicitly handed to a process.
+  // Writing is not possible if the pipe is closed.
+  if (*token == '\0' || jobserver_closed_)
+    return;
+
+  int ret = write(wfd_, token, 1);
+  if (ret != 1) {
+    Fatal("failed to write to jobserver: %d: %s", wfd_, strerror(errno));
+  }
+
+  *token = '\0';
+}

--- a/src/jobserver.h
+++ b/src/jobserver.h
@@ -1,0 +1,112 @@
+// Copyright 2024 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+/// The GNU jobserver limits parallelism by assigning a token from an external
+/// pool for each command. On posix systems, the pool is a fifo or simple pipe
+/// with N characters. On windows systems, the pool is a semaphore initialized
+/// to N. When a command is finished, the acquired token is released by writing
+/// it back to the fifo or pipe or by increasing the semaphore count.
+///
+/// The jobserver functionality is enabled by passing --jobserver-auth=<val>
+/// (previously --jobserver-fds=<val> in older versions of Make) in the MAKEFLAGS
+/// environment variable and creating the respective file descriptors or objects.
+/// On posix systems, <val> is 'fifo:<name>' or '<read_fd>,<write_fd>' for pipes.
+/// On windows systems, <val> is the name of the semaphore.
+///
+/// The classes parse the MAKEFLAGS variable and opens an object handle if needed.
+/// Once enabled, Acquire() must be called to acquire a token from the pool.
+/// If a token is acquired, a new command can be started.
+/// Once the command is completed, Release() must be called to return a token.
+/// The token server does not care in which order a token is received.
+struct Jobserver {
+  /// Return current token count or initialization signal if negative.
+  int Tokens() const { return token_count_; }
+
+  /// Read MAKEFLAGS environment variable and process the jobserver flag value.
+  virtual void Parse() {};
+
+  /// Return true if jobserver functionality is enabled and initialized.
+  virtual bool Enabled() const { return false; }
+
+  /// Implementation-specific method to acquire a token from the external pool
+  /// which is called for all tokens but returns early for the first token.
+  /// This method is called every time Ninja needs to start a command process.
+  /// Return a non-NUL char value on success (token acquired), and '\0' on failure.
+  /// First call always succeeds. Ninja is aborted on read errors from a fifo pipe.
+  /// The return is the token character to be saved for release after work is done.
+  virtual unsigned char Acquire() { return '\0'; }
+
+  /// Implementation-specific method to release a token to the external pool
+  /// which is called for all tokens but returns early for the last token.
+  /// The parameter is the token returned by Acquire() to be sent to the token server.
+  /// A token with the default value of '\0' will not be sent to the token server.
+  /// After sent, the token that the pointer parameter points to is cleared to '\0'.
+  /// It must be called for each successful call to Acquire() after the command exits,
+  /// even if subprocesses fail or in the case of errors causing Ninja to exit.
+  /// Ninja is aborted on write errors, and calls always decrement token count.
+  virtual void Release(unsigned char*) {};
+
+ protected:
+  /// The number of currently acquired tokens, or a status signal if negative.
+  /// This is used to estimate the load capacity for attempting to start a new job,
+  /// and when the implicit (first) token has been acquired (initialization).
+  /// -1: initialized without a token
+  ///  0: uninitialized or disabled
+  /// +n: number of tokens in use
+  int token_count_ = 0;
+
+  /// Whether a pipe to the jobserver token pool is closed
+  /// when it is expected to be open based on MAKEFLAGS
+  /// (e.g. subcommands not marked recursive, environment passed),
+  /// or the pipe is closed when expected to be closed
+  /// but when the parent process is jobserver-capable
+  /// (e.g. the parent jobserver process build is non-parallel).
+  bool jobserver_closed_ = false;
+
+  /// String of the parsed value of the jobserver flag passed to environment.
+  std::string jobserver_name_;
+
+  /// Substrings for parsing MAKEFLAGS environment variable.
+  static constexpr char const kAuthKey[] = "--jobserver-auth=";
+  static constexpr char const kFdsKey[]  = "--jobserver-fds=";
+  static constexpr char const kFifoKey[] = "fifo:";
+};
+
+struct PosixJobserverClient : public Jobserver {
+  /// Parse the MAKEFLAGS environment variable to receive the path / FDs
+  /// of the token pool, and open the handle to the pool if it is an object.
+  /// If a jobserver argument is found in the MAKEFLAGS environment variable,
+  /// and the handle is successfully opened, later calls to Enable() return true.
+  /// If a jobserver argument is found, but the handle fails to be opened,
+  /// the ninja process is aborted with an error, or, when the FDs provided are bad
+  /// the build falls back to non-parallel building and the client does not read.
+  explicit PosixJobserverClient();
+
+  void Parse() override;
+  bool Enabled() const override;
+  unsigned char Acquire() override;
+  void Release(unsigned char*) override;
+
+ private:
+  /// Whether the type of jobserver pipe supplied to ninja is named.
+  bool jobserver_fifo_ = false;
+
+  /// File descriptors to communicate with upstream jobserver token pool.
+  int rfd_ = -1;
+  int wfd_ = -1;
+};


### PR DESCRIPTION
a rework of #2450 supporting all versions of GNU Make, but without Windows support
(I'm not able to test for Windows, and I have doubts with proposed Windows support)

resolves #1139 for posix systems

thanks to @hundeboll for much of the work with this newer implementation

ping @jhasse @digit-google 

significant differences:
 - no changes to any function parameters
 - no new intermediary functions
 - instantiate client support in real_main() instead of Plan
 - pass ~~references~~ pointers to the jobserver class into other classes
 - use a constructor to initialize jobserver client
 - release all tokens on any fatal error
 - calculate a value for "load capacity" instead of returning `SIZE_MAX`
 - supports both fifo and simple pipe file descriptors from Make
 - detect invalid or closed pipe and inform user about the most likely reason