### PR TITLE
Support single statement usage of dyndep

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -211,8 +211,10 @@ bool Plan::EdgeFinished(Edge* edge, EdgeResult result, string* err) {
   edge->outputs_ready_ = true;
 
   // Check off any nodes we were waiting for with this edge.
-  for (vector<Node*>::iterator o = edge->outputs_.begin();
-       o != edge->outputs_.end(); ++o) {
+  // Iterate over a copy, since NodeFinished might update (implicit) outputs.
+  vector<Node*> edgeOutputs(edge->outputs_);
+  for (vector<Node*>::iterator o = edgeOutputs.begin();
+       o != edgeOutputs.end(); ++o) {
     if (!NodeFinished(*o, err))
       return false;
   }

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -405,7 +405,11 @@ bool ManifestParser::ParseEdge(string* err) {
     vector<Node*>::iterator dgi =
       std::find(edge->inputs_.begin(), edge->inputs_.end(), edge->dyndep_);
     if (dgi == edge->inputs_.end()) {
-      return lexer_.Error("dyndep '" + dyndep + "' is not an input", err);
+      //dyndep not found in inputs, lets check if we have it as output
+      dgi = std::find(edge->outputs_.begin(), edge->outputs_.end(), edge->dyndep_);
+      if (dgi == edge->outputs_.end()) {
+        return lexer_.Error("dyndep '" + dyndep + "' is not an input nor an output", err);
+      }
     }
     assert(!edge->dyndep_->generated_by_dep_loader());
   }

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -1086,7 +1086,7 @@ TEST_F(ParserTest, DyndepNotInput) {
 "build result: touch\n"
 "  dyndep = notin\n",
                                &err));
-  EXPECT_EQ("input:5: dyndep 'notin' is not an input\n", err);
+  EXPECT_EQ("input:5: dyndep 'notin' is not an input nor an output\n", err);
 }
 
 TEST_F(ParserTest, DyndepExplicitInput) {


### PR DESCRIPTION
We've been using dynout from #1953 successfully for some years, until recently we encountered a problem with it https://github.com/ninja-build/ninja/pull/1953#issuecomment-2117545688. 
#1953 has in the meantime been discontinued in favor of #2366 for which we encountered other issues (there has been progress and improvements addressing them in the meantime).

During all this, we had a closer look at the dyndep implementation and asked ourselves, whether that could be used from within a single build statement, too. Something like this:
```
rule dyndepRule
   command = cmd /C echo test>$out&&echo foobar>output.dynamic&&(echo ninja_dyndep_version = 1 & echo build $out ^| output.dynamic : dyndep) > dyndep

build output.static | dyndep: dyndepRule input
   dyndep = dyndep

default output.static
```
In this example we create an `output.static` explicitly and during execution it is discovered that the build statement will have a dynamic output `output.dynamic`, which is communicated to Ninja via the `dyndep` file. Just like one would use the `dynout` from #1953 / #2366.

While trying that, we immediately ran into some errors complaining that this is creating a cyclic dependency on itself. But digging deeper, we did not discover why these errors must be thrown. Moreover, we proceeded by removing them. Added some small workarounds and eventually reached a state in which it seems to work. Though, we focused on dynamic outputs and did not do a single test with dynamic inputs yet.

This PR is not meant to be in a state worth merging at this moment, as clearly we didn't add any tests (shame!) and added a lot of code duplication that deserves some extract method refactorings.
Right now, I would wish to use this PR as a means to discuss whether this direction is worth proceeding. Moreover, I want to raise the question: did we miss something conceptually why this approach will not generalize?