### PR TITLE
Add 'dupbuild' as deprecated warning

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1230,6 +1230,10 @@ bool WarningEnable(const string& name, Options* options) {
   } else if (name == "phonycycle=warn") {
     options->phony_cycle_should_err = false;
     return true;
+  } else if (name == "dupbuild=err" ||
+             name == "dupbuild=warn") {
+    Warning("deprecated warning 'dupbuild'");
+    return true;
   } else if (name == "depfilemulti=err" ||
              name == "depfilemulti=warn") {
     Warning("deprecated warning 'depfilemulti'");


### PR DESCRIPTION
Fixup after 8f47d5aa33c6c303a71093be2eac02672dfb2966

Since v1.12 ninja breaks compatibility with existing generators, particularly bob build system, which always invokes ninja with -w dupbuild=err

See: https://github.com/ARM-software/bob-build/blob/master/bob.bash

This patch should also be applied to the 'release' branch.