### PR TITLE
Remove warnings

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -48,12 +48,10 @@ namespace {
 
 /// A CommandRunner that doesn't actually run the commands.
 struct DryRunCommandRunner : public CommandRunner {
-  virtual ~DryRunCommandRunner() {}
-
   // Overridden from CommandRunner:
-  virtual size_t CanRunMore() const;
-  virtual bool StartCommand(Edge* edge);
-  virtual bool WaitForCommand(Result* result);
+  size_t CanRunMore() const override;
+  bool StartCommand(Edge* edge) override;
+  bool WaitForCommand(Result* result) override;
 
  private:
   queue<Edge*> finished_;
@@ -595,12 +593,11 @@ void Plan::Dump() const {
 
 struct RealCommandRunner : public CommandRunner {
   explicit RealCommandRunner(const BuildConfig& config) : config_(config) {}
-  virtual ~RealCommandRunner() {}
-  virtual size_t CanRunMore() const;
-  virtual bool StartCommand(Edge* edge);
-  virtual bool WaitForCommand(Result* result);
-  virtual vector<Edge*> GetActiveEdges();
-  virtual void Abort();
+  size_t CanRunMore() const override;
+  bool StartCommand(Edge* edge) override;
+  bool WaitForCommand(Result* result) override;
+  vector<Edge*> GetActiveEdges() override;
+  void Abort() override;
 
   const BuildConfig& config_;
   SubprocessSet subprocs_;

--- a/src/explanations.h
+++ b/src/explanations.h
@@ -53,7 +53,6 @@ struct Explanations {
   }
 
  private:
-  bool enabled_ = false;
   std::unordered_map<const void*, std::vector<std::string>> map_;
 };
 

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -37,15 +37,6 @@ int64_t HighResTimer() {
       .count();
 }
 
-constexpr int64_t GetFrequency() {
-  // If numerator isn't 1 then we lose precision and that will need to be
-  // assessed.
-  static_assert(std::chrono::steady_clock::period::num == 1,
-                "Numerator must be 1");
-  return std::chrono::steady_clock::period::den /
-         std::chrono::steady_clock::period::num;
-}
-
 int64_t TimerToMicros(int64_t dt) {
   // dt is in ticks.  We want microseconds.
   return chrono::duration_cast<chrono::microseconds>(

--- a/src/status_printer.h
+++ b/src/status_printer.h
@@ -26,21 +26,19 @@ struct StatusPrinter : Status {
   explicit StatusPrinter(const BuildConfig& config);
 
   /// Callbacks for the Plan to notify us about adding/removing Edge's.
-  virtual void EdgeAddedToPlan(const Edge* edge);
-  virtual void EdgeRemovedFromPlan(const Edge* edge);
+  void EdgeAddedToPlan(const Edge* edge) override;
+  void EdgeRemovedFromPlan(const Edge* edge) override;
 
-  virtual void BuildEdgeStarted(const Edge* edge, int64_t start_time_millis);
-  virtual void BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
+  void BuildEdgeStarted(const Edge* edge, int64_t start_time_millis) override;
+  void BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
                                  int64_t end_time_millis, bool success,
-                                 const std::string& output);
-  virtual void BuildStarted();
-  virtual void BuildFinished();
+                                 const std::string& output) override;
+  void BuildStarted() override;
+  void BuildFinished() override;
 
-  virtual void Info(const char* msg, ...);
-  virtual void Warning(const char* msg, ...);
-  virtual void Error(const char* msg, ...);
-
-  virtual ~StatusPrinter() {}
+  void Info(const char* msg, ...) override;
+  void Warning(const char* msg, ...) override;
+  void Error(const char* msg, ...) override;
 
   /// Format the progress status string by replacing the placeholders.
   /// See the user manual for more information about the available


### PR DESCRIPTION
Remove multiple C++ compiler warnings

A small series of patches to remove annoying warnings that appear with recent compilers, e.g. Clang 16.0

- status_printer.h: Add `override` statements to method declarations.
- explanations.h: Remove unused private member `Explanations::enabled_`.
- metrics.cc: Remove unused anonymous `GetFrequence()` function.
- build.cc: Add `override` directives to `CommandRunner` subclasses.