### PR TITLE
Ensure depfile's parent directory is created before running an action.

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -178,6 +178,21 @@ build a: cat
             except subprocess.CalledProcessError as err:
                 self.fail("non-zero exit code with: " + err.output)
 
+    def test_depfile_directory_creation(self) -> None:
+        b = BuildDir('''\
+            rule touch
+              command = touch $out && echo "$out: extra" > $depfile
+
+            build somewhere/out: touch
+              depfile = somewhere_else/out.d
+            ''')
+        with b:
+            self.assertEqual(b.run('', pipe=True), dedent('''\
+                [1/1] touch somewhere/out && echo "somewhere/out: extra" > somewhere_else/out.d
+                '''))
+            self.assertTrue(os.path.isfile(os.path.join(b.d.name, "somewhere", "out")))
+            self.assertTrue(os.path.isfile(os.path.join(b.d.name, "somewhere_else", "out.d")))
+
     def test_status(self) -> None:
         self.assertEqual(run(''), 'ninja: no work to do.\n')
         self.assertEqual(run('', pipe=True), 'ninja: no work to do.\n')

--- a/src/build.cc
+++ b/src/build.cc
@@ -903,6 +903,12 @@ bool Builder::StartEdge(Edge* edge, string* err) {
 
   edge->command_start_time_ = build_start;
 
+  // Create depfile directory if needed.
+  // XXX: this may also block; do we care?
+  std::string depfile = edge->GetUnescapedDepfile();
+  if (!depfile.empty() && !disk_interface_->MakeDirs(depfile))
+    return false;
+
   // Create response file, if needed
   // XXX: this may also block; do we care?
   string rspfile = edge->GetUnescapedRspfile();


### PR DESCRIPTION
For most actions, the depfile will be in the same directory as one of its outputs, and their  parent directory will be created by Ninja before running the command. However, this is not always the case.

In particular, the GN build tool is changing its Ninja build plan generation logic, switching from using stamp files to phony targets, after issue #478 was fixed in Ninja. For additionnal context see https://gn-review.googlesource.com/c/gn/+/11380.

The newly generated build plans trigger this condition more frequently, which results in flaky build failures for large GN-based projects such as Fuchsia.

This patch ensures the depfile's parent directory is always created before the command is launched to get rid of the issue entirely.