### PR TITLE
fix typos

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -526,7 +526,7 @@ void Plan::ComputeCriticalPath() {
   for (Edge* edge : sorted_edges)
     edge->set_critical_path_weight(EdgeWeightHeuristic(edge));
 
-  // Second propagate / increment weidghts from
+  // Second propagate / increment weights from
   // children to parents. Scan the list
   // in reverse order to do so.
   for (auto reverse_it = sorted_edges.rbegin();

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1852,7 +1852,7 @@ TEST_F(BuildWithLogTest, RestatSingleDependentOutputDirty) {
   // out2 and out3 will be built even though "in" is not touched when built.
   // Then, since out2 is rebuilt, out4 should be rebuilt -- the restat on the
   // "true" rule should not lead to the "touch" edge writing out2 and out3 being
-  // cleard.
+  // cleared.
   command_runner_.commands_ran_.clear();
   state_.Reset();
   EXPECT_TRUE(builder_.AddTarget("out4", &err));
@@ -3261,7 +3261,7 @@ TEST_F(BuildWithDepsLogTest, RestatMissingDepfileDepslog) {
 
   // Touch 'header.in', blank dependencies log (create a different one).
   // Building header.h triggers 'restat' outputs cleanup.
-  // Validate that out is rebuilt netherless, as deps are missing.
+  // Validate that out is rebuilt nevertheless, as deps are missing.
   fs_.Tick();
   fs_.Create("header.in", "");
 

--- a/src/json.h
+++ b/src/json.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-// Encode a string in JSON format without encolsing quotes
+// Encode a string in JSON format without enclosing quotes
 std::string EncodeJSONString(const std::string& in);
 
 // Print a string in JSON format to stdout without enclosing quotes

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -154,7 +154,7 @@ struct NinjaMain : public BuildLogUser {
   bool RebuildManifest(const char* input_file, string* err, Status* status);
 
   /// For each edge, lookup in build log how long it took last time,
-  /// and record that in the edge itself. It will be used for ETA predicton.
+  /// and record that in the edge itself. It will be used for ETA prediction.
   void ParsePreviousElapsedTimes();
 
   /// Build the targets listed on the command line.


### PR DESCRIPTION
opened as a Draft as `netherless` might be replaced with another string

```
$ sed -n '3264p' ninja/src/build_test.cc
  // Validate that out is rebuilt netherless, as deps are missing.
$ 
```