### PR TITLE
fix typo

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -786,7 +786,7 @@ A file is a series of declarations.  A declaration can be one of:
    Order-only dependencies may be tacked on the end with +||
    _dependency1_ _dependency2_+.  (See <<ref_dependencies,the reference on
    dependency types>>.)
-   Validations may be taken on the end with +|@ _validation1_ _validation2_+.
+   Validations may be tacked on the end with +|@ _validation1_ _validation2_+.
    (See <<validations,the reference on validations>>.)
 +
 Implicit outputs _(available since Ninja 1.7)_ may be added before


### PR DESCRIPTION
@jhasse

> "fixed" by ninja-build/ninja@2d17936

correct string replacement somewhat obvious from the preceding text

```
$ sed -n '782,794p' ninja/doc/manual.asciidoc
2. A build edge, which looks like +build _output1_ _output2_:
   _rulename_ _input1_ _input2_+. +
   Implicit dependencies may be tacked on the end with +|
   _dependency1_ _dependency2_+. +
   Order-only dependencies may be tacked on the end with +||
   _dependency1_ _dependency2_+.  (See <<ref_dependencies,the reference on
   dependency types>>.)
   Validations may be taken on the end with +|@ _validation1_ _validation2_+.
   (See <<validations,the reference on validations>>.)
+
Implicit outputs _(available since Ninja 1.7)_ may be added before
the `:` with +| _output1_ _output2_+ and do not appear in `$out`.
(See <<ref_outputs,the reference on output types>>.)
$ 
```