### PR TITLE
Update status periodically in smart terminals

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -190,7 +190,8 @@ you don't need to pass `-j`.)
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 
-Ninja supports one environment variable to control its behavior:
+Ninja supports a few environment variables to control its behavior:
+
 `NINJA_STATUS`, the progress status printed before the rule being run.
 
 Several placeholders are available:
@@ -214,6 +215,12 @@ specified by `-j` or its default)
 The default progress status is `"[%f/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status
 could be `"[%u/%r/%f] "`.
+
+`NINJA_STATUS_REFRESH_MILLIS`, the refresh timeout in milliseconds
+for status updates in interactive terminals. The default value is 1000,
+to allow time-sensitive formatters like `%w` to be updated during
+long build runs (e.g. when one or more build commands run for a long
+time).
 
 Extra tools
 ~~~~~~~~~~~

--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -16,6 +16,7 @@ from typing import Dict
 
 default_env = dict(os.environ)
 default_env.pop('NINJA_STATUS', None)
+default_env.pop('NINJA_STATUS_REFRESH_MILLIS', None)
 default_env.pop('CLICOLOR_FORCE', None)
 default_env['TERM'] = ''
 NINJA_PATH = os.path.abspath('./ninja')
@@ -284,6 +285,41 @@ build zoo: touch bar
         'Do we suppress the status information when --quiet is specified?'
         output = run(Output.BUILD_SIMPLE_ECHO, flags='--quiet')
         self.assertEqual(output, 'do thing\n')
+
+    @unittest.skip("Time-based test fails on Github CI")
+    def test_ninja_status_periodic_update(self) -> None:
+        b =  BuildDir('''\
+           rule sleep_then_print
+             command = sleep 2 && echo done
+             description = sleep2s
+
+           build all: sleep_then_print
+           ''')
+        with b:
+          env = default_env.copy()
+          env["NINJA_STATUS"] = "[%w] "
+          self.assertListEqual(
+            b.run('all', raw_output=True, env=env).replace("\r\n", "<CRLF>").split("\r"),
+            [
+              "",
+              "[00:00] sleep2s\x1b[K",
+              "[00:01] sleep2s\x1b[K",
+              "[00:02] sleep2s\x1b[K",
+              "[00:02] sleep2s\x1b[K<CRLF>done<CRLF>",
+            ])
+
+          env["NINJA_STATUS_REFRESH_MILLIS"] = "500"
+          self.assertListEqual(
+            b.run('all', raw_output=True, env=env).replace("\r\n", "<CRLF>").split("\r"),
+            [
+              "",
+              "[00:00] sleep2s\x1b[K",
+              "[00:00] sleep2s\x1b[K",
+              "[00:01] sleep2s\x1b[K",
+              "[00:01] sleep2s\x1b[K",
+              "[00:02] sleep2s\x1b[K",
+              "[00:02] sleep2s\x1b[K<CRLF>done<CRLF>",
+            ])
 
     def test_entering_directory_on_stdout(self) -> None:
         output = run(Output.BUILD_SIMPLE_ECHO, flags='-C$PWD', pipe=True)

--- a/src/build.cc
+++ b/src/build.cc
@@ -76,6 +76,9 @@ bool DryRunCommandRunner::WaitForCommand(Result* result) {
    return true;
 }
 
+// A callable value used to refresh the current Ninja status.
+using StatusRefresher = std::function<void(void)>;
+
 }  // namespace
 
 Plan::Plan(Builder* builder)
@@ -592,7 +595,9 @@ void Plan::Dump() const {
 }
 
 struct RealCommandRunner : public CommandRunner {
-  explicit RealCommandRunner(const BuildConfig& config) : config_(config) {}
+  explicit RealCommandRunner(const BuildConfig& config,
+                             StatusRefresher&& refresh_status)
+      : config_(config), refresh_status_(std::move(refresh_status)) {}
   size_t CanRunMore() const override;
   bool StartCommand(Edge* edge) override;
   bool WaitForCommand(Result* result) override;
@@ -600,6 +605,7 @@ struct RealCommandRunner : public CommandRunner {
   void Abort() override;
 
   const BuildConfig& config_;
+  StatusRefresher refresh_status_;
   SubprocessSet subprocs_;
   map<const Subprocess*, Edge*> subproc_to_edge_;
 };
@@ -651,8 +657,13 @@ bool RealCommandRunner::StartCommand(Edge* edge) {
 bool RealCommandRunner::WaitForCommand(Result* result) {
   Subprocess* subproc;
   while ((subproc = subprocs_.NextFinished()) == NULL) {
-    bool interrupted = subprocs_.DoWork();
-    if (interrupted)
+    SubprocessSet::WorkResult ret =
+        subprocs_.DoWork(config_.status_refresh_millis);
+    if (ret == SubprocessSet::WorkResult::TIMEOUT) {
+      refresh_status_();
+      continue;
+    }
+    if (ret == SubprocessSet::WorkResult::INTERRUPTION)
       return false;
   }
 
@@ -772,10 +783,13 @@ bool Builder::Build(string* err) {
 
   // Set up the command runner if we haven't done so already.
   if (!command_runner_.get()) {
-    if (config_.dry_run)
+    if (config_.dry_run) {
       command_runner_.reset(new DryRunCommandRunner);
-    else
-      command_runner_.reset(new RealCommandRunner(config_));
+    } else {
+      command_runner_.reset(new RealCommandRunner(config_, [this]() {
+        status_->Refresh(GetTimeMillis() - start_time_millis_);
+      }));
+    }
   }
 
   // We are about to start the build process.

--- a/src/build.h
+++ b/src/build.h
@@ -166,8 +166,7 @@ struct CommandRunner {
 
 /// Options (e.g. verbosity, parallelism) passed to a build.
 struct BuildConfig {
-  BuildConfig() : verbosity(NORMAL), dry_run(false), parallelism(1),
-                  failures_allowed(1), max_load_average(-0.0f) {}
+  BuildConfig() = default;
 
   enum Verbosity {
     QUIET,  // No output -- used when testing.
@@ -175,13 +174,16 @@ struct BuildConfig {
     NORMAL,  // regular output and status update
     VERBOSE
   };
-  Verbosity verbosity;
-  bool dry_run;
-  int parallelism;
-  int failures_allowed;
+  Verbosity verbosity = NORMAL;
+  bool dry_run = false;
+  int parallelism = 1;
+  int failures_allowed = 1;
   /// The maximum load average we must not exceed. A negative value
   /// means that we do not have any limit.
-  double max_load_average;
+  double max_load_average = -0.0f;
+  /// Number of milliseconds between status refreshes in interactive
+  /// terminals.
+  int status_refresh_millis = 1000;
   DepfileParserOptions depfile_parser_options;
 };
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1546,6 +1546,11 @@ NORETURN void real_main(int argc, char** argv) {
   Options options = {};
   options.input_file = "build.ninja";
 
+  const char* status_refresh_env = getenv("NINJA_STATUS_REFRESH_MILLIS");
+  if (status_refresh_env) {
+    config.status_refresh_millis = atoi(status_refresh_env);
+  }
+
   setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
   const char* ninja_command = argv[0];
 

--- a/src/status.h
+++ b/src/status.h
@@ -34,6 +34,13 @@ struct Status {
   virtual void BuildStarted() = 0;
   virtual void BuildFinished() = 0;
 
+  /// Refresh status display after some time has passed.  Useful
+  /// when printing the status on an interactive terminal. Does
+  /// nothing by default. \arg cur_time_millis is the current time
+  /// expressed in milliseconds, using the same epoch than the
+  /// one used in BuildEdgeStart() and BuildEdgeFinished().
+  virtual void Refresh(int64_t cur_time_millis) {}
+
   /// Set the Explanations instance to use to report explanations,
   /// argument can be nullptr if no explanations need to be printed
   /// (which is the default).

--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -304,13 +304,13 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
 
         // Overall finished edges per second.
       case 'o':
-        SnprintfRate(finished_edges_ / (time_millis_ / 1e3), buf, "%.1f");
+        SnprintfRate(finished_edges_ / (time_millis / 1e3), buf, "%.1f");
         out += buf;
         break;
 
         // Current rate, average over the last '-j' jobs.
       case 'c':
-        current_rate_.UpdateRate(finished_edges_, time_millis_);
+        current_rate_.UpdateRate(finished_edges_, time_millis);
         SnprintfRate(current_rate_.rate(), buf, "%.1f");
         out += buf;
         break;
@@ -336,15 +336,15 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
       case 'E':  // ETA, seconds
       case 'W':  // ETA, human-readable
       {
-        double elapsed_sec = time_millis_ / 1e3;
+        double elapsed_sec = time_millis / 1e3;
         double eta_sec = -1;  // To be printed as "?".
         if (time_predicted_percentage_ != 0.0) {
-          // So, we know that we've spent time_millis_ wall clock,
+          // So, we know that we've spent time_millis wall clock,
           // and that is time_predicted_percentage_ percent.
           // How much time will we need to complete 100%?
-          double total_wall_time = time_millis_ / time_predicted_percentage_;
+          double total_wall_time = time_millis / time_predicted_percentage_;
           // Naturally, that gives us the time remaining.
-          eta_sec = (total_wall_time - time_millis_) / 1e3;
+          eta_sec = (total_wall_time - time_millis) / 1e3;
         }
 
         const bool print_with_hours =
@@ -428,15 +428,26 @@ void StatusPrinter::PrintStatus(const Edge* edge, int64_t time_millis) {
 
   bool force_full_command = config_.verbosity == BuildConfig::VERBOSE;
 
-  string to_print = edge->GetBinding("description");
-  if (to_print.empty() || force_full_command)
-    to_print = edge->GetBinding("command");
+  last_description_ = edge->GetBinding("description");
+  if (last_description_.empty() || force_full_command)
+    last_description_ = edge->GetBinding("command");
 
-  to_print = FormatProgressStatus(progress_status_format_, time_millis)
-      + to_print;
+  RefreshStatus(time_millis, force_full_command);
+}
 
+void StatusPrinter::RefreshStatus(int64_t cur_time_millis,
+                                  bool force_full_command) {
+  std::string to_print =
+      FormatProgressStatus(progress_status_format_, cur_time_millis) +
+      last_description_;
   printer_.Print(to_print,
                  force_full_command ? LinePrinter::FULL : LinePrinter::ELIDE);
+}
+
+void StatusPrinter::Refresh(int64_t cur_time_millis) {
+  if (printer_.is_smart_terminal()) {
+    RefreshStatus(cur_time_millis, false);
+  }
 }
 
 void StatusPrinter::Warning(const char* msg, ...) {

--- a/src/status_printer.h
+++ b/src/status_printer.h
@@ -36,6 +36,8 @@ struct StatusPrinter : Status {
   void BuildStarted() override;
   void BuildFinished() override;
 
+  void Refresh(int64_t cur_time_millis) override;
+
   void Info(const char* msg, ...) override;
   void Warning(const char* msg, ...) override;
   void Error(const char* msg, ...) override;
@@ -82,6 +84,8 @@ struct StatusPrinter : Status {
   /// For how many edges we don't know the previous run time?
   int eta_unpredictable_edges_remaining_ = 0;
 
+  void RefreshStatus(int64_t cur_time_millis, bool force_full_command);
+
   void RecalculateProgressPrediction();
 
   /// Prints progress output.
@@ -92,6 +96,9 @@ struct StatusPrinter : Status {
 
   /// The custom progress status format to use.
   const char* progress_status_format_;
+
+  /// Last command's description or command-line.
+  std::string last_description_;
 
   template <size_t S>
   void SnprintfRate(double rate, char (&buf)[S], const char* format) const {

--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -248,14 +248,38 @@ Subprocess *SubprocessSet::Add(const string& command, bool use_console) {
   return subprocess;
 }
 
-#ifdef USE_PPOLL
 bool SubprocessSet::DoWork() {
-  vector<pollfd> fds;
+  WorkResult ret = DoWork(-1);
+  return ret == WorkResult::INTERRUPTION;
+}
+
+// An optional timespec struct value for pselect() or ppoll(). Usage:
+// - Create instance, pass timeout in milliseconds.
+// - Call ptr() tp get the pointer to pass to pselect() or ppoll().
+struct TimeoutHelper {
+  // Constructor. A negative timeout_ms value means no timeout.
+  TimeoutHelper(int64_t timeout_ms) {
+    if (timeout_ms >= 0) {
+      ts_.tv_sec = static_cast<long>(timeout_ms / 1000);
+      ts_.tv_nsec = static_cast<long>((timeout_ms % 1000) * 1000000L);
+      ptr_ = &ts_;
+    }
+  }
+
+  const struct timespec* ptr() const { return ptr_; }
+
+ private:
+  struct timespec ts_ {};
+  const struct timespec* ptr_ = nullptr;
+};
+
+#ifdef USE_PPOLL
+SubprocessSet::WorkResult SubprocessSet::DoWork(int64_t timeout_millis) {
+  std::vector<pollfd> fds;
   nfds_t nfds = 0;
 
-  for (vector<Subprocess*>::iterator i = running_.begin();
-       i != running_.end(); ++i) {
-    int fd = (*i)->fd_;
+  for (const auto& proc : running_) {
+    int fd = proc->fd_;
     if (fd < 0)
       continue;
     pollfd pfd = { fd, POLLIN | POLLPRI, 0 };
@@ -264,49 +288,50 @@ bool SubprocessSet::DoWork() {
   }
 
   interrupted_ = 0;
-  int ret = ppoll(&fds.front(), nfds, NULL, &old_mask_);
+  TimeoutHelper timeout(timeout_millis);
+  int ret = ppoll(&fds.front(), nfds, timeout.ptr(), &old_mask_);
+  if (ret == 0) {
+    return WorkResult::TIMEOUT;
+  }
   if (ret == -1) {
     if (errno != EINTR) {
-      perror("ninja: ppoll");
-      return false;
+      Fatal("ppoll", strerror(errno));
     }
-    return IsInterrupted();
+    return IsInterrupted() ? WorkResult::INTERRUPTION : WorkResult::COMPLETION;
   }
 
   HandlePendingInterruption();
   if (IsInterrupted())
-    return true;
+    return WorkResult::INTERRUPTION;
 
   nfds_t cur_nfd = 0;
-  for (vector<Subprocess*>::iterator i = running_.begin();
-       i != running_.end(); ) {
-    int fd = (*i)->fd_;
+  for (auto it = running_.begin(); it != running_.end();) {
+    int fd = (*it)->fd_;
     if (fd < 0)
       continue;
     assert(fd == fds[cur_nfd].fd);
     if (fds[cur_nfd++].revents) {
-      (*i)->OnPipeReady();
-      if ((*i)->Done()) {
-        finished_.push(*i);
-        i = running_.erase(i);
+      (*it)->OnPipeReady();
+      if ((*it)->Done()) {
+        finished_.push(*it);
+        it = running_.erase(it);
         continue;
       }
     }
-    ++i;
+    ++it;
   }
 
-  return IsInterrupted();
+  return IsInterrupted() ? WorkResult::INTERRUPTION : WorkResult::COMPLETION;
 }
 
 #else  // !defined(USE_PPOLL)
-bool SubprocessSet::DoWork() {
+SubprocessSet::WorkResult SubprocessSet::DoWork(int64_t timeout_millis) {
   fd_set set;
   int nfds = 0;
   FD_ZERO(&set);
 
-  for (vector<Subprocess*>::iterator i = running_.begin();
-       i != running_.end(); ++i) {
-    int fd = (*i)->fd_;
+  for (const auto& proc : running_) {
+    int fd = proc->fd_;
     if (fd >= 0) {
       FD_SET(fd, &set);
       if (nfds < fd+1)
@@ -315,34 +340,37 @@ bool SubprocessSet::DoWork() {
   }
 
   interrupted_ = 0;
-  int ret = pselect(nfds, &set, 0, 0, 0, &old_mask_);
+  TimeoutHelper timeout(timeout_millis);
+  int ret = pselect(nfds, &set, 0, 0, timeout.ptr(), &old_mask_);
+  if (ret == 0)
+    return WorkResult::TIMEOUT;
+
   if (ret == -1) {
     if (errno != EINTR) {
-      perror("ninja: pselect");
-      return false;
+      Fatal("pselect", strerror(errno));
     }
-    return IsInterrupted();
+    return IsInterrupted() ? WorkResult::INTERRUPTION : WorkResult::COMPLETION;
   }
 
   HandlePendingInterruption();
   if (IsInterrupted())
-    return true;
+    return WorkResult::INTERRUPTION;
 
-  for (vector<Subprocess*>::iterator i = running_.begin();
-       i != running_.end(); ) {
-    int fd = (*i)->fd_;
+  for (std::vector<Subprocess*>::iterator it = running_.begin();
+       it != running_.end();) {
+    int fd = (*it)->fd_;
     if (fd >= 0 && FD_ISSET(fd, &set)) {
-      (*i)->OnPipeReady();
-      if ((*i)->Done()) {
-        finished_.push(*i);
-        i = running_.erase(i);
+      (*it)->OnPipeReady();
+      if ((*it)->Done()) {
+        finished_.push(*it);
+        it = running_.erase(it);
         continue;
       }
     }
-    ++i;
+    ++it;
   }
 
-  return IsInterrupted();
+  return IsInterrupted() ? WorkResult::INTERRUPTION : WorkResult::COMPLETION;
 }
 #endif  // !defined(USE_PPOLL)
 

--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -15,9 +15,11 @@
 #ifndef NINJA_SUBPROCESS_H_
 #define NINJA_SUBPROCESS_H_
 
+#include <stdint.h>
+
+#include <queue>
 #include <string>
 #include <vector>
-#include <queue>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -83,9 +85,43 @@ struct SubprocessSet {
   SubprocessSet();
   ~SubprocessSet();
 
+  // Value returned by DoWork() method,
+  // - COMPLETION means that a process has completed.
+  // - INTERRUPTION means that user interruption happened. On Posix this means
+  //   a SIGINT, SIGHUP or SIGTERM signal. On Win32, this means Ctrl-C was
+  //   pressed.
+  // - TIMEOUT means that the called timed out.
+  enum class WorkResult {
+    COMPLETION = 0,
+    INTERRUPTION = 1,
+    TIMEOUT = 3,
+  };
+
+  // Start a new subprocess running |command|. Set |use_console| to true
+  // if the process will inherit the current console handles (terminal
+  // input and outputs on Posix). If false, the subprocess' output
+  // will be buffered instead, and available after completion.
   Subprocess* Add(const std::string& command, bool use_console = false);
+
+  // Equivalent to DoWork(-1), which returns true in case of interruption
+  // and false otherwise.
   bool DoWork();
+
+  // Wait for at most |timeout_millis| milli-seconds for either a process
+  // completion or a user-initiated interruption. If |timeout_millis| is
+  // negative, waits indefinitely, and never return WorkStatus::TIMEOUT.
+  //
+  // IMPORTANT: On Posix, spurious wakeups are possible, and will return
+  // WorkResult::COMPLETION even though no process has really
+  // completed. The caller should call NextFinished() and compare the
+  // its result to nullptr to check for this rare condition.
+  WorkResult DoWork(int64_t timeout_millis);
+
+  // Return the next Subprocess after a WorkResult::COMPLETION result.
+  // The result can be nullptr on Posix in case of spurious wakeups.
+  // NOTE: This transfers ownership of the Subprocess instance to the caller.
   Subprocess* NextFinished();
+
   void Clear();
 
   std::vector<Subprocess*> running_;

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -146,6 +146,21 @@ TEST_F(SubprocessTest, InterruptParentWithSigHup) {
   ASSERT_FALSE("We should have been interrupted");
 }
 
+TEST_F(SubprocessTest, Timeout) {
+  Subprocess* subproc = subprocs_.Add("sleep 1");
+  ASSERT_NE((Subprocess*)0, subproc);
+  size_t timeout_count = 0;
+  while (true) {
+    ASSERT_FALSE(subproc->Done());
+    SubprocessSet::WorkResult ret = subprocs_.DoWork(100);
+    if (ret == SubprocessSet::WorkResult::TIMEOUT)
+      ++timeout_count;
+    else
+      break;
+  }
+  ASSERT_GT(timeout_count, 0);
+}
+
 TEST_F(SubprocessTest, Console) {
   // Skip test if we don't have the console ourselves.
   if (isatty(0) && isatty(1) && isatty(2)) {


### PR DESCRIPTION
Ensure that time-related `NINJA_STATUS` formatters such as `%w` as properly updated when running in a smart terminal.

This fixes issue #2515 by ensuring that Ninja can refresh its status even when only long commands are running.

- Modify `Subprocess::DoWork()` to accept a timeout, and return an enum describing the exit condition.
- Add `Status::Refresh()` and `StatusPrinter::Refresh()` to update the status on smart terminals.
- Modify `RealCommandRunner` to call `DoWork()` with a timeout, and call `status->Refresh()` on expiration to trigger the update.

The end result is that the status is properly updated in smart terminals when a single long command is invoked (see the example build plan in #2515).

NOTE: This adds a new regression test in `misc/output_test.py`, however, the test is flaky since it is time-dependent, i.e. it runs successfully on a lightly loaded laptop, but fails frequently on Github CI. Hence it is disabled by default but can be run manually during development.