### PR TITLE
Fix for #2520: Force C++11 for MacOS CI builder.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.15
       run: |
-        cmake -Bbuild -GXcode '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64'
+        cmake -Bbuild -GXcode '-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64' -DCMAKE_CXX_STANDARD=11
         cmake --build build --config Release
 
     - name: Test ninja (Release)

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1526,6 +1526,12 @@ int ReadFlags(int* argc, char*** argv,
   return -1;
 }
 
+// Check that this file is properly compiled in C++11 mode.
+// See PR #2520.
+#if __cplusplus < 201103
+#error "This file should be compiled with C++11 or higher!"
+#endif
+
 NORETURN void real_main(int argc, char** argv) {
   // Use exit() instead of return in this function to avoid potentially
   // expensive cleanup when destructing NinjaMain.


### PR DESCRIPTION
MacOS CI builders use a compiler which defaults to C++03. Unfortunately, CMakeLists.txt only forces C++11 for libninja, try to force it through CMAKE_CXX_STANDARD.

Note a few interesting points:

- Tests use GoogleTest which officially *requires* C++14. However, it seems that compiling them with C++03 or C++11 doesn´t seem to be an issue on this platform for now.

- To avoid future problems, it might be useful to enforce a separate default of C++14 for test programs.

- GoogleTest plans to switch to C++17 in December 2024 [1],

[1] https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md