### PR TITLE
Add multi-inputs tool

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -265,6 +265,47 @@ output files are out of date.
 rebuild those targets.
 _Available since Ninja 1.11._
 
+`multi-inputs`:: print one or more sets of inputs required to build targets.
+Each line will consist of a target, a delimiter, an input and a terminator character.
+The list produced by the tool can be helpful if one would like to know which targets
+that are affected by a certain input.
++
+The output will be a series of lines with the following elements:
++
+----
+<target> <delimiter> <input> <terminator>
+----
++
+The default `<delimiter>` is a single TAB character.
+The delimiter can be modified to any string using the `--delimiter` argument.
++
+The default `<terminator>` is a line terminator (i.e. `\n` on Posix and `\r\n` on Windows).
+The terminator can be changed to `\0` by using the `--print0` argument.
++
+----
+----
++
+Example usage of the `multi-inputs` tool:
++
+----
+ninja -t multi-inputs target1 target2 target3
+----
++
+Example of produced output from the `multi-inputs` tool:
++
+----
+target1 file1.c
+target2 file1.c
+target2 file2.c
+target3 file1.c
+target3 file2.c
+target3 file3.c
+----
++
+_Note that a given input may appear for several targets if it is used by more
+than one targets._
+_Available since Ninja 1.13._
+
 `clean`:: remove built files. By default, it removes all built files
 except for those created by the generator.  Adding the `-g` flag also
 removes built files created by the generator (see <<ref_rule,the rule

--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -449,6 +449,40 @@ options:
             self.assertEqual(expected, actual)
 
 
+    def test_tool_multi_inputs(self) -> None:
+        plan = '''
+rule cat
+  command = cat $in $out
+build out1 : cat in1
+build out2 : cat in1 in2
+build out3 : cat in1 in2 in3
+'''
+        self.assertEqual(run(plan, flags='-t multi-inputs out1'),
+'''out1<TAB>in1
+'''.replace("<TAB>", "\t"))
+
+        self.assertEqual(run(plan, flags='-t multi-inputs out1 out2 out3'),
+'''out1<TAB>in1
+out2<TAB>in1
+out2<TAB>in2
+out3<TAB>in1
+out3<TAB>in2
+out3<TAB>in3
+'''.replace("<TAB>", "\t"))
+
+        self.assertEqual(run(plan, flags='-t multi-inputs -d: out1'),
+'''out1:in1
+''')
+
+        self.assertEqual(
+          run(
+            plan,
+            flags='-t multi-inputs -d, --print0 out1 out2'
+          ),
+          '''out1,in1\0out2,in1\0out2,in2\0'''
+        )
+
+
     def test_explain_output(self):
         b = BuildDir('''\
             build .FORCE: phony


### PR DESCRIPTION
The 'multi-inputs' option will list all <target> + <inputs> for the given targets.

Run:
ninja -t multi-inputs target1 target2 target3

Ninja will then output:
target1 input_x
target1 input_y
target2 input_x
target2 input_z
target3 input_y