### PR TITLE
Update CI Mac builders to use macos-13

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This updates `macos.yml` to use `macos-13` instead of `macos-12`.

macos-12 is deprecated and results in longer queue times during peak hours. In practice, also failed builds.

For details, see https://github.com/actions/runner-images/issues/10721