### PR TITLE
Fix build log leak

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -41,8 +41,6 @@
 #define strtoll _strtoi64
 #endif
 
-using namespace std;
-
 // Implementation details:
 // Each run's log appends to the log file.
 // To load, we run through all log entries in series, throwing away
@@ -63,14 +61,12 @@ uint64_t BuildLog::LogEntry::HashCommand(StringPiece command) {
   return rapidhash(command.str_, command.len_);
 }
 
-BuildLog::LogEntry::LogEntry(const string& output)
-  : output(output) {}
+BuildLog::LogEntry::LogEntry(const std::string& output) : output(output) {}
 
-BuildLog::LogEntry::LogEntry(const string& output, uint64_t command_hash,
-  int start_time, int end_time, TimeStamp mtime)
-  : output(output), command_hash(command_hash),
-    start_time(start_time), end_time(end_time), mtime(mtime)
-{}
+BuildLog::LogEntry::LogEntry(const std::string& output, uint64_t command_hash,
+                             int start_time, int end_time, TimeStamp mtime)
+    : output(output), command_hash(command_hash), start_time(start_time),
+      end_time(end_time), mtime(mtime) {}
 
 BuildLog::BuildLog() = default;
 
@@ -78,8 +74,8 @@ BuildLog::~BuildLog() {
   Close();
 }
 
-bool BuildLog::OpenForWrite(const string& path, const BuildLogUser& user,
-                            string* err) {
+bool BuildLog::OpenForWrite(const std::string& path, const BuildLogUser& user,
+                            std::string* err) {
   if (needs_recompaction_) {
     if (!Recompact(path, user, err))
       return false;
@@ -93,11 +89,11 @@ bool BuildLog::OpenForWrite(const string& path, const BuildLogUser& user,
 
 bool BuildLog::RecordCommand(Edge* edge, int start_time, int end_time,
                              TimeStamp mtime) {
-  string command = edge->EvaluateCommand(true);
+  std::string command = edge->EvaluateCommand(true);
   uint64_t command_hash = LogEntry::HashCommand(command);
-  for (vector<Node*>::iterator out = edge->outputs_.begin();
+  for (std::vector<Node*>::iterator out = edge->outputs_.begin();
        out != edge->outputs_.end(); ++out) {
-    const string& path = (*out)->path();
+    const std::string& path = (*out)->path();
     Entries::iterator i = entries_.find(path);
     LogEntry* log_entry;
     if (i != entries_.end()) {
@@ -208,7 +204,7 @@ struct LineReader {
   char* line_end_;
 };
 
-LoadStatus BuildLog::Load(const string& path, string* err) {
+LoadStatus BuildLog::Load(const std::string& path, std::string* err) {
   METRIC_RECORD(".ninja_log load");
   FILE* file = fopen(path.c_str(), "r");
   if (!file) {
@@ -282,7 +278,7 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
     end = static_cast<char*>(memchr(start, kFieldSeparator, line_end - start));
     if (!end)
       continue;
-    string output = string(start, end - start);
+    std::string output(start, end - start);
 
     start = end + 1;
     end = line_end;
@@ -326,7 +322,7 @@ LoadStatus BuildLog::Load(const string& path, string* err) {
   return LOAD_SUCCESS;
 }
 
-BuildLog::LogEntry* BuildLog::LookupByOutput(const string& path) {
+BuildLog::LogEntry* BuildLog::LookupByOutput(const std::string& path) {
   Entries::iterator i = entries_.find(path);
   if (i != entries_.end())
     return i->second;
@@ -339,12 +335,12 @@ bool BuildLog::WriteEntry(FILE* f, const LogEntry& entry) {
           entry.output.c_str(), entry.command_hash) > 0;
 }
 
-bool BuildLog::Recompact(const string& path, const BuildLogUser& user,
-                         string* err) {
+bool BuildLog::Recompact(const std::string& path, const BuildLogUser& user,
+                         std::string* err) {
   METRIC_RECORD(".ninja_log recompact");
 
   Close();
-  string temp_path = path + ".recompact";
+  std::string temp_path = path + ".recompact";
   FILE* f = fopen(temp_path.c_str(), "wb");
   if (!f) {
     *err = strerror(errno);
@@ -357,7 +353,7 @@ bool BuildLog::Recompact(const string& path, const BuildLogUser& user,
     return false;
   }
 
-  vector<StringPiece> dead_outputs;
+  std::vector<StringPiece> dead_outputs;
   for (Entries::iterator i = entries_.begin(); i != entries_.end(); ++i) {
     if (user.IsPathDead(i->first)) {
       dead_outputs.push_back(i->first);

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -72,8 +72,7 @@ BuildLog::LogEntry::LogEntry(const string& output, uint64_t command_hash,
     start_time(start_time), end_time(end_time), mtime(mtime)
 {}
 
-BuildLog::BuildLog()
-  : log_file_(NULL), needs_recompaction_(false) {}
+BuildLog::BuildLog() = default;
 
 BuildLog::~BuildLog() {
   Close();

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -61,7 +61,7 @@ uint64_t BuildLog::LogEntry::HashCommand(StringPiece command) {
   return rapidhash(command.str_, command.len_);
 }
 
-BuildLog::LogEntry::LogEntry(const std::string& output) : output(output) {}
+BuildLog::LogEntry::LogEntry(std::string output) : output(std::move(output)) {}
 
 BuildLog::LogEntry::LogEntry(const std::string& output, uint64_t command_hash,
                              int start_time, int end_time, TimeStamp mtime)
@@ -288,7 +288,7 @@ LoadStatus BuildLog::Load(const std::string& path, std::string* err) {
     if (i != entries_.end()) {
       entry = i->second;
     } else {
-      entry = new LogEntry(output);
+      entry = new LogEntry(std::move(output));
       entries_.insert(Entries::value_type(entry->output, entry));
       ++unique_entry_count;
     }

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -57,10 +57,10 @@ struct BuildLog {
 
   struct LogEntry {
     std::string output;
-    uint64_t command_hash;
-    int start_time;
-    int end_time;
-    TimeStamp mtime;
+    uint64_t command_hash = 0;
+    int start_time = 0;
+    int end_time = 0;
+    TimeStamp mtime = 0;
 
     static uint64_t HashCommand(StringPiece command);
 
@@ -99,9 +99,9 @@ struct BuildLog {
   bool OpenForWriteIfNeeded();
 
   Entries entries_;
-  FILE* log_file_;
+  FILE* log_file_ = nullptr;
   std::string log_file_path_;
-  bool needs_recompaction_;
+  bool needs_recompaction_ = false;
 };
 
 #endif // NINJA_BUILD_LOG_H_

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -71,7 +71,7 @@ struct BuildLog {
           mtime == o.mtime;
     }
 
-    explicit LogEntry(const std::string& output);
+    explicit LogEntry(std::string output);
     LogEntry(const std::string& output, uint64_t command_hash,
              int start_time, int end_time, TimeStamp mtime);
   };

--- a/src/build_log.h
+++ b/src/build_log.h
@@ -15,8 +15,10 @@
 #ifndef NINJA_BUILD_LOG_H_
 #define NINJA_BUILD_LOG_H_
 
-#include <string>
 #include <stdio.h>
+
+#include <memory>
+#include <string>
 
 #include "hash_map.h"
 #include "load_status.h"
@@ -90,7 +92,7 @@ struct BuildLog {
   bool Restat(StringPiece path, const DiskInterface& disk_interface,
               int output_count, char** outputs, std::string* err);
 
-  typedef ExternalStringHashMap<LogEntry*>::Type Entries;
+  typedef ExternalStringHashMap<std::unique_ptr<LogEntry>>::Type Entries;
   const Entries& entries() const { return entries_; }
 
  private:

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -27,8 +27,6 @@
 #endif
 #include <cassert>
 
-using namespace std;
-
 namespace {
 
 const char kTestFilename[] = "BuildLogTest-tempfile";
@@ -50,7 +48,7 @@ TEST_F(BuildLogTest, WriteRead) {
 "build mid: cat in\n");
 
   BuildLog log1;
-  string err;
+  std::string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
   log1.RecordCommand(state_.edges_[0], 15, 18);
@@ -77,7 +75,7 @@ TEST_F(BuildLogTest, FirstWriteAddsSignature) {
   const size_t kVersionPos = strlen(kExpectedVersion) - 2;  // Points at 'X'.
 
   BuildLog log;
-  string contents, err;
+  std::string contents, err;
 
   EXPECT_TRUE(log.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
@@ -111,7 +109,7 @@ TEST_F(BuildLogTest, DoubleEntry) {
       BuildLog::LogEntry::HashCommand("command def"));
   fclose(f);
 
-  string err;
+  std::string err;
   BuildLog log;
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
@@ -128,7 +126,7 @@ TEST_F(BuildLogTest, Truncate) {
 
   {
     BuildLog log1;
-    string err;
+    std::string err;
     EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
     ASSERT_EQ("", err);
     log1.RecordCommand(state_.edges_[0], 15, 18);
@@ -148,7 +146,7 @@ TEST_F(BuildLogTest, Truncate) {
   // crash when parsing.
   for (off_t size = statbuf.st_size; size > 0; --size) {
     BuildLog log2;
-    string err;
+    std::string err;
     EXPECT_TRUE(log2.OpenForWrite(kTestFilename, *this, &err));
     ASSERT_EQ("", err);
     log2.RecordCommand(state_.edges_[0], 15, 18);
@@ -169,10 +167,10 @@ TEST_F(BuildLogTest, ObsoleteOldVersion) {
   fprintf(f, "123 456 0 out command\n");
   fclose(f);
 
-  string err;
+  std::string err;
   BuildLog log;
   EXPECT_TRUE(log.Load(kTestFilename, &err));
-  ASSERT_NE(err.find("version"), string::npos);
+  ASSERT_NE(err.find("version"), std::string::npos);
 }
 
 TEST_F(BuildLogTest, SpacesInOutput) {
@@ -182,7 +180,7 @@ TEST_F(BuildLogTest, SpacesInOutput) {
       BuildLog::LogEntry::HashCommand("command"));
   fclose(f);
 
-  string err;
+  std::string err;
   BuildLog log;
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
@@ -208,7 +206,7 @@ TEST_F(BuildLogTest, DuplicateVersionHeader) {
       BuildLog::LogEntry::HashCommand("command2"));
   fclose(f);
 
-  string err;
+  std::string err;
   BuildLog log;
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
@@ -229,22 +227,23 @@ TEST_F(BuildLogTest, DuplicateVersionHeader) {
 }
 
 struct TestDiskInterface : public DiskInterface {
-  virtual TimeStamp Stat(const string& path, string* err) const {
+  virtual TimeStamp Stat(const std::string& path, std::string* err) const {
     return 4;
   }
-  virtual bool WriteFile(const string& path, const string& contents) {
+  virtual bool WriteFile(const std::string& path, const std::string& contents) {
     assert(false);
     return true;
   }
-  virtual bool MakeDir(const string& path) {
+  virtual bool MakeDir(const std::string& path) {
     assert(false);
     return false;
   }
-  virtual Status ReadFile(const string& path, string* contents, string* err) {
+  virtual Status ReadFile(const std::string& path, std::string* contents,
+                          std::string* err) {
     assert(false);
     return NotFound;
   }
-  virtual int RemoveFile(const string& path) {
+  virtual int RemoveFile(const std::string& path) {
     assert(false);
     return 0;
   }
@@ -289,7 +288,7 @@ TEST_F(BuildLogTest, VeryLongInputLine) {
       BuildLog::LogEntry::HashCommand("command2"));
   fclose(f);
 
-  string err;
+  std::string err;
   BuildLog log;
   EXPECT_TRUE(log.Load(kTestFilename, &err));
   ASSERT_EQ("", err);
@@ -335,7 +334,7 @@ TEST_F(BuildLogRecompactTest, Recompact) {
 "build out2: cat in\n");
 
   BuildLog log1;
-  string err;
+  std::string err;
   EXPECT_TRUE(log1.OpenForWrite(kTestFilename, *this, &err));
   ASSERT_EQ("", err);
   // Record the same edge several times, to trigger recompaction


### PR DESCRIPTION
This patch fixes a memory leak in BuildLog::Recompact(), when calling `entries_.erase()` for dead outputs would not free the pointed-to LogEntry.

Rather than doing a local fix with an expliciti delete, this changes the `Entries` type to use `std::unique_ptr<LogEntry>` values instead of raw pointers, as this will prevent similar bugs to appear in the future. Other call sites are updated appropriately.

This also contains minor cleanups in separate commits:

- Use default member initialization in `build_log.h`.
- Remove `using namespace std` from `build_log.cc` and `build_log_test.cc`
- Remove one unnecessary string copy per entry when reading the build log.