### PR TITLE
Use `/utf-8` compiler option to fix MSVC C4819 warning.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -329,11 +329,12 @@ if platform.is_msvc():
         raise Exception('cl.exe not found. Run again from the Developer Command Prompt for VS')
     cflags = ['/showIncludes',
               '/nologo',  # Don't print startup banner.
+              '/utf-8',
               '/Zi',  # Create pdb with debug info.
               '/W4',  # Highest warning level.
               '/WX',  # Warnings as errors.
               '/wd4530', '/wd4100', '/wd4706', '/wd4244',
-              '/wd4512', '/wd4800', '/wd4702', '/wd4819',
+              '/wd4512', '/wd4800', '/wd4702',
               # Disable warnings about constant conditional expressions.
               '/wd4127',
               # Disable warnings about passing "this" during initialization.


### PR DESCRIPTION
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4819?view=msvc-170
> The file contains a character that cannot be represented in the current code page (number). Save the file in Unicode format to prevent data loss.

https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170
> Specifies both the source character set and the execution character set as UTF-8.

PR #1915 added UTF-8 manifest, I think use `/utf-8` would be a nature fix for C4819 warning (on `src/depfile_parser.cc`), instead of just suppress it.

 cc @jhasse