### PR TITLE
Fix Windows GCC and Clang format warning for `DWORD`.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -544,7 +544,7 @@ string GetLastErrorString() {
 
   if (msg_buf == nullptr) {
     char fallback_msg[128] = {0};
-    snprintf(fallback_msg, sizeof(fallback_msg), "GetLastError() = %d", err);
+    snprintf(fallback_msg, sizeof(fallback_msg), "GetLastError() = %lu", err);
     return fallback_msg;
   }
 


### PR DESCRIPTION
`DWORD` is defined as `unsigned long`, `%lu` is the correct format specifier.