### PR TITLE
Propagate supbrocess' exit codes to the ninja exit code

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -34,12 +34,12 @@
 #include "depfile_parser.h"
 #include "deps_log.h"
 #include "disk_interface.h"
+#include "exit_status.h"
 #include "explanations.h"
 #include "graph.h"
 #include "metrics.h"
 #include "state.h"
 #include "status.h"
-#include "subprocess.h"
 #include "util.h"
 
 using namespace std;
@@ -687,7 +687,7 @@ bool Builder::AlreadyUpToDate() const {
   return !plan_.more_to_do();
 }
 
-bool Builder::Build(string* err) {
+ExitStatus Builder::Build(string* err) {
   assert(!AlreadyUpToDate());
   plan_.PrepareQueue();
 
@@ -726,14 +726,14 @@ bool Builder::Build(string* err) {
         if (!StartEdge(edge, err)) {
           Cleanup();
           status_->BuildFinished();
-          return false;
+          return ExitFailure;
         }
 
         if (edge->is_phony()) {
           if (!plan_.EdgeFinished(edge, Plan::kEdgeSucceeded, err)) {
             Cleanup();
             status_->BuildFinished();
-            return false;
+            return ExitFailure;
           }
         } else {
           ++pending_commands;
@@ -760,14 +760,16 @@ bool Builder::Build(string* err) {
         Cleanup();
         status_->BuildFinished();
         *err = "interrupted by user";
-        return false;
+        return result.status;
       }
 
       --pending_commands;
-      if (!FinishCommand(&result, err)) {
+      bool command_finished = FinishCommand(&result, err);
+      SetFailureCode(result.status);
+      if (!command_finished) {
         Cleanup();
         status_->BuildFinished();
-        return false;
+        return result.status;
       }
 
       if (!result.success()) {
@@ -791,11 +793,11 @@ bool Builder::Build(string* err) {
     else
       *err = "stuck [this is a bug]";
 
-    return false;
+    return GetExitCode();
   }
 
   status_->BuildFinished();
-  return true;
+  return ExitSuccess;
 }
 
 bool Builder::StartEdge(Edge* edge, string* err) {
@@ -1035,4 +1037,11 @@ bool Builder::LoadDyndeps(Node* node, string* err) {
     return false;
 
   return true;
+}
+
+void Builder::SetFailureCode(ExitStatus code) {
+  // ExitSuccess should not overwrite any error
+  if (code != ExitSuccess) {
+    exit_code_ = code;
+  }
 }

--- a/src/build.cc
+++ b/src/build.cc
@@ -885,7 +885,7 @@ bool Builder::FinishCommand(CommandRunner::Result* result, string* err) {
   running_edges_.erase(it);
 
   status_->BuildEdgeFinished(edge, start_time_millis, end_time_millis,
-                             result->success(), result->output);
+                             result->status, result->output);
 
   // The rest of this function only applies to successful commands.
   if (!result->success()) {

--- a/src/build.h
+++ b/src/build.h
@@ -209,9 +209,9 @@ struct Builder {
   /// Returns true if the build targets are already up to date.
   bool AlreadyUpToDate() const;
 
-  /// Run the build.  Returns false on error.
+  /// Run the build.  Returns ExitStatus or the exit code of the last failed job.
   /// It is an error to call this function when AlreadyUpToDate() is true.
-  bool Build(std::string* err);
+  ExitStatus Build(std::string* err);
 
   bool StartEdge(Edge* edge, std::string* err);
 
@@ -233,6 +233,10 @@ struct Builder {
   std::unique_ptr<CommandRunner> command_runner_;
   Status* status_;
 
+  /// Returns ExitStatus or the exit code of the last failed job
+  /// (doesn't need to be an enum value of ExitStatus)
+  ExitStatus GetExitCode() const { return exit_code_; }
+
  private:
   bool ExtractDeps(CommandRunner::Result* result, const std::string& deps_type,
                    const std::string& deps_prefix,
@@ -252,6 +256,10 @@ struct Builder {
   std::unique_ptr<Explanations> explanations_;
 
   DependencyScan scan_;
+
+  /// Keep the global exit code for the build
+  ExitStatus exit_code_ = ExitSuccess;
+  void SetFailureCode(ExitStatus code);
 
   // Unimplemented copy ctor and operator= ensure we don't copy the auto_ptr.
   Builder(const Builder &other);        // DO NOT IMPLEMENT

--- a/src/exit_status.h
+++ b/src/exit_status.h
@@ -15,10 +15,19 @@
 #ifndef NINJA_EXIT_STATUS_H_
 #define NINJA_EXIT_STATUS_H_
 
-enum ExitStatus {
-  ExitSuccess,
+// The underlying type of the ExitStatus enum, used to represent a platform-specific
+// process exit code.
+#ifdef _WIN32
+#define EXIT_STATUS_TYPE unsigned long
+#else  // !_WIN32
+#define EXIT_STATUS_TYPE int
+#endif  // !_WIN32
+
+
+enum ExitStatus : EXIT_STATUS_TYPE {
+  ExitSuccess=0,
   ExitFailure,
-  ExitInterrupted
+  ExitInterrupted=130,
 };
 
 #endif  // NINJA_EXIT_STATUS_H_

--- a/src/status.h
+++ b/src/status.h
@@ -16,6 +16,7 @@
 #define NINJA_STATUS_H_
 
 #include <string>
+#include "exit_status.h"
 
 struct BuildConfig;
 struct Edge;
@@ -29,7 +30,7 @@ struct Status {
   virtual void BuildEdgeStarted(const Edge* edge,
                                 int64_t start_time_millis) = 0;
   virtual void BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
-                                 int64_t end_time_millis, bool success,
+                                 int64_t end_time_millis, ExitStatus exit_code,
                                  const std::string& output) = 0;
   virtual void BuildStarted() = 0;
   virtual void BuildFinished() = 0;

--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -33,6 +33,7 @@
 
 #include "build.h"
 #include "debug_flags.h"
+#include "exit_status.h"
 
 using namespace std;
 
@@ -174,7 +175,7 @@ void StatusPrinter::RecalculateProgressPrediction() {
 }
 
 void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
-                                      int64_t end_time_millis, bool success,
+                                      int64_t end_time_millis, ExitStatus exit_code,
                                       const string& output) {
   time_millis_ = end_time_millis;
   ++finished_edges_;
@@ -202,16 +203,17 @@ void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
   --running_edges_;
 
   // Print the command that is spewing before printing its output.
-  if (!success) {
+  if (exit_code != ExitSuccess) {
     string outputs;
     for (vector<Node*>::const_iterator o = edge->outputs_.begin();
          o != edge->outputs_.end(); ++o)
       outputs += (*o)->path() + " ";
 
+    string failed = "FAILED: [code=" + std::to_string(exit_code) + "] ";
     if (printer_.supports_color()) {
-        printer_.PrintOnNewLine("\x1B[31m" "FAILED: " "\x1B[0m" + outputs + "\n");
+        printer_.PrintOnNewLine("\x1B[31m" + failed + "\x1B[0m" + outputs + "\n");
     } else {
-        printer_.PrintOnNewLine("FAILED: " + outputs + "\n");
+        printer_.PrintOnNewLine(failed + outputs + "\n");
     }
     printer_.PrintOnNewLine(edge->EvaluateCommand() + "\n");
   }

--- a/src/status_printer.h
+++ b/src/status_printer.h
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <queue>
 
+#include "exit_status.h"
 #include "explanations.h"
 #include "line_printer.h"
 #include "status.h"
@@ -31,7 +32,7 @@ struct StatusPrinter : Status {
 
   void BuildEdgeStarted(const Edge* edge, int64_t start_time_millis) override;
   void BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
-                                 int64_t end_time_millis, bool success,
+                                 int64_t end_time_millis, ExitStatus exit_code,
                                  const std::string& output) override;
   void BuildStarted() override;
   void BuildFinished() override;

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "exit_status.h"
 #include "subprocess.h"
 
 #include <assert.h>
@@ -198,9 +199,8 @@ ExitStatus Subprocess::Finish() {
   CloseHandle(child_);
   child_ = NULL;
 
-  return exit_code == 0              ? ExitSuccess :
-         exit_code == CONTROL_C_EXIT ? ExitInterrupted :
-                                       ExitFailure;
+  return exit_code == CONTROL_C_EXIT ? ExitInterrupted :
+                                       static_cast<ExitStatus>(exit_code);
 }
 
 bool Subprocess::Done() const {

--- a/src/subprocess_test.cc
+++ b/src/subprocess_test.cc
@@ -14,6 +14,7 @@
 
 #include "subprocess.h"
 
+#include "exit_status.h"
 #include "test.h"
 
 #ifndef _WIN32
@@ -50,7 +51,8 @@ TEST_F(SubprocessTest, BadCommandStderr) {
     subprocs_.DoWork();
   }
 
-  EXPECT_EQ(ExitFailure, subproc->Finish());
+  ExitStatus exit = subproc->Finish();
+  EXPECT_NE(ExitSuccess, exit);
   EXPECT_NE("", subproc->GetOutput());
 }
 
@@ -64,7 +66,8 @@ TEST_F(SubprocessTest, NoSuchCommand) {
     subprocs_.DoWork();
   }
 
-  EXPECT_EQ(ExitFailure, subproc->Finish());
+  ExitStatus exit = subproc->Finish();
+  EXPECT_NE(ExitSuccess, exit);
   EXPECT_NE("", subproc->GetOutput());
 #ifdef _WIN32
   ASSERT_EQ("CreateProcess failed: The system cannot find the file "


### PR DESCRIPTION
Now, ninjas could exit with codes 0, 1, and 2.

With these codes, it's nearly impossible to get what went wrong in the subcommands.

This patch propagates the subcommand's exit code to the ninja's exit code.

It fixes #1123, fixes #1507, and technically substitutes the https://github.com/ninja-build/ninja/pull/1805