### PR TITLE
Add default virtual destructor for `Parser` class.

### DIFF
--- a/src/parser.h
+++ b/src/parser.h
@@ -26,6 +26,7 @@ struct State;
 struct Parser {
   Parser(State* state, FileReader* file_reader)
       : state_(state), file_reader_(file_reader) {}
+  virtual ~Parser() {}
 
   /// Load and parse a file.
   bool Load(const std::string& filename, std::string* err, Lexer* parent = NULL);


### PR DESCRIPTION
This fixed clang `[-Wdelete-non-abstract-non-virtual-dtor]` warning:
    delete called on non-final 'ManifestParser' that has virtual
    functions but non-virtual destructor.
for `subparser_.reset(new ManifestParser(state_, file_reader_, options_));`.