### PR TITLE
Fix Clang and GCC `[-Wcast-function-type]` warning on casting result of `GetProcAddress()` function.

### DIFF
--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -165,7 +165,7 @@ RealDiskInterface::RealDiskInterface()
   HINSTANCE ntdll_lib = ::GetModuleHandleW(L"ntdll");
   if (ntdll_lib) {
     typedef BOOLEAN(WINAPI FunctionType)();
-    auto* func_ptr = reinterpret_cast<FunctionType*>(
+    auto* func_ptr = FunctionCast<FunctionType*>(
         ::GetProcAddress(ntdll_lib, "RtlAreLongPathsEnabled"));
     if (func_ptr) {
       long_paths_enabled_ = (*func_ptr)();

--- a/src/minidump-win32.cc
+++ b/src/minidump-win32.cc
@@ -51,8 +51,8 @@ void CreateWin32MiniDump(_EXCEPTION_POINTERS* pep) {
     return;
   }
 
-  MiniDumpWriteDumpFunc mini_dump_write_dump =
-      (MiniDumpWriteDumpFunc)GetProcAddress(dbghelp, "MiniDumpWriteDump");
+  MiniDumpWriteDumpFunc mini_dump_write_dump = FunctionCast
+      <MiniDumpWriteDumpFunc>(GetProcAddress(dbghelp, "MiniDumpWriteDump"));
   if (mini_dump_write_dump == NULL) {
     Error("failed to create minidump: GetProcAddress('MiniDumpWriteDump'): %s",
           GetLastErrorString().c_str());

--- a/src/util.h
+++ b/src/util.h
@@ -124,6 +124,16 @@ std::string GetLastErrorString();
 
 /// Calls Fatal() with a function name and GetLastErrorString.
 NORETURN void Win32Fatal(const char* function, const char* hint = NULL);
+
+/// Naive implementation of C++ 20 std::bit_cast(), used to fix Clang and GCC
+/// [-Wcast-function-type] warning on casting result of GetProcAddress().
+template <class To, class From>
+inline To FunctionCast(From from) {
+	static_assert(sizeof(To) == sizeof(From), "");
+	To result;
+	memcpy(&result, &from, sizeof(To));
+	return result;
+}
 #endif
 
 #endif  // NINJA_UTIL_H_


### PR DESCRIPTION
This change added a naive implementation of C++ 20 `std::bit_cast()` into util.h.
https://en.cppreference.com/w/cpp/numeric/bit_cast