### PR TITLE
Fix rspfile name length exceeding MAX_FILENAME_SIZE (140) characters

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -152,6 +152,15 @@ bool ManifestParser::ParseRule(string* err) {
       return false;
 
     if (Rule::IsReservedBinding(key)) {
+      if (key == "rspfile") {
+        //Info("*** ManifestParser::ParseRule() Key:'%s' Value:'%s'****\n",key.c_str(),value.Unparse().c_str());
+        char safeFileName[MAX_FILENAME_SIZE];
+        if (checkFileName(value.Unparse().c_str(), safeFileName)) {
+          Warning("File name truncated: %s -> %s\n", value.Unparse().c_str(), safeFileName);
+          value.Clear(); //clear the value
+          value.AddText(StringPiece(safeFileName, MAX_FILENAME_SIZE)); //exchange the 'too long' value with shorter variant
+        }
+      }
       rule->AddBinding(key, value);
     } else {
       // Die on other keyvals for now; revisit if we want to add a

--- a/src/util.h
+++ b/src/util.h
@@ -48,6 +48,11 @@ NORETURN void Fatal(const char* msg, ...);
 #  define NINJA_FALLTHROUGH // nothing
 #endif
 
+///Define max filename size. Limit on ecrypt fs is 144 so 140 should be safe
+#define MAX_FILENAME_SIZE 140
+///Len of the hash that fill up the oversized filename
+#define HASH_SIZE_LEN 8
+
 /// Log a warning message.
 void Warning(const char* msg, ...);
 void Warning(const char* msg, va_list ap);
@@ -136,4 +141,9 @@ inline To FunctionCast(From from) {
 }
 #endif
 
+// Helper function to compute a simple hash
+unsigned int simpleHash(const char* str);
+
+// Method to check and truncate file names if necessary
+int checkFileName(const char* inPath, char* outPath);
 #endif  // NINJA_UTIL_H_


### PR DESCRIPTION
### Description

This Pull Request addresses an issue where `rspfile` names exceeding 144 characters cause build failures due to encrypted filesystem limitations. The proposed solution truncates overly long `rspfile` names and appends a unique identifier to ensure they remain within the acceptable length.

### Changes Made

- **ManifestParser::ParseRule:** Introduced a length check for `rspfile` names and applied truncation when necessary.
- **checkFileName:** Checks the lengeth of the filename strings. If necessary it shortens it by cut the first 'n' characters and add a checksum to keep the files unique. 
- **simpleHash:** Generates a checksum to keep the shortened files unique.

### Benefits

- Prevents build failures caused by excessively long `rspfile` names.
- Enhances compatibility with filesystems that impose strict filename length restrictions.
- Maintains uniqueness of `rspfile` names to avoid conflicts.

### Testing

- Created test cases with `rspfile` names exceeding 140 characters to ensure they are correctly truncated.
- Verified that build processes succeed without `rspfile` name length issues.
