### PR TITLE
Create linux-musl.yml

### DIFF
--- a/.github/workflows/linux-musl.yml
+++ b/.github/workflows/linux-musl.yml
@@ -33,6 +33,9 @@ jobs:
 
     name: ${{ matrix.build_method}} ${{ matrix.binary_name }}
 
+    env:
+      container_name: crossbuild
+
     steps:
       - name: Host - checkout
         uses: actions/checkout@v4
@@ -40,42 +43,49 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Host - Create docker crossbuild container
-        run: docker run --name crossbuild -it -d -e "LDFLAGS=-s -static --static" -w /root -v ${{ github.workspace }}:/root ${{ matrix.container }}
+      - name: Host - Create docker build container
+        run: |
+          # We create an Alpine edge container for cross-compilation with a user named gh which has same id as runner 1001 and provide sudo access
+          # This way we can run commands as a non-root user, avoiding permission issues on host runner. Switching between user and root as needed.
+          docker run --name ${container_name} -it -d -e "LDFLAGS=-s -static --static" -w /home/gh -v ${{ github.workspace }}:/home/gh ${{ matrix.container }}
+          # Create the user gh with the id 1001:1001 which is the same as the runner user id and group id.
+          docker exec ${container_name} sh -c 'adduser -h /home/gh -Ds /bin/bash -u 1001 gh && apk add sudo'
+          # Allow the user gh to run sudo without password prompt: docker exec -u gh:gh ${container_name} sudo ls
+          docker exec ${container_name} sh -c 'printf "%s" "gh ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/gh'
 
       - name: Docker - Install ninja build optional dependencies
         run: |
-          docker exec crossbuild apk update
-          docker exec crossbuild apk add -u --no-cache python3 build-base cmake re2c
+          docker exec ${container_name} apk update
+          docker exec ${container_name} apk add -u --no-cache python3 build-base cmake re2c
 
       - name: Docker - Configure ${{ matrix.binary_name }}
         if: matrix.build_method == 'cmake'
-        run: docker exec crossbuild cmake -B build -D CMAKE_BUILD_TYPE="Release"
+        run: docker exec -u gh:gh ${container_name} cmake -B build -D CMAKE_BUILD_TYPE="Release"
 
       - name: Docker - Cmake Build ${{ matrix.binary_name }}
         if: matrix.build_method == 'cmake'
-        run: docker exec crossbuild cmake --build build --parallel --config Release
+        run: docker exec -u gh:gh ${container_name} cmake --build build --parallel --config Release
 
       - name: Docker - Cmake test ${{ matrix.binary_name }}
         if: matrix.build_method == 'cmake'
-        run: docker exec crossbuild build/ninja_test --gtest_color=yes
+        run: docker exec -u gh:gh ${container_name} build/ninja_test --gtest_color=yes
 
       - name: Docker - Python Build ${{ matrix.binary_name }}
         if: matrix.build_method == 'python'
-        run: docker exec crossbuild python3 configure.py --bootstrap --verbose
+        run: docker exec -u gh:gh ${container_name} python3 configure.py --bootstrap --verbose
 
       - name: Docker - Python test ${{ matrix.binary_name }}
         if: matrix.build_method == 'python'
         run: |
-          docker exec crossbuild /root/ninja all
-          docker exec crossbuild python3 misc/ninja_syntax_test.py
-          # docker exec crossbuild python3 misc/output_test.py
+          docker exec -u gh:gh ${container_name} /home/gh/ninja all
+          docker exec -u gh:gh ${container_name} python3 misc/ninja_syntax_test.py
+          # docker exec -u gh:gh ${container_name} python3 misc/output_test.py
 
       - name: Host - Rename ${{ matrix.binary_name }} to ${{ env.release_asset }}
-        run: sudo mv -f ${{ (matrix.build_method == 'cmake') && 'build/' || '' }}ninja ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}
+        run: mv -f ${{ matrix.build_method == 'cmake' && 'build/' || '' }}ninja ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}
 
       - name: Host - ninja-${{ matrix.binary_name }} --version
         run: ./ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }} --version >> $GITHUB_STEP_SUMMARY
 
-      - name: Host - crossbuild binary info via file
+      - name: Host - ${{ env.container_name}} binary info via file
         run: file ./ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }} >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/linux-musl.yml
+++ b/.github/workflows/linux-musl.yml
@@ -11,30 +11,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build:
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ubuntu-24.04
+    container: alpine:edge
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
         build_method: ["python", "cmake"]
-        runs-on: ["ubuntu-24.04", "ubuntu-24.04-arm"]
-        include:
-          - runs-on: "ubuntu-24.04"
-            container: "amd64/alpine:latest"
-            binary_name: amd64
-          - runs-on: "ubuntu-24.04-arm"
-            container: "arm64v8/alpine:latest"
-            binary_name: aarch64
-          - build_method: "python"
-            build_suffix: "-python"
-
-    name: ${{ matrix.build_method}} ${{ matrix.binary_name }}
-
-    env:
-      container_name: crossbuild
 
     steps:
       - name: Host - checkout
@@ -43,49 +31,38 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Host - Create docker build container
-        run: |
-          # We create an Alpine edge container for cross-compilation with a user named gh which has same id as runner 1001 and provide sudo access
-          # This way we can run commands as a non-root user, avoiding permission issues on host runner. Switching between user and root as needed.
-          docker run --name ${container_name} -it -d -e "LDFLAGS=-s -static --static" -w /home/gh -v ${{ github.workspace }}:/home/gh ${{ matrix.container }}
-          # Create the user gh with the id 1001:1001 which is the same as the runner user id and group id.
-          docker exec ${container_name} sh -c 'adduser -h /home/gh -Ds /bin/bash -u 1001 gh && apk add sudo'
-          # Allow the user gh to run sudo without password prompt: docker exec -u gh:gh ${container_name} sudo ls
-          docker exec ${container_name} sh -c 'printf "%s" "gh ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/gh'
+      - name: Install ninja build optional dependencies
+        run: apk update && apk add -u --no-cache python3 build-base cmake re2c
 
-      - name: Docker - Install ninja build optional dependencies
-        run: |
-          docker exec ${container_name} apk update
-          docker exec ${container_name} apk add -u --no-cache python3 build-base cmake re2c
-
-      - name: Docker - Configure ${{ matrix.binary_name }}
+      - name: Configure ninja build
         if: matrix.build_method == 'cmake'
-        run: docker exec -u gh:gh ${container_name} cmake -B build -D CMAKE_BUILD_TYPE="Release"
+        run: cmake -B build -D CMAKE_BUILD_TYPE="Release"
 
-      - name: Docker - Cmake Build ${{ matrix.binary_name }}
+      - name: Cmake Build ninja
         if: matrix.build_method == 'cmake'
-        run: docker exec -u gh:gh ${container_name} cmake --build build --parallel --config Release
+        run: cmake --build build --parallel --config Release
 
-      - name: Docker - Cmake test ${{ matrix.binary_name }}
+      - name: Cmake test ninja
         if: matrix.build_method == 'cmake'
-        run: docker exec -u gh:gh ${container_name} build/ninja_test --gtest_color=yes
+        run: build/ninja_test --gtest_color=yes
 
-      - name: Docker - Python Build ${{ matrix.binary_name }}
+      - name: Python Build ninja
         if: matrix.build_method == 'python'
-        run: docker exec -u gh:gh ${container_name} python3 configure.py --bootstrap --verbose
+        run: python3 configure.py --bootstrap --verbose
 
-      - name: Docker - Python test ${{ matrix.binary_name }}
+      - name: Python test ninja
         if: matrix.build_method == 'python'
         run: |
-          docker exec -u gh:gh ${container_name} /home/gh/ninja all
-          docker exec -u gh:gh ${container_name} python3 misc/ninja_syntax_test.py
-          # docker exec -u gh:gh ${container_name} python3 misc/output_test.py
+          ./ninja all
+          python3 misc/ninja_syntax_test.py
+          # python3 misc/output_test.py
 
-      - name: Host - Rename ${{ matrix.binary_name }} to ${{ env.release_asset }}
-        run: mv -f ${{ matrix.build_method == 'cmake' && 'build/' || '' }}ninja ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}
+      - name: Move ninja binary
+        if: matrix.build_method == 'cmake'
+        run: mv -f build/ninja ninja
 
-      - name: Host - ninja-${{ matrix.binary_name }} --version
-        run: ./ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }} --version >> $GITHUB_STEP_SUMMARY
+      - name: ninja-ninja --version
+        run: ./ninja --version >> $GITHUB_STEP_SUMMARY
 
-      - name: Host - ${{ env.container_name}} binary info via file
-        run: file ./ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }} >> $GITHUB_STEP_SUMMARY
+      - name: binary info via file
+        run: file ./ninja >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/linux-musl.yml
+++ b/.github/workflows/linux-musl.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
-      id-token: write
-      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -81,15 +79,3 @@ jobs:
 
       - name: Host - crossbuild binary info via file
         run: file ./ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }} >> $GITHUB_STEP_SUMMARY
-
-      - name: Host - signed build provenance attestations
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}
-
-      - name: Upload artifact - ${{ matrix.binary_name }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}
-          path: ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}

--- a/.github/workflows/linux-musl.yml
+++ b/.github/workflows/linux-musl.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04 # needs to be ubuntu-24.04 for qemu-user-static loongarch64 support
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
       id-token: write
@@ -22,85 +22,37 @@ jobs:
       fail-fast: false
       matrix:
         build_method: ["python", "cmake"]
-        arch:
-          [
-            aarch64-linux-musl,
-            arm-linux-musleabi,
-            arm-linux-musleabihf,
-            armv6-linux-musleabihf,
-            armv7l-linux-musleabihf,
-            i686-linux-musl,
-            x86_64-linux-musl,
-            mips-linux-musl,
-            mips64-linux-musl,
-            mips64el-linux-musl,
-            mipsel-linux-musl,
-            powerpc-linux-musl,
-            powerpc64le-linux-musl,
-            s390x-linux-musl,
-            riscv64-linux-musl,
-            loongarch64-linux-musl,
-          ]
+        runs-on: ["ubuntu-24.04", "ubuntu-24.04-arm"]
         include:
-          - arch: aarch64-linux-musl
+          - runs-on: "ubuntu-24.04"
+            container: "amd64/alpine:latest"
+            binary_name: amd64
+          - runs-on: "ubuntu-24.04-arm"
+            container: "arm64v8/alpine:latest"
             binary_name: aarch64
-          - arch: arm-linux-musleabi
-            binary_name: armv5
-          - arch: arm-linux-musleabihf
-            binary_name: armhf
-          - arch: armv6-linux-musleabihf
-            binary_name: armv6
-          - arch: armv7l-linux-musleabihf
-            binary_name: armv7
-          - arch: i686-linux-musl
-            binary_name: x86
-          - arch: x86_64-linux-musl
-            binary_name: x86_64
-          - arch: mips-linux-musl
-            binary_name: mips
-          - arch: mips64-linux-musl
-            binary_name: mips64
-          - arch: mips64el-linux-musl
-            binary_name: mips64el
-          - arch: mipsel-linux-musl
-            binary_name: mipsel
-          - arch: powerpc-linux-musl
-            binary_name: powerpc
-          - arch: powerpc64le-linux-musl
-            binary_name: powerpc64le
-          - arch: s390x-linux-musl
-            binary_name: s390x
-          - arch: riscv64-linux-musl
-            binary_name: riscv64
-          - arch: loongarch64-linux-musl
-            binary_name: loongarch64
+          - build_method: "python"
+            build_suffix: "-python"
 
-    name: ${{ matrix.build_method}} ${{ matrix.arch }}
+    name: ${{ matrix.build_method}} ${{ matrix.binary_name }}
 
     steps:
       - name: Host - checkout
         uses: actions/checkout@v4
-
-      - name: Host - update
-        run: sudo apt-get update
-
-      - name: Host - set up qemu-user-static binfmt-support
-        run: sudo apt-get install libpipeline1 qemu-user-static binfmt-support
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Host - Create docker crossbuild container
-        run: docker run --name crossbuild -it -d -e "LDFLAGS=-s -static --static" -w /home/github -v ${{ github.workspace }}:/home/github ghcr.io/userdocs/qbt-musl-cross-make:${{ matrix.arch }}
+        run: docker run --name crossbuild -it -d -e "LDFLAGS=-s -static --static" -w /root -v ${{ github.workspace }}:/root ${{ matrix.container }}
 
       - name: Docker - Install ninja build optional dependencies
         run: |
-          docker exec crossbuild sudo apk update
-          docker exec crossbuild sudo apk add --no-cache python3
+          docker exec crossbuild apk update
+          docker exec crossbuild apk add -u --no-cache python3 build-base cmake re2c
 
       - name: Docker - Configure ${{ matrix.binary_name }}
         if: matrix.build_method == 'cmake'
-        run: >
-          docker exec crossbuild
-          cmake -B build
-          -D CMAKE_BUILD_TYPE="Release"
+        run: docker exec crossbuild cmake -B build -D CMAKE_BUILD_TYPE="Release"
 
       - name: Docker - Cmake Build ${{ matrix.binary_name }}
         if: matrix.build_method == 'cmake'
@@ -108,45 +60,35 @@ jobs:
 
       - name: Docker - Cmake test ${{ matrix.binary_name }}
         if: matrix.build_method == 'cmake'
-        run: docker exec crossbuild ./build/ninja_test --gtest_color=yes
+        run: docker exec crossbuild build/ninja_test --gtest_color=yes
 
       - name: Docker - Python Build ${{ matrix.binary_name }}
         if: matrix.build_method == 'python'
-        run: |
-          docker exec crossbuild ./configure.py --bootstrap --verbose
-          printf "%s\n" "build_suffix=-python" >> $GITHUB_ENV
+        run: docker exec crossbuild python3 configure.py --bootstrap --verbose
 
       - name: Docker - Python test ${{ matrix.binary_name }}
         if: matrix.build_method == 'python'
         run: |
-          docker exec crossbuild ./ninja all
+          docker exec crossbuild /root/ninja all
           docker exec crossbuild python3 misc/ninja_syntax_test.py
-          # docker exec crossbuild ./misc/output_test.py
-
-      - name: Set Build Path for Python
-        if: matrix.build_method == 'python'
-        run: echo "BUILD_PATH=${{ github.workspace }}" >> $GITHUB_ENV
-
-      - name: Set Build Path for cmake
-        if: matrix.build_method == 'cmake'
-        run: echo "BUILD_PATH=${{ github.workspace }}/build" >> $GITHUB_ENV
+          # docker exec crossbuild python3 misc/output_test.py
 
       - name: Host - Rename ${{ matrix.binary_name }} to ${{ env.release_asset }}
-        run: mv -f ${BUILD_PATH}/ninja ninja-${{ matrix.binary_name }}${{ env.build_suffix }}
+        run: sudo mv -f ${{ (matrix.build_method == 'cmake') && 'build/' || '' }}ninja ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}
 
       - name: Host - ninja-${{ matrix.binary_name }} --version
-        run: ./ninja-${{ matrix.binary_name }}${{ env.build_suffix }} --version >> $GITHUB_STEP_SUMMARY
+        run: ./ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }} --version >> $GITHUB_STEP_SUMMARY
 
       - name: Host - crossbuild binary info via file
-        run: file ./ninja-${{ matrix.binary_name }}${{ env.build_suffix }} >> $GITHUB_STEP_SUMMARY
+        run: file ./ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }} >> $GITHUB_STEP_SUMMARY
 
       - name: Host - signed build provenance attestations
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: ninja-${{ matrix.binary_name }}${{ env.build_suffix }}
+          subject-path: ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}
 
       - name: Upload artifact - ${{ matrix.binary_name }}
         uses: actions/upload-artifact@v4
         with:
-          name: ninja-${{ matrix.binary_name }}${{ env.build_suffix }}
-          path: ninja-${{ matrix.binary_name }}${{ env.build_suffix }}
+          name: ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}
+          path: ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}

--- a/.github/workflows/linux-musl.yml
+++ b/.github/workflows/linux-musl.yml
@@ -1,0 +1,152 @@
+name: ci-linux-musl
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04 # needs to be ubuntu-24.04 for qemu-user-static loongarch64 support
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        build_method: ["python", "cmake"]
+        arch:
+          [
+            aarch64-linux-musl,
+            arm-linux-musleabi,
+            arm-linux-musleabihf,
+            armv6-linux-musleabihf,
+            armv7l-linux-musleabihf,
+            i686-linux-musl,
+            x86_64-linux-musl,
+            mips-linux-musl,
+            mips64-linux-musl,
+            mips64el-linux-musl,
+            mipsel-linux-musl,
+            powerpc-linux-musl,
+            powerpc64le-linux-musl,
+            s390x-linux-musl,
+            riscv64-linux-musl,
+            loongarch64-linux-musl,
+          ]
+        include:
+          - arch: aarch64-linux-musl
+            binary_name: aarch64
+          - arch: arm-linux-musleabi
+            binary_name: armv5
+          - arch: arm-linux-musleabihf
+            binary_name: armhf
+          - arch: armv6-linux-musleabihf
+            binary_name: armv6
+          - arch: armv7l-linux-musleabihf
+            binary_name: armv7
+          - arch: i686-linux-musl
+            binary_name: x86
+          - arch: x86_64-linux-musl
+            binary_name: x86_64
+          - arch: mips-linux-musl
+            binary_name: mips
+          - arch: mips64-linux-musl
+            binary_name: mips64
+          - arch: mips64el-linux-musl
+            binary_name: mips64el
+          - arch: mipsel-linux-musl
+            binary_name: mipsel
+          - arch: powerpc-linux-musl
+            binary_name: powerpc
+          - arch: powerpc64le-linux-musl
+            binary_name: powerpc64le
+          - arch: s390x-linux-musl
+            binary_name: s390x
+          - arch: riscv64-linux-musl
+            binary_name: riscv64
+          - arch: loongarch64-linux-musl
+            binary_name: loongarch64
+
+    name: ${{ matrix.build_method}} ${{ matrix.arch }}
+
+    steps:
+      - name: Host - checkout
+        uses: actions/checkout@v4
+
+      - name: Host - update
+        run: sudo apt-get update
+
+      - name: Host - set up qemu-user-static binfmt-support
+        run: sudo apt-get install libpipeline1 qemu-user-static binfmt-support
+
+      - name: Host - Create docker crossbuild container
+        run: docker run --name crossbuild -it -d -e "LDFLAGS=-s -static --static" -w /home/github -v ${{ github.workspace }}:/home/github ghcr.io/userdocs/qbt-musl-cross-make:${{ matrix.arch }}
+
+      - name: Docker - Install ninja build optional dependencies
+        run: |
+          docker exec crossbuild sudo apk update
+          docker exec crossbuild sudo apk add --no-cache python3
+
+      - name: Docker - Configure ${{ matrix.binary_name }}
+        if: matrix.build_method == 'cmake'
+        run: >
+          docker exec crossbuild
+          cmake -B build
+          -D CMAKE_BUILD_TYPE="Release"
+
+      - name: Docker - Cmake Build ${{ matrix.binary_name }}
+        if: matrix.build_method == 'cmake'
+        run: docker exec crossbuild cmake --build build --parallel --config Release
+
+      - name: Docker - Cmake test ${{ matrix.binary_name }}
+        if: matrix.build_method == 'cmake'
+        run: docker exec crossbuild ./build/ninja_test --gtest_color=yes
+
+      - name: Docker - Python Build ${{ matrix.binary_name }}
+        if: matrix.build_method == 'python'
+        run: |
+          docker exec crossbuild ./configure.py --bootstrap --verbose
+          printf "%s\n" "build_suffix=-python" >> $GITHUB_ENV
+
+      - name: Docker - Python test ${{ matrix.binary_name }}
+        if: matrix.build_method == 'python'
+        run: |
+          docker exec crossbuild ./ninja all
+          docker exec crossbuild python3 misc/ninja_syntax_test.py
+          # docker exec crossbuild ./misc/output_test.py
+
+      - name: Set Build Path for Python
+        if: matrix.build_method == 'python'
+        run: echo "BUILD_PATH=${{ github.workspace }}" >> $GITHUB_ENV
+
+      - name: Set Build Path for cmake
+        if: matrix.build_method == 'cmake'
+        run: echo "BUILD_PATH=${{ github.workspace }}/build" >> $GITHUB_ENV
+
+      - name: Host - Rename ${{ matrix.binary_name }} to ${{ env.release_asset }}
+        run: mv -f ${BUILD_PATH}/ninja ninja-${{ matrix.binary_name }}${{ env.build_suffix }}
+
+      - name: Host - ninja-${{ matrix.binary_name }} --version
+        run: ./ninja-${{ matrix.binary_name }}${{ env.build_suffix }} --version >> $GITHUB_STEP_SUMMARY
+
+      - name: Host - crossbuild binary info via file
+        run: file ./ninja-${{ matrix.binary_name }}${{ env.build_suffix }} >> $GITHUB_STEP_SUMMARY
+
+      - name: Host - signed build provenance attestations
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ninja-${{ matrix.binary_name }}${{ env.build_suffix }}
+
+      - name: Upload artifact - ${{ matrix.binary_name }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ninja-${{ matrix.binary_name }}${{ env.build_suffix }}
+          path: ninja-${{ matrix.binary_name }}${{ env.build_suffix }}

--- a/.github/workflows/linux-musl.yml
+++ b/.github/workflows/linux-musl.yml
@@ -83,6 +83,7 @@ jobs:
         run: file ./ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }} >> $GITHUB_STEP_SUMMARY
 
       - name: Host - signed build provenance attestations
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: ninja-${{ matrix.binary_name }}${{ matrix.build_suffix }}


### PR DESCRIPTION
A static musl crossbuild binaries workflow to test building against musl cc across a range of arch targets,

A continuation of this; https://github.com/ninja-build/ninja/issues/2426 

It uses a variation of this https://github.com/richfelker/musl-cross-make via https://github.com/userdocs/qbt-musl-cross-make which provides the crossbuild toolchains on demand, here using the docker images.

They are using alpine linux settings from here https://git.alpinelinux.org/aports/tree/main/gcc/APKBUILD#n287

You could also release the static binaries using this.

Take about 3 minutes per build https://github.com/userdocs/ninja/actions/runs/12575349270
