### PR TITLE
Fix includes normalize win32

### DIFF
--- a/src/includes_normalize-win32.cc
+++ b/src/includes_normalize-win32.cc
@@ -24,12 +24,10 @@
 
 #include <windows.h>
 
-using namespace std;
-
 namespace {
 
 bool InternalGetFullPathName(const StringPiece& file_name, char* buffer,
-                             size_t buffer_length, string *err) {
+                             size_t buffer_length, std::string* err) {
   DWORD result_size = GetFullPathNameA(file_name.AsString().c_str(),
                                        buffer_length, buffer, NULL);
   if (result_size == 0) {
@@ -71,7 +69,7 @@ bool SameDriveFast(StringPiece a, StringPiece b) {
 }
 
 // Return true if paths a and b are on the same Windows drive.
-bool SameDrive(StringPiece a, StringPiece b, string* err)  {
+bool SameDrive(StringPiece a, StringPiece b, std::string* err) {
   if (SameDriveFast(a, b)) {
     return true;
   }
@@ -126,8 +124,8 @@ bool IsFullPathName(StringPiece s) {
 
 }  // anonymous namespace
 
-IncludesNormalize::IncludesNormalize(const string& relative_to) {
-  string err;
+IncludesNormalize::IncludesNormalize(const std::string& relative_to) {
+  std::string err;
   relative_to_ = AbsPath(relative_to, &err);
   if (!err.empty()) {
     Fatal("Initializing IncludesNormalize(): %s", err.c_str());
@@ -135,9 +133,9 @@ IncludesNormalize::IncludesNormalize(const string& relative_to) {
   split_relative_to_ = SplitStringPiece(relative_to_, '/');
 }
 
-string IncludesNormalize::AbsPath(StringPiece s, string* err) {
+std::string IncludesNormalize::AbsPath(StringPiece s, std::string* err) {
   if (IsFullPathName(s)) {
-    string result = s.AsString();
+    std::string result = s.AsString();
     for (size_t i = 0; i < result.size(); ++i) {
       if (result[i] == '\\') {
         result[i] = '/';
@@ -156,21 +154,23 @@ string IncludesNormalize::AbsPath(StringPiece s, string* err) {
   return result;
 }
 
-string IncludesNormalize::Relativize(
-    StringPiece path, const vector<StringPiece>& start_list, string* err) {
-  string abs_path = AbsPath(path, err);
+std::string IncludesNormalize::Relativize(
+    StringPiece path, const std::vector<StringPiece>& start_list,
+    std::string* err) {
+  std::string abs_path = AbsPath(path, err);
   if (!err->empty())
     return "";
-  vector<StringPiece> path_list = SplitStringPiece(abs_path, '/');
+  std::vector<StringPiece> path_list = SplitStringPiece(abs_path, '/');
   int i;
-  for (i = 0; i < static_cast<int>(min(start_list.size(), path_list.size()));
+  for (i = 0;
+       i < static_cast<int>(std::min(start_list.size(), path_list.size()));
        ++i) {
     if (!EqualsCaseInsensitiveASCII(start_list[i], path_list[i])) {
       break;
     }
   }
 
-  vector<StringPiece> rel_list;
+  std::vector<StringPiece> rel_list;
   rel_list.reserve(start_list.size() - i + path_list.size() - i);
   for (int j = 0; j < static_cast<int>(start_list.size() - i); ++j)
     rel_list.push_back("..");
@@ -181,8 +181,8 @@ string IncludesNormalize::Relativize(
   return JoinStringPiece(rel_list, '/');
 }
 
-bool IncludesNormalize::Normalize(const string& input,
-                                  string* result, string* err) const {
+bool IncludesNormalize::Normalize(const std::string& input, std::string* result,
+                                  std::string* err) const {
   char copy[_MAX_PATH + 1];
   size_t len = input.size();
   if (len > _MAX_PATH) {
@@ -193,7 +193,7 @@ bool IncludesNormalize::Normalize(const string& input,
   uint64_t slash_bits;
   CanonicalizePath(copy, &len, &slash_bits);
   StringPiece partially_fixed(copy, len);
-  string abs_input = AbsPath(partially_fixed, err);
+  std::string abs_input = AbsPath(partially_fixed, err);
   if (!err->empty())
     return false;
 

--- a/src/includes_normalize-win32.cc
+++ b/src/includes_normalize-win32.cc
@@ -12,32 +12,99 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "includes_normalize.h"
-
-#include "string_piece.h"
-#include "string_piece_util.h"
-#include "util.h"
+#include <string.h>
+#include <windows.h>
 
 #include <algorithm>
 #include <iterator>
 #include <sstream>
 
-#include <windows.h>
+#include "includes_normalize.h"
+#include "string_piece.h"
+#include "string_piece_util.h"
+#include "util.h"
 
 namespace {
 
-bool InternalGetFullPathName(const StringPiece& file_name, char* buffer,
-                             size_t buffer_length, std::string* err) {
-  DWORD result_size = GetFullPathNameA(file_name.AsString().c_str(),
-                                       buffer_length, buffer, NULL);
-  if (result_size == 0) {
-    *err = "GetFullPathNameA(" + file_name.AsString() + "): " +
-        GetLastErrorString();
+// Get the full path of a given filename. On success set |*path| and return
+// true. On failure, clear |path|, set |*err| then result false.
+bool InternalGetFullPathName(const StringPiece& file_name, std::string* path,
+                             std::string* err) {
+  // IMPORTANT: Using GetFullPathNameA() with a long paths will fail with
+  // "The filename or extension is too long" even if long path supported is
+  // enabled. GetFullPathNameW() must be used for this function to work!
+#if 1
+  path->clear();
+  // Convert to wide filename first.
+  std::string filename_str = file_name.AsString();
+  std::wstring wide_filename;
+  if (!ConvertUTF8ToWin32Unicode(filename_str, &wide_filename, err))
     return false;
-  } else if (result_size > buffer_length) {
-    *err = "path too long";
+
+  // Call GetFullPathNameW()
+  DWORD wide_full_size = GetFullPathNameW(wide_filename.c_str(), 0, NULL, NULL);
+  if (wide_full_size == 0) {
+    *err = "GetFullPathNameW(" +
+           std::string(wide_filename.begin(), wide_filename.end()) +
+           "): " + GetLastErrorString();
     return false;
   }
+
+  // NOTE: wide_full_size includes the null-terminating character.
+  std::wstring wide_path;
+  wide_path.resize(static_cast<size_t>(wide_full_size - 1));
+  DWORD wide_full_size2 =
+      GetFullPathNameW(wide_filename.c_str(), wide_full_size,
+                       const_cast<wchar_t*>(wide_path.data()), NULL);
+  if (wide_full_size2 == 0) {
+    *err = "GetFullPathNameA(" + filename_str + "): " + GetLastErrorString();
+    path->clear();
+    return false;
+  }
+
+  // Convert wide_path to Unicode.
+  return ConvertWin32UnicodeToUTF8(wide_path, path, err);
+#else
+  path->clear();
+  std::string filename_str = file_name.AsString();
+  DWORD full_size = GetFullPathNameA(filename_str.c_str(), 0, NULL, NULL);
+  if (full_size == 0) {
+    *err = "GetFullPathNameA(" + filename_str + "): " + GetLastErrorString();
+    return false;
+  }
+
+  // NOTE: full_size includes the null-terminating character.
+  path->resize(static_cast<size_t>(full_size - 1));
+  DWORD result2 = GetFullPathNameA(filename_str.c_str(), full_size,
+                                   const_cast<char*>(path->data()), NULL);
+  if (result2 == 0) {
+    *err = "GetFullPathNameA(" + filename_str + "): " + GetLastErrorString();
+    return false;
+  }
+
+  path->resize(static_cast<size_t>(result2));
+  return true;
+#endif
+}
+
+// Get the drive prefix of a given filename. On success set |*drive| then return
+// true. On failure, clear |*drive|, set |*err| then return false.
+bool InternalGetDrive(const StringPiece& file_name, std::string* drive,
+                      std::string* err) {
+  std::string path;
+  if (!InternalGetFullPathName(file_name, &path, err))
+    return false;
+
+  char drive_buffer[_MAX_DRIVE];
+  errno_t ret = _splitpath_s(path.data(), drive_buffer, sizeof(drive_buffer),
+                             NULL, 0, NULL, 0, NULL, 0);
+  if (ret != 0) {
+    *err = "_splitpath_s() returned " + std::string(strerror(ret)) +
+           " for path: " + path;
+    drive->clear();
+    return false;
+  }
+  drive->assign(drive_buffer);
   return true;
 }
 
@@ -74,19 +141,13 @@ bool SameDrive(StringPiece a, StringPiece b, std::string* err) {
     return true;
   }
 
-  char a_absolute[_MAX_PATH];
-  char b_absolute[_MAX_PATH];
-  if (!InternalGetFullPathName(a, a_absolute, sizeof(a_absolute), err)) {
+  std::string a_drive;
+  std::string b_drive;
+  if (!InternalGetDrive(a, &a_drive, err) ||
+      !InternalGetDrive(b, &b_drive, err)) {
     return false;
   }
-  if (!InternalGetFullPathName(b, b_absolute, sizeof(b_absolute), err)) {
-    return false;
-  }
-  char a_drive[_MAX_DIR];
-  char b_drive[_MAX_DIR];
-  _splitpath(a_absolute, a_drive, NULL, NULL, NULL);
-  _splitpath(b_absolute, b_drive, NULL, NULL, NULL);
-  return _stricmp(a_drive, b_drive) == 0;
+  return _stricmp(a_drive.c_str(), b_drive.c_str()) == 0;
 }
 
 // Check path |s| is FullPath style returned by GetFullPathName.
@@ -144,13 +205,14 @@ std::string IncludesNormalize::AbsPath(StringPiece s, std::string* err) {
     return result;
   }
 
-  char result[_MAX_PATH];
-  if (!InternalGetFullPathName(s, result, sizeof(result), err)) {
+  std::string result;
+  if (!InternalGetFullPathName(s, &result, err)) {
     return "";
   }
-  for (char* c = result; *c; ++c)
-    if (*c == '\\')
-      *c = '/';
+  for (char& c : result) {
+    if (c == '\\')
+      c = '/';
+  }
   return result;
 }
 
@@ -183,24 +245,17 @@ std::string IncludesNormalize::Relativize(
 
 bool IncludesNormalize::Normalize(const std::string& input, std::string* result,
                                   std::string* err) const {
-  char copy[_MAX_PATH + 1];
-  size_t len = input.size();
-  if (len > _MAX_PATH) {
-    *err = "path too long";
-    return false;
-  }
-  strncpy(copy, input.c_str(), input.size() + 1);
+  std::string copy = input;
   uint64_t slash_bits;
-  CanonicalizePath(copy, &len, &slash_bits);
-  StringPiece partially_fixed(copy, len);
-  std::string abs_input = AbsPath(partially_fixed, err);
+  CanonicalizePath(&copy, &slash_bits);
+  std::string abs_input = AbsPath(copy, err);
   if (!err->empty())
     return false;
 
   if (!SameDrive(abs_input, relative_to_, err)) {
     if (!err->empty())
       return false;
-    *result = partially_fixed.AsString();
+    *result = copy;
     return true;
   }
   *result = Relativize(abs_input, split_relative_to_, err);

--- a/src/includes_normalize_test.cc
+++ b/src/includes_normalize_test.cc
@@ -22,28 +22,26 @@
 #include "test.h"
 #include "util.h"
 
-using namespace std;
-
 namespace {
 
-string GetCurDir() {
+std::string GetCurDir() {
   char buf[_MAX_PATH];
   _getcwd(buf, sizeof(buf));
-  vector<StringPiece> parts = SplitStringPiece(buf, '\\');
+  std::vector<StringPiece> parts = SplitStringPiece(buf, '\\');
   return parts[parts.size() - 1].AsString();
 }
 
-string NormalizeAndCheckNoError(const string& input) {
-  string result, err;
+std::string NormalizeAndCheckNoError(const std::string& input) {
+  std::string result, err;
   IncludesNormalize normalizer(".");
   EXPECT_TRUE(normalizer.Normalize(input, &result, &err));
   EXPECT_EQ("", err);
   return result;
 }
 
-string NormalizeRelativeAndCheckNoError(const string& input,
-                                        const string& relative_to) {
-  string result, err;
+std::string NormalizeRelativeAndCheckNoError(const std::string& input,
+                                             const std::string& relative_to) {
+  std::string result, err;
   IncludesNormalize normalizer(relative_to);
   EXPECT_TRUE(normalizer.Normalize(input, &result, &err));
   EXPECT_EQ("", err);
@@ -60,15 +58,15 @@ TEST(IncludesNormalize, Simple) {
 }
 
 TEST(IncludesNormalize, WithRelative) {
-  string err;
-  string currentdir = GetCurDir();
+  std::string err;
+  std::string currentdir = GetCurDir();
   EXPECT_EQ("c", NormalizeRelativeAndCheckNoError("a/b/c", "a/b"));
   EXPECT_EQ("a",
             NormalizeAndCheckNoError(IncludesNormalize::AbsPath("a", &err)));
   EXPECT_EQ("", err);
-  EXPECT_EQ(string("../") + currentdir + string("/a"),
+  EXPECT_EQ(std::string("../") + currentdir + std::string("/a"),
             NormalizeRelativeAndCheckNoError("a", "../b"));
-  EXPECT_EQ(string("../") + currentdir + string("/a/b"),
+  EXPECT_EQ(std::string("../") + currentdir + std::string("/a/b"),
             NormalizeRelativeAndCheckNoError("a/b", "../c"));
   EXPECT_EQ("../../a", NormalizeRelativeAndCheckNoError("a", "b/c"));
   EXPECT_EQ(".", NormalizeRelativeAndCheckNoError("a", "a"));
@@ -107,7 +105,7 @@ TEST(IncludesNormalize, LongInvalidPath) {
       "is usually a configuration error. Compilation will continue using /Z7 "
       "instead of /Zi, but expect a similar error when you link your program.";
   // Too long, won't be canonicalized. Ensure doesn't crash.
-  string result, err;
+  std::string result, err;
   IncludesNormalize normalizer(".");
   EXPECT_FALSE(
       normalizer.Normalize(kLongInputString, &result, &err));
@@ -137,7 +135,7 @@ TEST(IncludesNormalize, LongInvalidPath) {
   kExactlyMaxPath[_MAX_PATH] = '\0';
   EXPECT_EQ(strlen(kExactlyMaxPath), _MAX_PATH);
 
-  string forward_slashes(kExactlyMaxPath);
+  std::string forward_slashes(kExactlyMaxPath);
   replace(forward_slashes.begin(), forward_slashes.end(), '\\', '/');
   // Make sure a path that's exactly _MAX_PATH long is canonicalized.
   EXPECT_EQ(forward_slashes.substr(cwd_len + 1),
@@ -145,7 +143,7 @@ TEST(IncludesNormalize, LongInvalidPath) {
 }
 
 TEST(IncludesNormalize, ShortRelativeButTooLongAbsolutePath) {
-  string result, err;
+  std::string result, err;
   IncludesNormalize normalizer(".");
   // A short path should work
   EXPECT_TRUE(normalizer.Normalize("a", &result, &err));
@@ -165,5 +163,5 @@ TEST(IncludesNormalize, ShortRelativeButTooLongAbsolutePath) {
 
   // Make sure a path that's exactly _MAX_PATH long fails with a proper error.
   EXPECT_FALSE(normalizer.Normalize(kExactlyMaxPath, &result, &err));
-  EXPECT_TRUE(err.find("GetFullPathName") != string::npos);
+  EXPECT_TRUE(err.find("GetFullPathName") != std::string::npos);
 }

--- a/src/util.cc
+++ b/src/util.cc
@@ -560,7 +560,55 @@ void Win32Fatal(const char* function, const char* hint) {
     Fatal("%s: %s", function, GetLastErrorString().c_str());
   }
 }
-#endif
+
+bool ConvertUTF8ToWin32Unicode(const std::string& input, std::wstring* output,
+                               std::string* err) {
+  output->clear();
+  if (input.empty())
+    return true;
+
+  int int_size = static_cast<int>(input.size());
+  if (static_cast<size_t>(int_size) != input.size()) {
+    *err = "Input string length > INT_MAX";
+    return false;
+  }
+  int wide_size =
+      MultiByteToWideChar(CP_UTF8, 0, input.c_str(), int_size, nullptr, 0);
+  if (wide_size <= 0) {
+    *err = "MultiByteToWideChar(" + input + "): " + GetLastErrorString();
+    return false;
+  }
+  output->resize(static_cast<size_t>(wide_size));
+  MultiByteToWideChar(CP_UTF8, 0, input.c_str(), int_size,
+                      const_cast<wchar_t*>(output->data()), wide_size);
+  return true;
+}
+
+bool ConvertWin32UnicodeToUTF8(const std::wstring& input, std::string* output,
+                               std::string* err) {
+  output->clear();
+  if (input.empty())
+    return true;
+
+  int int_size = static_cast<int>(input.size());
+  if (int_size != input.size()) {
+    *err = "Input string length > INT_MAX";
+    return false;
+  }
+  int utf8_size = WideCharToMultiByte(CP_UTF8, 0, input.c_str(), int_size, NULL,
+                                      0, NULL, NULL);
+  if (utf8_size <= 0) {
+    *err = "WideCharToMultiByte(" + std::string(input.begin(), input.end()) +
+           "): " + GetLastErrorString();
+    return false;
+  }
+
+  output->resize(static_cast<size_t>(utf8_size));
+  WideCharToMultiByte(CP_UTF8, 0, input.c_str(), int_size,
+                      const_cast<char*>(output->data()), utf8_size, NULL, NULL);
+  return true;
+}
+#endif  // _WIN32
 
 bool islatinalpha(int c) {
   // isalpha() is locale-dependent.

--- a/src/util.h
+++ b/src/util.h
@@ -125,6 +125,18 @@ std::string GetLastErrorString();
 /// Calls Fatal() with a function name and GetLastErrorString.
 NORETURN void Win32Fatal(const char* function, const char* hint = NULL);
 
+/// Convert UTF-8 string to Win32 Unicode.
+/// On success, set |*output| then return true.
+/// On Failure, clear |*output|, set |*err| then return false.
+bool ConvertUTF8ToWin32Unicode(const std::string& input, std::wstring* output,
+                               std::string* err);
+
+/// Convert WIN32 Unicode to UTF-8 string.
+/// On success, set |*output| then return true.
+/// On Failure, clear |*output|, set |*err| then return false.
+bool ConvertWin32UnicodeToUTF8(const std::wstring& input, std::string* output,
+                               std::string* err);
+
 /// Naive implementation of C++ 20 std::bit_cast(), used to fix Clang and GCC
 /// [-Wcast-function-type] warning on casting result of GetProcAddress().
 template <class To, class From>

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -502,3 +502,25 @@ TEST(StripAnsiEscapeCodes, StripColors) {
   EXPECT_EQ("affixmgr.cxx:286:15: warning: using the result... [-Wparentheses]",
             stripped);
 }
+
+#ifdef _WIN32
+TEST(ConvertWin32UnicodeToUTF8, Test) {
+  std::string output;
+  std::string err;
+  EXPECT_TRUE(ConvertWin32UnicodeToUTF8(std::wstring(L"B\u00E9b\u00E9"),
+                                        &output, &err));
+  EXPECT_TRUE(err.empty()) << err;
+  EXPECT_EQ(output, std::string("B\xC3\xA9"
+                                "b\xC3\xA9"));
+}
+
+TEST(ConvertUTF8ToWin32Unicode, Test) {
+  std::string err;
+  std::wstring output;
+  EXPECT_TRUE(ConvertUTF8ToWin32Unicode(std::string("B\xC3\xA9"
+                                                    "b\xC3\xA9"),
+                                        &output, &err));
+  EXPECT_TRUE(err.empty()) << err;
+  EXPECT_EQ(output, std::wstring(L"B\u00E9b\u00E9"));
+}
+#endif  // _WIN32


### PR DESCRIPTION
Remove the use of fixed-size buffers in `src/includes_normalize-win32.cc`  in order to support long file paths.

This also requires using GetFullPathNameW() as, surprisingly, GetFullPathNameA() would fail with long paths even when long paths are enabled on the host system running the tests.

To achieve this, introduce ConvertWin32UnicodeToUTF8() and ConvertUTF8ToWin32Unicode() functions to perform conversions properly in `src/util.cc`.