### PR TITLE
Issue 2531 fix vs2022 build

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -237,7 +237,7 @@ LoadStatus BuildLog::Load(const std::string& path, std::string* err) {
       }
       if (invalid_log_version) {
         fclose(file);
-        unlink(path.c_str());
+        _unlink(path.c_str());
         // Don't report this as a failure. A missing build log will cause
         // us to rebuild the outputs anyway.
         return LOAD_NOT_FOUND;
@@ -373,7 +373,7 @@ bool BuildLog::Recompact(const std::string& path, const BuildLogUser& user,
     entries_.erase(output);
 
   fclose(f);
-  if (unlink(path.c_str()) < 0) {
+  if (_unlink(path.c_str()) < 0) {
     *err = strerror(errno);
     return false;
   }
@@ -430,7 +430,7 @@ bool BuildLog::Restat(const StringPiece path,
   }
 
   fclose(f);
-  if (unlink(path.str_) < 0) {
+  if (_unlink(path.str_) < 0) {
     *err = strerror(errno);
     return false;
   }

--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -237,7 +237,7 @@ LoadStatus BuildLog::Load(const std::string& path, std::string* err) {
       }
       if (invalid_log_version) {
         fclose(file);
-        _unlink(path.c_str());
+        platformAwareUnlink(path.c_str());
         // Don't report this as a failure. A missing build log will cause
         // us to rebuild the outputs anyway.
         return LOAD_NOT_FOUND;
@@ -373,7 +373,7 @@ bool BuildLog::Recompact(const std::string& path, const BuildLogUser& user,
     entries_.erase(output);
 
   fclose(f);
-  if (_unlink(path.c_str()) < 0) {
+  if (platformAwareUnlink(path.c_str()) < 0) {
     *err = strerror(errno);
     return false;
   }
@@ -430,7 +430,7 @@ bool BuildLog::Restat(const StringPiece path,
   }
 
   fclose(f);
-  if (_unlink(path.str_) < 0) {
+  if (platformAwareUnlink(path.str_) < 0) {
     *err = strerror(errno);
     return false;
   }

--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -144,7 +144,7 @@ int main() {
   printf("min %dms  max %dms  avg %.1fms\n",
          min, max, total / times.size());
 
-  _unlink(kTestFilename);
+  platformAwareUnlink(kTestFilename);
 
   return 0;
 }

--- a/src/build_log_perftest.cc
+++ b/src/build_log_perftest.cc
@@ -144,7 +144,7 @@ int main() {
   printf("min %dms  max %dms  avg %.1fms\n",
          min, max, total / times.size());
 
-  unlink(kTestFilename);
+  _unlink(kTestFilename);
 
   return 0;
 }

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -34,10 +34,10 @@ const char kTestFilename[] = "BuildLogTest-tempfile";
 struct BuildLogTest : public StateTestWithBuiltinRules, public BuildLogUser {
   virtual void SetUp() {
     // In case a crashing test left a stale file behind.
-    unlink(kTestFilename);
+    _unlink(kTestFilename);
   }
   virtual void TearDown() {
-    unlink(kTestFilename);
+    _unlink(kTestFilename);
   }
   virtual bool IsPathDead(StringPiece s) const { return false; }
 };

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -34,10 +34,10 @@ const char kTestFilename[] = "BuildLogTest-tempfile";
 struct BuildLogTest : public StateTestWithBuiltinRules, public BuildLogUser {
   virtual void SetUp() {
     // In case a crashing test left a stale file behind.
-    _unlink(kTestFilename);
+    platformAwareUnlink(kTestFilename);
   }
   virtual void TearDown() {
-    _unlink(kTestFilename);
+    platformAwareUnlink(kTestFilename);
   }
   virtual bool IsPathDead(StringPiece s) const { return false; }
 };

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -1745,8 +1745,8 @@ TEST_F(BuildWithLogTest, RestatTest) {
   ASSERT_EQ("", err);
   EXPECT_EQ(builder_.Build(&err), ExitSuccess);
   ASSERT_EQ("", err);
-  EXPECT_EQ(3u, command_runner_.commands_ran_.size());
-  EXPECT_EQ(3u, builder_.plan_.command_edge_count());
+  EXPECT_EQ(size_t(3), command_runner_.commands_ran_.size());
+  EXPECT_EQ(3, builder_.plan_.command_edge_count());
   command_runner_.commands_ran_.clear();
   state_.Reset();
 
@@ -1936,8 +1936,8 @@ TEST_F(BuildWithLogTest, RestatInputChangesDueToRule) {
   ASSERT_EQ("", err);
   EXPECT_EQ(builder_.Build(&err), ExitSuccess);
   ASSERT_EQ("", err);
-  EXPECT_EQ(2u, command_runner_.commands_ran_.size());
-  EXPECT_EQ(2u, builder_.plan_.command_edge_count());
+  EXPECT_EQ(size_t(2), command_runner_.commands_ran_.size());
+  EXPECT_EQ(2, builder_.plan_.command_edge_count());
   BuildLog::LogEntry* log_entry = build_log_.LookupByOutput("out1");
   ASSERT_TRUE(NULL != log_entry);
   ASSERT_EQ(2u, log_entry->mtime);
@@ -1959,8 +1959,8 @@ TEST_F(BuildWithLogTest, RestatInputChangesDueToRule) {
   EXPECT_TRUE(!state_.GetNode("out1", 0)->dirty());
   EXPECT_EQ(builder_.Build(&err), ExitSuccess);
   ASSERT_EQ("", err);
-  EXPECT_EQ(1u, command_runner_.commands_ran_.size());
-  EXPECT_EQ(1u, builder_.plan_.command_edge_count());
+  EXPECT_EQ(size_t(1), command_runner_.commands_ran_.size());
+  EXPECT_EQ(1, builder_.plan_.command_edge_count());
 }
 
 TEST_F(BuildWithLogTest, GeneratedPlainDepfileMtime) {
@@ -4275,7 +4275,7 @@ TEST_F(BuildWithDepsLogTest, ValidationThroughDepfile) {
     EXPECT_EQ("", err);
 
     // On the first build, only the out2 command is run.
-    ASSERT_EQ(command_runner_.commands_ran_.size(), 1);
+    ASSERT_EQ(command_runner_.commands_ran_.size(), size_t(1));
     EXPECT_EQ("cat in3 > out2", command_runner_.commands_ran_[0]);
 
     // The deps file should have been removed.
@@ -4311,7 +4311,7 @@ TEST_F(BuildWithDepsLogTest, ValidationThroughDepfile) {
     EXPECT_EQ("", err);
 
     // The out and validate actions should have been run as well as out2.
-    ASSERT_EQ(command_runner_.commands_ran_.size(), 3);
+    ASSERT_EQ(command_runner_.commands_ran_.size(), size_t(3));
     // out has to run first, as both out2 and validate depend on it.
     EXPECT_EQ("cat in > out", command_runner_.commands_ran_[0]);
 

--- a/src/clean_test.cc
+++ b/src/clean_test.cc
@@ -469,11 +469,11 @@ TEST_F(CleanTest, CleanDepFileAndRspFileWithSpaces) {
 struct CleanDeadTest : public CleanTest, public BuildLogUser{
   virtual void SetUp() {
     // In case a crashing test left a stale file behind.
-    _unlink(kTestFilename);
+    platformAwareUnlink(kTestFilename);
     CleanTest::SetUp();
   }
   virtual void TearDown() {
-    _unlink(kTestFilename);
+    platformAwareUnlink(kTestFilename);
   }
   virtual bool IsPathDead(StringPiece) const { return false; }
 };

--- a/src/clean_test.cc
+++ b/src/clean_test.cc
@@ -469,11 +469,11 @@ TEST_F(CleanTest, CleanDepFileAndRspFileWithSpaces) {
 struct CleanDeadTest : public CleanTest, public BuildLogUser{
   virtual void SetUp() {
     // In case a crashing test left a stale file behind.
-    unlink(kTestFilename);
+    _unlink(kTestFilename);
     CleanTest::SetUp();
   }
   virtual void TearDown() {
-    unlink(kTestFilename);
+    _unlink(kTestFilename);
   }
   virtual bool IsPathDead(StringPiece) const { return false; }
 };

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -179,7 +179,7 @@ LoadStatus DepsLog::Load(const string& path, State* state, string* err) {
     else
       *err = "bad deps log signature or version; starting over";
     fclose(f);
-    unlink(path.c_str());
+    _unlink(path.c_str());
     // Don't report this as a failure.  An empty deps log will cause
     // us to rebuild the outputs anyway.
     return LOAD_SUCCESS;
@@ -331,7 +331,7 @@ bool DepsLog::Recompact(const string& path, string* err) {
 
   // OpenForWrite() opens for append.  Make sure it's not appending to a
   // left-over file from a previous recompaction attempt that crashed somehow.
-  unlink(temp_path.c_str());
+  _unlink(temp_path.c_str());
 
   DepsLog new_log;
   if (!new_log.OpenForWrite(temp_path, err))
@@ -363,7 +363,7 @@ bool DepsLog::Recompact(const string& path, string* err) {
   deps_.swap(new_log.deps_);
   nodes_.swap(new_log.nodes_);
 
-  if (unlink(path.c_str()) < 0) {
+  if (_unlink(path.c_str()) < 0) {
     *err = strerror(errno);
     return false;
   }

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -179,7 +179,7 @@ LoadStatus DepsLog::Load(const string& path, State* state, string* err) {
     else
       *err = "bad deps log signature or version; starting over";
     fclose(f);
-    _unlink(path.c_str());
+    platformAwareUnlink(path.c_str());
     // Don't report this as a failure.  An empty deps log will cause
     // us to rebuild the outputs anyway.
     return LOAD_SUCCESS;
@@ -331,7 +331,7 @@ bool DepsLog::Recompact(const string& path, string* err) {
 
   // OpenForWrite() opens for append.  Make sure it's not appending to a
   // left-over file from a previous recompaction attempt that crashed somehow.
-  _unlink(temp_path.c_str());
+  platformAwareUnlink(temp_path.c_str());
 
   DepsLog new_log;
   if (!new_log.OpenForWrite(temp_path, err))
@@ -363,7 +363,7 @@ bool DepsLog::Recompact(const string& path, string* err) {
   deps_.swap(new_log.deps_);
   nodes_.swap(new_log.nodes_);
 
-  if (_unlink(path.c_str()) < 0) {
+  if (platformAwareUnlink(path.c_str()) < 0) {
     *err = strerror(errno);
     return false;
   }

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -33,9 +33,9 @@ const char kTestFilename[] = "DepsLogTest-tempfile";
 struct DepsLogTest : public testing::Test {
   virtual void SetUp() {
     // In case a crashing test left a stale file behind.
-    _unlink(kTestFilename);
+    platformAwareUnlink(kTestFilename);
   }
-  virtual void TearDown() { _unlink(kTestFilename); }
+  virtual void TearDown() { platformAwareUnlink(kTestFilename); }
 };
 
 TEST_F(DepsLogTest, WriteRead) {

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -33,9 +33,9 @@ const char kTestFilename[] = "DepsLogTest-tempfile";
 struct DepsLogTest : public testing::Test {
   virtual void SetUp() {
     // In case a crashing test left a stale file behind.
-    unlink(kTestFilename);
+    _unlink(kTestFilename);
   }
-  virtual void TearDown() { unlink(kTestFilename); }
+  virtual void TearDown() { _unlink(kTestFilename); }
 };
 
 TEST_F(DepsLogTest, WriteRead) {

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -109,7 +109,7 @@ TEST_F(GraphTest, ImplicitOutputParse) {
 "build out | out.imp: cat in\n"));
 
   Edge* edge = GetNode("out")->in_edge();
-  EXPECT_EQ(2, edge->outputs_.size());
+  EXPECT_EQ(size_t(2), edge->outputs_.size());
   EXPECT_EQ("out", edge->outputs_[0]->path());
   EXPECT_EQ("out.imp", edge->outputs_[1]->path());
   EXPECT_EQ(1, edge->implicit_outs_);
@@ -151,7 +151,7 @@ TEST_F(GraphTest, ImplicitOutputOnlyParse) {
 "build | out.imp: cat in\n"));
 
   Edge* edge = GetNode("out.imp")->in_edge();
-  EXPECT_EQ(1, edge->outputs_.size());
+  EXPECT_EQ(size_t(1), edge->outputs_.size());
   EXPECT_EQ("out.imp", edge->outputs_[0]->path());
   EXPECT_EQ(1, edge->implicit_outs_);
   EXPECT_EQ(edge, GetNode("out.imp")->in_edge());
@@ -549,7 +549,7 @@ TEST_F(GraphTest, CycleWithLengthZeroFromDepfile) {
   // but the depfile also adds b as an input), the deps should have been loaded
   // only once:
   Edge* edge = GetNode("a")->in_edge();
-  EXPECT_EQ(1, edge->inputs_.size());
+  EXPECT_EQ(size_t(1), edge->inputs_.size());
   EXPECT_EQ("b", edge->inputs_[0]->path());
 }
 
@@ -574,7 +574,7 @@ TEST_F(GraphTest, CycleWithLengthOneFromDepfile) {
   // but c's in_edge has b as input but the depfile also adds |edge| as
   // output)), the deps should have been loaded only once:
   Edge* edge = GetNode("a")->in_edge();
-  EXPECT_EQ(1, edge->inputs_.size());
+  EXPECT_EQ(size_t(1), edge->inputs_.size());
   EXPECT_EQ("c", edge->inputs_[0]->path());
 }
 
@@ -601,7 +601,7 @@ TEST_F(GraphTest, CycleWithLengthOneFromDepfileOneHopAway) {
   // but c's in_edge has b as input but the depfile also adds |edge| as
   // output)), the deps should have been loaded only once:
   Edge* edge = GetNode("a")->in_edge();
-  EXPECT_EQ(1, edge->inputs_.size());
+  EXPECT_EQ(size_t(1), edge->inputs_.size());
   EXPECT_EQ("c", edge->inputs_[0]->path());
 }
 
@@ -645,13 +645,13 @@ TEST_F(GraphTest, DyndepLoadTrivial) {
   EXPECT_FALSE(GetNode("dd")->dyndep_pending());
 
   Edge* edge = GetNode("out")->in_edge();
-  ASSERT_EQ(1u, edge->outputs_.size());
+  ASSERT_EQ(size_t(1), edge->outputs_.size());
   EXPECT_EQ("out", edge->outputs_[0]->path());
-  ASSERT_EQ(2u, edge->inputs_.size());
+  ASSERT_EQ(size_t(2), edge->inputs_.size());
   EXPECT_EQ("in", edge->inputs_[0]->path());
   EXPECT_EQ("dd", edge->inputs_[1]->path());
-  EXPECT_EQ(0u, edge->implicit_deps_);
-  EXPECT_EQ(1u, edge->order_only_deps_);
+  EXPECT_EQ(0, edge->implicit_deps_);
+  EXPECT_EQ(1, edge->order_only_deps_);
   EXPECT_FALSE(edge->GetBindingBool("restat"));
 }
 
@@ -675,14 +675,14 @@ TEST_F(GraphTest, DyndepLoadImplicit) {
   EXPECT_FALSE(GetNode("dd")->dyndep_pending());
 
   Edge* edge = GetNode("out1")->in_edge();
-  ASSERT_EQ(1u, edge->outputs_.size());
+  ASSERT_EQ(size_t(1), edge->outputs_.size());
   EXPECT_EQ("out1", edge->outputs_[0]->path());
-  ASSERT_EQ(3u, edge->inputs_.size());
+  ASSERT_EQ(size_t(3), edge->inputs_.size());
   EXPECT_EQ("in", edge->inputs_[0]->path());
   EXPECT_EQ("out2", edge->inputs_[1]->path());
   EXPECT_EQ("dd", edge->inputs_[2]->path());
-  EXPECT_EQ(1u, edge->implicit_deps_);
-  EXPECT_EQ(1u, edge->order_only_deps_);
+  EXPECT_EQ(1, edge->implicit_deps_);
+  EXPECT_EQ(1, edge->order_only_deps_);
   EXPECT_FALSE(edge->GetBindingBool("restat"));
 }
 
@@ -808,35 +808,35 @@ TEST_F(GraphTest, DyndepLoadMultiple) {
   EXPECT_FALSE(GetNode("dd")->dyndep_pending());
 
   Edge* edge1 = GetNode("out1")->in_edge();
-  ASSERT_EQ(2u, edge1->outputs_.size());
+  ASSERT_EQ(size_t(2), edge1->outputs_.size());
   EXPECT_EQ("out1", edge1->outputs_[0]->path());
   EXPECT_EQ("out1imp", edge1->outputs_[1]->path());
-  EXPECT_EQ(1u, edge1->implicit_outs_);
-  ASSERT_EQ(3u, edge1->inputs_.size());
+  EXPECT_EQ(1, edge1->implicit_outs_);
+  ASSERT_EQ(size_t(3), edge1->inputs_.size());
   EXPECT_EQ("in1", edge1->inputs_[0]->path());
   EXPECT_EQ("in1imp", edge1->inputs_[1]->path());
   EXPECT_EQ("dd", edge1->inputs_[2]->path());
-  EXPECT_EQ(1u, edge1->implicit_deps_);
-  EXPECT_EQ(1u, edge1->order_only_deps_);
+  EXPECT_EQ(1, edge1->implicit_deps_);
+  EXPECT_EQ(1, edge1->order_only_deps_);
   EXPECT_FALSE(edge1->GetBindingBool("restat"));
   EXPECT_EQ(edge1, GetNode("out1imp")->in_edge());
   Node* in1imp = GetNode("in1imp");
-  ASSERT_EQ(1u, in1imp->out_edges().size());
+  ASSERT_EQ(size_t(1), in1imp->out_edges().size());
   EXPECT_EQ(edge1, in1imp->out_edges()[0]);
 
   Edge* edge2 = GetNode("out2")->in_edge();
-  ASSERT_EQ(1u, edge2->outputs_.size());
+  ASSERT_EQ(size_t(1), edge2->outputs_.size());
   EXPECT_EQ("out2", edge2->outputs_[0]->path());
-  EXPECT_EQ(0u, edge2->implicit_outs_);
-  ASSERT_EQ(3u, edge2->inputs_.size());
+  EXPECT_EQ(0, edge2->implicit_outs_);
+  ASSERT_EQ(size_t(3), edge2->inputs_.size());
   EXPECT_EQ("in2", edge2->inputs_[0]->path());
   EXPECT_EQ("in2imp", edge2->inputs_[1]->path());
   EXPECT_EQ("dd", edge2->inputs_[2]->path());
-  EXPECT_EQ(1u, edge2->implicit_deps_);
-  EXPECT_EQ(1u, edge2->order_only_deps_);
+  EXPECT_EQ(1, edge2->implicit_deps_);
+  EXPECT_EQ(1, edge2->order_only_deps_);
   EXPECT_TRUE(edge2->GetBindingBool("restat"));
   Node* in2imp = GetNode("in2imp");
-  ASSERT_EQ(1u, in2imp->out_edges().size());
+  ASSERT_EQ(size_t(1), in2imp->out_edges().size());
   EXPECT_EQ(edge2, in2imp->out_edges()[0]);
 }
 
@@ -1026,12 +1026,12 @@ TEST_F(GraphTest, DyndepFileCircular) {
 
   // Verify that "out.d" was loaded exactly once despite
   // circular reference discovered from dyndep file.
-  ASSERT_EQ(3u, edge->inputs_.size());
+  ASSERT_EQ(size_t(3), edge->inputs_.size());
   EXPECT_EQ("in", edge->inputs_[0]->path());
   EXPECT_EQ("inimp", edge->inputs_[1]->path());
   EXPECT_EQ("dd", edge->inputs_[2]->path());
-  EXPECT_EQ(1u, edge->implicit_deps_);
-  EXPECT_EQ(1u, edge->order_only_deps_);
+  EXPECT_EQ(1, edge->implicit_deps_);
+  EXPECT_EQ(1, edge->order_only_deps_);
 }
 
 TEST_F(GraphTest, Validation) {
@@ -1045,7 +1045,7 @@ TEST_F(GraphTest, Validation) {
   EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), &validation_nodes, &err));
   ASSERT_EQ("", err);
 
-  ASSERT_EQ(validation_nodes.size(), 1);
+  ASSERT_EQ(validation_nodes.size(), size_t(1));
   EXPECT_EQ(validation_nodes[0]->path(), "validate");
 
   EXPECT_TRUE(GetNode("out")->dirty());
@@ -1117,7 +1117,7 @@ TEST_F(GraphTest, EdgeQueuePriority) {
     queue.push(edges[i]);
   }
 
-  EXPECT_EQ(queue.size(), n_edges);
+  EXPECT_EQ(queue.size(), static_cast<size_t>(n_edges));
   for (int i = 0; i < n_edges; ++i) {
     EXPECT_EQ(queue.top(), edges[n_edges - 1 - i]);
     queue.pop();

--- a/src/includes_normalize_test.cc
+++ b/src/includes_normalize_test.cc
@@ -135,7 +135,8 @@ TEST(IncludesNormalize, LongInvalidPath) {
   }
 
   kExactlyMaxPath[_MAX_PATH] = '\0';
-  EXPECT_EQ(strlen(kExactlyMaxPath), _MAX_PATH);
+  // This is a relatively safe cast as we can expect that _MAX_PATH will never be negative
+  EXPECT_EQ(strlen(kExactlyMaxPath), static_cast<size_t>(_MAX_PATH));
 
   string forward_slashes(kExactlyMaxPath);
   replace(forward_slashes.begin(), forward_slashes.end(), '\\', '/');
@@ -161,7 +162,7 @@ TEST(IncludesNormalize, ShortRelativeButTooLongAbsolutePath) {
       kExactlyMaxPath[i] = 'a';
   }
   kExactlyMaxPath[_MAX_PATH] = '\0';
-  EXPECT_EQ(strlen(kExactlyMaxPath), _MAX_PATH);
+  EXPECT_EQ(strlen(kExactlyMaxPath), static_cast<size_t>(_MAX_PATH));
 
   // Make sure a path that's exactly _MAX_PATH long fails with a proper error.
   EXPECT_FALSE(normalizer.Normalize(kExactlyMaxPath, &result, &err));

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -380,7 +380,7 @@ TEST_F(ParserTest, PhonySelfReferenceKept) {
 
   Node* node = state.LookupNode("a");
   Edge* edge = node->in_edge();
-  ASSERT_EQ(edge->inputs_.size(), 1);
+  ASSERT_EQ(edge->inputs_.size(), size_t(1));
   ASSERT_EQ(edge->inputs_[0], node);
 }
 
@@ -944,7 +944,7 @@ TEST_F(ParserTest, Validations) {
 "build foo: cat bar |@ baz\n"));
 
   Edge* edge = state.LookupNode("foo")->in_edge();
-  ASSERT_EQ(edge->validations_.size(), 1);
+  ASSERT_EQ(edge->validations_.size(), size_t(1));
   EXPECT_EQ(edge->validations_[0]->path(), "baz");
 }
 
@@ -955,7 +955,7 @@ TEST_F(ParserTest, ImplicitOutput) {
 "build foo | imp: cat bar\n"));
 
   Edge* edge = state.LookupNode("imp")->in_edge();
-  ASSERT_EQ(edge->outputs_.size(), 2);
+  ASSERT_EQ(edge->outputs_.size(), size_t(2));
   EXPECT_TRUE(edge->is_implicit_out(1));
 }
 
@@ -966,7 +966,7 @@ TEST_F(ParserTest, ImplicitOutputEmpty) {
 "build foo | : cat bar\n"));
 
   Edge* edge = state.LookupNode("foo")->in_edge();
-  ASSERT_EQ(edge->outputs_.size(), 1);
+  ASSERT_EQ(edge->outputs_.size(), size_t(1));
   EXPECT_FALSE(edge->is_implicit_out(0));
 }
 

--- a/src/msvc_helper_main-win32.cc
+++ b/src/msvc_helper_main-win32.cc
@@ -54,23 +54,23 @@ void WriteDepFileOrDie(const char* object_path, const CLParser& parse) {
   string depfile_path = string(object_path) + ".d";
   FILE* depfile = fopen(depfile_path.c_str(), "w");
   if (!depfile) {
-    unlink(object_path);
+    _unlink(object_path);
     Fatal("opening %s: %s", depfile_path.c_str(),
           GetLastErrorString().c_str());
   }
   if (fprintf(depfile, "%s: ", object_path) < 0) {
-    unlink(object_path);
+    _unlink(object_path);
     fclose(depfile);
-    unlink(depfile_path.c_str());
+    _unlink(depfile_path.c_str());
     Fatal("writing %s", depfile_path.c_str());
   }
   const set<string>& headers = parse.includes_;
   for (set<string>::const_iterator i = headers.begin();
        i != headers.end(); ++i) {
     if (fprintf(depfile, "%s\n", EscapeForDepfile(*i).c_str()) < 0) {
-      unlink(object_path);
+      _unlink(object_path);
       fclose(depfile);
-      unlink(depfile_path.c_str());
+      _unlink(depfile_path.c_str());
       Fatal("writing %s", depfile_path.c_str());
     }
   }

--- a/src/msvc_helper_main-win32.cc
+++ b/src/msvc_helper_main-win32.cc
@@ -54,23 +54,23 @@ void WriteDepFileOrDie(const char* object_path, const CLParser& parse) {
   string depfile_path = string(object_path) + ".d";
   FILE* depfile = fopen(depfile_path.c_str(), "w");
   if (!depfile) {
-    _unlink(object_path);
+    platformAwareUnlink(object_path);
     Fatal("opening %s: %s", depfile_path.c_str(),
           GetLastErrorString().c_str());
   }
   if (fprintf(depfile, "%s: ", object_path) < 0) {
-    _unlink(object_path);
+    platformAwareUnlink(object_path);
     fclose(depfile);
-    _unlink(depfile_path.c_str());
+    platformAwareUnlink(depfile_path.c_str());
     Fatal("writing %s", depfile_path.c_str());
   }
   const set<string>& headers = parse.includes_;
   for (set<string>::const_iterator i = headers.begin();
        i != headers.end(); ++i) {
     if (fprintf(depfile, "%s\n", EscapeForDepfile(*i).c_str()) < 0) {
-      _unlink(object_path);
+      platformAwareUnlink(object_path);
       fclose(depfile);
-      _unlink(depfile_path.c_str());
+      platformAwareUnlink(depfile_path.c_str());
       Fatal("writing %s", depfile_path.c_str());
     }
   }

--- a/src/string_piece_util_test.cc
+++ b/src/string_piece_util_test.cc
@@ -23,7 +23,7 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
     string input("a:b:c");
     vector<StringPiece> list = SplitStringPiece(input, ':');
 
-    EXPECT_EQ(list.size(), 3);
+    EXPECT_EQ(list.size(), size_t(3));
 
     EXPECT_EQ(list[0], "a");
     EXPECT_EQ(list[1], "b");
@@ -34,7 +34,7 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
     string empty;
     vector<StringPiece> list = SplitStringPiece(empty, ':');
 
-    EXPECT_EQ(list.size(), 1);
+    EXPECT_EQ(list.size(), size_t(1));
 
     EXPECT_EQ(list[0], "");
   }
@@ -43,7 +43,7 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
     string one("a");
     vector<StringPiece> list = SplitStringPiece(one, ':');
 
-    EXPECT_EQ(list.size(), 1);
+    EXPECT_EQ(list.size(), size_t(1));
 
     EXPECT_EQ(list[0], "a");
   }
@@ -52,7 +52,7 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
     string sep_only(":");
     vector<StringPiece> list = SplitStringPiece(sep_only, ':');
 
-    EXPECT_EQ(list.size(), 2);
+    EXPECT_EQ(list.size(), size_t(2));
 
     EXPECT_EQ(list[0], "");
     EXPECT_EQ(list[1], "");
@@ -62,7 +62,7 @@ TEST(StringPieceUtilTest, SplitStringPiece) {
     string sep(":a:b:c:");
     vector<StringPiece> list = SplitStringPiece(sep, ':');
 
-    EXPECT_EQ(list.size(), 5);
+    EXPECT_EQ(list.size(), size_t(5));
 
     EXPECT_EQ(list[0], "");
     EXPECT_EQ(list[1], "a");

--- a/src/test.cc
+++ b/src/test.cc
@@ -254,7 +254,7 @@ ScopedFilePath& ScopedFilePath::operator=(ScopedFilePath&& other) noexcept {
 
 ScopedFilePath::~ScopedFilePath() {
   if (!released_) {
-    _unlink(path_.c_str());
+    platformAwareUnlink(path_.c_str());
   }
 }
 

--- a/src/test.cc
+++ b/src/test.cc
@@ -254,7 +254,7 @@ ScopedFilePath& ScopedFilePath::operator=(ScopedFilePath&& other) noexcept {
 
 ScopedFilePath::~ScopedFilePath() {
   if (!released_) {
-    unlink(path_.c_str());
+    _unlink(path_.c_str());
   }
 }
 

--- a/src/third_party/emhash/hash_table8.hpp
+++ b/src/third_party/emhash/hash_table8.hpp
@@ -1337,8 +1337,8 @@ private:
 
         while (true) {
             if (EMH_EQHASH(next_bucket, key_hash)) {
-                const auto slot = _index[next_bucket].slot & _mask;
-                if (EMH_LIKELY(_eq(key, _pairs[slot].first)))
+                const auto next_slot = _index[next_bucket].slot & _mask;
+                if (EMH_LIKELY(_eq(key, _pairs[next_slot].first)))
                     return next_bucket;
             }
 
@@ -1372,9 +1372,9 @@ private:
 
         while (true) {
             if (EMH_EQHASH(next_bucket, key_hash)) {
-                const auto slot = _index[next_bucket].slot & _mask;
-                if (EMH_LIKELY(_eq(key, _pairs[slot].first)))
-                    return slot;
+                const auto next_slot = _index[next_bucket].slot & _mask;
+                if (EMH_LIKELY(_eq(key, _pairs[next_slot].first)))
+                    return next_slot;
             }
 
             const auto nbucket = _index[next_bucket].next;

--- a/src/util.cc
+++ b/src/util.cc
@@ -950,3 +950,11 @@ bool Truncate(const string& path, size_t size, string* err) {
   }
   return true;
 }
+
+int platformAwareUnlink(const char* filename) {
+	#ifdef _WIN32
+		return _unlink(filename);
+	#else
+		return unlink(filename);
+	#endif
+}

--- a/src/util.h
+++ b/src/util.h
@@ -135,4 +135,6 @@ inline To FunctionCast(From from) {
 }
 #endif
 
+int platformAwareUnlink(const char* filename);
+
 #endif  // NINJA_UTIL_H_

--- a/src/util.h
+++ b/src/util.h
@@ -111,7 +111,6 @@ bool Truncate(const std::string& path, size_t size, std::string* err);
 #ifdef _MSC_VER
 #define snprintf _snprintf
 #define fileno _fileno
-#define unlink _unlink
 #define chdir _chdir
 #define strtoull _strtoui64
 #define getcwd _getcwd

--- a/src/util.h
+++ b/src/util.h
@@ -135,12 +135,4 @@ inline To FunctionCast(From from) {
 }
 #endif
 
-inline int platformAwareUnlink(const char* filename) {
-	#ifdef _WIN32
-		return _unlink(filename);
-	#else
-		return unlink(filename);
-	#endif
-}
-
 #endif  // NINJA_UTIL_H_

--- a/src/util.h
+++ b/src/util.h
@@ -135,4 +135,12 @@ inline To FunctionCast(From from) {
 }
 #endif
 
+inline int platformAwareUnlink(const char* filename) {
+	#ifdef _WIN32
+		return _unlink(filename);
+	#else
+		return unlink(filename);
+	#endif
+}
+
 #endif  // NINJA_UTIL_H_

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -350,7 +350,7 @@ TEST(CanonicalizePath, TooManyComponents) {
       "a\\.\\a\\.\\a\\.\\a\\.\\a\\.\\a\\.\\a\\.\\a\\.\\"
       "a\\.\\a\\.\\a\\.\\a\\.\\a\\.\\a\\.\\a\\.\\a\\.\\x\\y.h";
   CanonicalizePath(&path, &slash_bits);
-  EXPECT_EQ(slash_bits, 0x1ffffffff);
+  EXPECT_EQ(slash_bits, uint64_t(0x1ffffffff));
 
 
   // 59 after canonicalization is OK.
@@ -368,7 +368,7 @@ TEST(CanonicalizePath, TooManyComponents) {
       "a\\a\\a\\a\\a\\a\\a\\a\\a\\x\\y.h";
   EXPECT_EQ(58, std::count(path.begin(), path.end(), '\\'));
   CanonicalizePath(&path, &slash_bits);
-  EXPECT_EQ(slash_bits, 0x3ffffffffffffff);
+  EXPECT_EQ(slash_bits, uint64_t(0x3ffffffffffffff));
 
   // More than 60 components is now completely ok too.
   path =


### PR DESCRIPTION
Okay my plan here is to take a multi stage approach to getting the latest hash_table8 moved into the project.

1. [This PR] Fix all VS2022 build errors including the original shadowing error mentioned in #2531 
2. Target c++14
3. Pull in the latest version of hash_table8

### Changes

1. Fixed the variable shadowing in hash_table8. The justification for fixing here instead of taking version 1.7 directly from the emhash project is that we are targeting c++11 and can't support the latest version.
2. We had defined the macro ```#define unlink _unlink``` but the compiler still viewed 'unlink' as a POSIX function. I created a function that injects the correct version of unlink depending on the platform.
3. Lots of sign mismatch warnings. Logically something like ```EXPECT_EQ(list.size(), 1);``` makes sense, but the compiler doesn't like it. Ideally we would be matching all of our assertions to the exact type. But realistically ```EXPECT_EQ(list.size(), size_t(1));``` and ```EXPECT_EQ(list.size(), 1u);``` are going to be equivalent for small values. 