### PR TITLE
Migrate to c++14

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -623,7 +623,7 @@ if gtest_src_dir:
     n.comment('Tests all build into ninja_test executable.')
 
     # Test-specific version of cflags, must include the GoogleTest
-    # include directory. 
+    # include directory.
     test_cflags = cflags.copy()
     test_cflags.append('-I' + os.path.join(gtest_src_dir, 'googletest', 'include'))
 

--- a/configure.py
+++ b/configure.py
@@ -362,7 +362,7 @@ else:
               '-Wno-unused-parameter',
               '-fno-rtti',
               '-fno-exceptions',
-              '-std=c++11',
+              '-std=c++14',
               '-fvisibility=hidden', '-pipe',
               '-DNINJA_PYTHON="%s"' % options.with_python]
     if options.debug:
@@ -623,8 +623,8 @@ if gtest_src_dir:
     n.comment('Tests all build into ninja_test executable.')
 
     # Test-specific version of cflags, must include the GoogleTest
-    # include directory. Also GoogleTest can only build with a C++14 compiler.
-    test_cflags = [f.replace('std=c++11', 'std=c++14') for f in cflags]
+    # include directory. 
+    test_cflags = cflags.copy()
     test_cflags.append('-I' + os.path.join(gtest_src_dir, 'googletest', 'include'))
 
     test_variables = [('cflags', test_cflags)]


### PR DESCRIPTION
This is related to #2531 

Before we can bring in the latest version of hash_table8 we need to migrate to c++14. This should also bring some quality of life to future development as developers will have access to ```std::make_unique```. There weren't any major deprecations in c++14 so we shouldn't see any warnings there if we ever happen to remove ```-Wno-deprecated```. 

### What changed

Updated configure.py to...
1. set cflags to target c++14.
2. remove a function that replaced c++11 with c++14 when building ninja_test as we are now targeting the required version.