### PR TITLE
Removed parallel from build-aarch64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -183,7 +183,7 @@ jobs:
       - run: |
           # BUILD
           cmake -DCMAKE_BUILD_TYPE=Release -B release-build
-          cmake --build release-build --parallel --config Release
+          cmake --build release-build --config Release
           strip release-build/ninja
           file release-build/ninja
 


### PR DESCRIPTION
### Experimental fix for build aarch64

I replicated the build system on a raspberry pi 4 and ran the same cmake commands. Over multiple test runs I found that the kernel would get locked up in the same spot. I switched to a 3b+ and got the same results.

I took the --parallel flag off the build command and the build completed. 

I'm interested in seeing what happens in the github environment.

[pi4-output.txt](https://github.com/user-attachments/files/18597240/pi4-output.txt)
 