### PR TITLE
browse: do not compare str to None during sort

### DIFF
--- a/src/browse.py
+++ b/src/browse.py
@@ -82,7 +82,7 @@ def parse(text: str) -> Node:
         if match:
             (match, line) = match_strip(next(lines), '    ')
             while match:
-                type = None
+                type = ""
                 (match, line) = match_strip(line, '| ')
                 if match:
                     type = 'implicit'


### PR DESCRIPTION
Ran into this issue trying to debug a build - ninja -t browse simply doesn't work with python3! `None < "implicit'` was valid under python 2, but under python 3 it's an error. Switching to the empty string causes the sort to succeed while still being a falsey value for what was previously a check for None.