### PR TITLE
[Doc] add cmake -DBUILD_TESTING option hint for users building with CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,17 @@ version of the library.
 
 ### CMake
 
+To build the ninja binary without building the unit tests, disable test building by setting `BUILD_TESTING` to `false`:
+
 ```
-cmake -Bbuild-cmake
+cmake -Bbuild-cmake -DBUILD_TESTING=false
 cmake --build build-cmake
 ```
 
 The `ninja` binary will now be inside the `build-cmake` directory (you can
 choose any other name you like).
 
-To run the unit tests:
+To run the unit tests, omit the `-DBUILD_TESTING=false` option, and after building, run:
 
 ```
 ./build-cmake/ninja_test

--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ version of the library.
 
 ### CMake
 
-To build the ninja binary without building the unit tests, disable test building by setting `BUILD_TESTING` to `false`:
+To build the ninja binary without building the unit tests, disable test building by setting `BUILD_TESTING` to `OFF`:
 
 ```
-cmake -Bbuild-cmake -DBUILD_TESTING=false
+cmake -Bbuild-cmake -DBUILD_TESTING=OFF
 cmake --build build-cmake
 ```
 
 The `ninja` binary will now be inside the `build-cmake` directory (you can
 choose any other name you like).
 
-To run the unit tests, omit the `-DBUILD_TESTING=false` option, and after building, run:
+To run the unit tests, omit the `-DBUILD_TESTING=OFF` option, and after building, run:
 
 ```
 ./build-cmake/ninja_test


### PR DESCRIPTION
Building with CMake currently defaults to building unit tests, which pulls in the full GoogleTest source. This is unnecessary for users who only need the ninja binary, and it increases build time and disk usage — especially problematic in minimal environments like Docker.

This update adds a note to the README showing how to disable test builds using: `-DBUILD_TESTING=OFF`  
This makes the build process faster and lighter for users who don't need testing.