### PR TITLE
Add support for cgroup2 in CPU quota parsing

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -794,8 +794,8 @@ int ParseCgroupV2(std::string& path) {
 }
 
 int ParseCPUFromCGroup() {
-  std::map<string, CGroupSubSys> subsystems = ParseSelfCGroup();
-  std::map<string, string> cgroups = ParseMountInfo(subsystems);
+  auto subsystems = ParseSelfCGroup();
+  auto cgroups = ParseMountInfo(subsystems);
 
   // Prefer cgroup v2 if both v1 and v2 should be present
   if (const auto cgroup2 = cgroups.find("cgroup2"); cgroup2 != cgroups.end()) {


### PR DESCRIPTION
On systems using cgroup2, CPU quota auto detection would fail.
Now, cgroup v2 cpu.max will be parsed with a fallback to cgroup v1.

Tested with Docker on Ubuntu 24.04 with cgroup v2 and Ubuntu 20.04 with cgroup v1.

```
docker run -it --rm --cpus 2.5 ubuntu:24.04
ninja -h

...
-j N     run N jobs in parallel (0 means infinity) [default=3 on this system]
```

Fixes #2166 