### PR TITLE
add option to subtool graph

### DIFF
--- a/src/graphviz.cc
+++ b/src/graphviz.cc
@@ -22,13 +22,20 @@
 
 using namespace std;
 
-void GraphViz::AddTarget(Node* node) {
+void GraphViz::printNodeLabel(Node* node){
+   if (labeled_nodes_.find(node) == labeled_nodes_.end()) {
+    string pathstr = node->path();
+    replace(pathstr.begin(), pathstr.end(), '\\', '/');
+    printf("\"%p\" [label=\"%s\"]\n", node, pathstr.c_str());
+    labeled_nodes_.insert(node);
+  }
+}
+
+void GraphViz::AddTarget(Node* node, const int depth) {
   if (visited_nodes_.find(node) != visited_nodes_.end())
     return;
 
-  string pathstr = node->path();
-  replace(pathstr.begin(), pathstr.end(), '\\', '/');
-  printf("\"%p\" [label=\"%s\"]\n", node, pathstr.c_str());
+  printNodeLabel(node);
   visited_nodes_.insert(node);
 
   Edge* edge = node->in_edge();
@@ -54,11 +61,15 @@ void GraphViz::AddTarget(Node* node) {
     // Can draw simply.
     // Note extra space before label text -- this is cosmetic and feels
     // like a graphviz bug.
-    printf("\"%p\" -> \"%p\" [label=\" %s\"]\n",
-           edge->inputs_[0], edge->outputs_[0], edge->rule_->name().c_str());
+    printNodeLabel(edge->inputs_[0]);
+    printf("\"%p\" -> \"%p\" [label=\" %s\"]\n", edge->inputs_[0],
+           edge->outputs_[0], edge->rule_->name().c_str());    
   } else {
-    printf("\"%p\" [label=\"%s\", shape=ellipse]\n",
-           edge, edge->rule_->name().c_str());
+    if (labeled_edges_.find(edge) == labeled_edges_.end()) {
+      printf("\"%p\" [label=\"%s\", shape=ellipse]\n", edge,
+             edge->rule_->name().c_str());
+      labeled_edges_.insert(edge);
+    }
     for (vector<Node*>::iterator out = edge->outputs_.begin();
          out != edge->outputs_.end(); ++out) {
       printf("\"%p\" -> \"%p\"\n", edge, *out);
@@ -68,13 +79,16 @@ void GraphViz::AddTarget(Node* node) {
       const char* order_only = "";
       if (edge->is_order_only(in - edge->inputs_.begin()))
         order_only = " style=dotted";
+      printNodeLabel(*in);
       printf("\"%p\" -> \"%p\" [arrowhead=none%s]\n", (*in), edge, order_only);
     }
   }
 
-  for (vector<Node*>::iterator in = edge->inputs_.begin();
-       in != edge->inputs_.end(); ++in) {
-    AddTarget(*in);
+  if (depth != 0) {
+    for (vector<Node*>::iterator in = edge->inputs_.begin();
+         in != edge->inputs_.end(); ++in) {
+      AddTarget(*in, depth < 0 ? -1 : depth - 1);
+    }
   }
 }
 

--- a/src/graphviz.h
+++ b/src/graphviz.h
@@ -30,12 +30,16 @@ struct GraphViz {
   GraphViz(State* state, DiskInterface* disk_interface)
       : dyndep_loader_(state, disk_interface) {}
   void Start();
-  void AddTarget(Node* node);
+  void AddTarget(Node* node, int depth);
   void Finish();
 
+  void printNodeLabel(Node* node);
+
   DyndepLoader dyndep_loader_;
-  std::set<Node*> visited_nodes_;
+  std::set<Node*> visited_nodes_;  
   EdgeSet visited_edges_;
+  std::set<Node*> labeled_nodes_;
+  EdgeSet labeled_edges_;
 };
 
 #endif  // NINJA_GRAPHVIZ_H_

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -379,6 +379,45 @@ bool NinjaMain::CollectTargetsFromArgs(int argc, char* argv[],
 }
 
 int NinjaMain::ToolGraph(const Options* options, int argc, char* argv[]) {
+
+  // The graph tool uses getopt, and expects argv[0] to contain the name of
+  // the tool, i.e. "graph".
+  argc++;
+  argv--;
+
+  int depth = -1; 
+
+  optind = 1;
+  int opt;
+  const option kLongOptions[] = { { "help", no_argument, NULL, 'h' },
+                                  { "depth", required_argument, NULL, 'd' },
+                                  { NULL, 0, NULL, 0 } };
+  while ((opt = getopt_long(argc, argv, "d:h0", kLongOptions, NULL)) != -1) {
+    switch (opt) {
+    case 'd':
+      depth = atoi(optarg);
+      break;   
+    case 'h':
+    default:
+      // clang-format off
+      printf(
+"Usage '-t graph [options] [targets]\n"
+"\n"
+"output graphviz dot file for targets.\n"
+"For smaller outputs try the --depth option.\n"
+"  example:\n"
+"   ninja -t graph mytarget | dot -Tsvg -ograph.svg\n"
+"Options:\n"
+"  -h, --help   Print this message.\n"
+"  -d, --depth  limit the dependency depth to inputs.\n"
+      );
+      // clang-format on
+      return 1;
+    }
+  }
+  argv += optind;
+  argc -= optind;
+
   vector<Node*> nodes;
   string err;
   if (!CollectTargetsFromArgs(argc, argv, &nodes, &err)) {
@@ -389,7 +428,7 @@ int NinjaMain::ToolGraph(const Options* options, int argc, char* argv[]) {
   GraphViz graph(&state_, &disk_interface_);
   graph.Start();
   for (vector<Node*>::const_iterator n = nodes.begin(); n != nodes.end(); ++n)
-    graph.AddTarget(*n);
+    graph.AddTarget(*n, depth);
   graph.Finish();
 
   return 0;


### PR DESCRIPTION
the command
`ninja -t graph mytarget`
will generate a .dot file to visualize the dependency graph. This is a good working feature to understand the build.
But for large (cmake) projects, the generated .dot file is getting large as well. Generating a graphic file from those large files is practically not possible.

For the case you only want to see a subset of the graph of a dedicated target, I propose to add the following option:
`ninja -t graph -d 1 mytarget`
`ninja -t graph -d [integer] mytarget`
The -d option gives a possibility to specify the maximum dependency distance of the target and their inputs.
Without the -d flag, the behavior is as before, same as for negative values.

In the following, some examples using the ninja as an target

`ninja -t graph -d 0 ninja`
![depth0](https://github.com/user-attachments/assets/7082912e-7536-4c44-b6f7-1b495e1c9fe6)
`ninja -t graph -d 1 ninja`
![depth1](https://github.com/user-attachments/assets/07661f16-4b6d-42d3-b34f-744b74bcd130)
`ninja -t graph ninja`
![original](https://github.com/user-attachments/assets/af89a589-2cd4-4b5d-882b-9057a7ff500f)