### PR TITLE
Issue2599ampersands

### DIFF
--- a/src/depfile_parser.in.cc
+++ b/src/depfile_parser.in.cc
@@ -134,7 +134,7 @@ bool DepfileParser::Parse(string* content, string* err) {
         *out++ = '$';
         continue;
       }
-      '\\'+ [^\000\r\n] | [a-zA-Z0-9+?,/_:.~()}{%=@\x5B\x5D!\x80-\xFF-]+ {
+      '\\'+ [^\000\r\n] | [a-zA-Z0-9+?,/_:.&~()}{%=@\x5B\x5D!\x80-\xFF-]+ {
         // Got a span of plain text.
         int len = (int)(in - start);
         // Need to shift it over if we're overwriting backslashes.

--- a/src/depfile_parser_test.cc
+++ b/src/depfile_parser_test.cc
@@ -198,13 +198,14 @@ TEST_F(DepfileParserTest, SpecialChars) {
 " en@quot.header~ t+t-x!=1 \\\n"
 " openldap/slapd.d/cn=config/cn=schema/cn={0}core.ldif\\\n"
 " Fu\303\244ball\\\n"
+" ampersand&Special\\\n"
 " a[1]b@2%c",
       &err));
   ASSERT_EQ("", err);
   ASSERT_EQ(1u, parser_.outs_.size());
   EXPECT_EQ("C:/Program Files (x86)/Microsoft crtdefs.h",
             parser_.outs_[0].AsString());
-  ASSERT_EQ(5u, parser_.ins_.size());
+  ASSERT_EQ(6u, parser_.ins_.size());
   EXPECT_EQ("en@quot.header~",
             parser_.ins_[0].AsString());
   EXPECT_EQ("t+t-x!=1",
@@ -213,8 +214,10 @@ TEST_F(DepfileParserTest, SpecialChars) {
             parser_.ins_[2].AsString());
   EXPECT_EQ("Fu\303\244ball",
             parser_.ins_[3].AsString());
-  EXPECT_EQ("a[1]b@2%c",
+  EXPECT_EQ("ampersand&Special",
             parser_.ins_[4].AsString());
+  EXPECT_EQ("a[1]b@2%c",
+            parser_.ins_[5].AsString());
 }
 
 TEST_F(DepfileParserTest, UnifyMultipleOutputs) {


### PR DESCRIPTION
This solves [issue2599](https://github.com/ninja-build/ninja/issues/2599).
The character '&' has not been accepted as part of the input or output string in a dep file.