### PR TITLE
Prevent ninja starting new job when physical memory become low.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 # --- compiler flags
 if(MSVC)
 	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-	string(REPLACE "/GR" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+	string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 	# Note that these settings are separately specified in configure.py, and
 	# these lists should be kept in sync.
 	add_compile_options(/W4 /wd4100 /wd4267 /wd4706 /wd4702 /wd4244 /GR- /Zc:__cplusplus)

--- a/src/build.h
+++ b/src/build.h
@@ -187,6 +187,7 @@ struct BuildConfig {
   int parallelism = 1;
   bool disable_jobserver_client = false;
   int failures_allowed = 1;
+  long desired_free_ram = -1;
   /// The maximum load average we must not exceed. A negative value
   /// means that we do not have any limit.
   double max_load_average = -0.0f;

--- a/src/build.h
+++ b/src/build.h
@@ -187,7 +187,7 @@ struct BuildConfig {
   int parallelism = 1;
   bool disable_jobserver_client = false;
   int failures_allowed = 1;
-  long desired_free_ram = -1;
+  long desired_free_ram = 0;
   /// The maximum load average we must not exceed. A negative value
   /// means that we do not have any limit.
   double max_load_average = -0.0f;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1685,7 +1685,7 @@ class DeferGuessParallelism {
   ~DeferGuessParallelism() { Refresh(); }
 };
 
-static inline constexpr long GetUnitToByteRatio(char unit) {
+static inline long GetUnitToByteRatio(char unit) {
   switch (unit) {
   case 'G':
   case 'g':

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -246,7 +246,8 @@ void Usage(const BuildConfig& config) {
 "  -d MODE  enable debugging (use '-d list' to list modes)\n"
 "  -t TOOL  run a subtool (use '-t list' to list subtools)\n"
 "    terminates toplevel options; further flags are passed to the tool\n"
-"  -w FLAG  adjust warnings (use '-w list' to list warnings)\n",
+"  -w FLAG  adjust warnings (use '-w list' to list warnings)\n"
+"  --keep-free-memory AMOUNT the amount of ram required to start a job\n",
           kNinjaVersion, config.parallelism);
 }
 
@@ -1690,12 +1691,13 @@ int ReadFlags(int* argc, char*** argv,
               Options* options, BuildConfig* config) {
   DeferGuessParallelism deferGuessParallelism(config);
 
-  enum { OPT_VERSION = 1, OPT_QUIET = 2 };
+  enum { OPT_VERSION = 1, OPT_QUIET = 2, OPT_FREE_MEM = 3 };
   const option kLongOptions[] = {
     { "help", no_argument, NULL, 'h' },
     { "version", no_argument, NULL, OPT_VERSION },
     { "verbose", no_argument, NULL, 'v' },
     { "quiet", no_argument, NULL, OPT_QUIET },
+    { "keep-free-memory", required_argument, NULL, OPT_FREE_MEM},
     { NULL, 0, NULL, 0 }
   };
 
@@ -1769,6 +1771,14 @@ int ReadFlags(int* argc, char*** argv,
       case OPT_VERSION:
         printf("%s\n", kNinjaVersion);
         return 0;
+      case OPT_FREE_MEM: {
+        char * end;
+        long value = strtol(optarg, &end, 10);
+        if (*end != 0 || value < 0)
+          Fatal("invalid --keep-free-memory parameter");
+        config->desired_free_ram = value;
+        break;
+      }
       case 'h':
       default:
         deferGuessParallelism.Refresh();

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1685,6 +1685,23 @@ class DeferGuessParallelism {
   ~DeferGuessParallelism() { Refresh(); }
 };
 
+static inline constexpr long GetUnitToByteRatio(char unit) {
+  switch (unit) {
+  case 'G':
+  case 'g':
+    return 1e+9;
+  case 'M':
+  case 'm':
+    return 1e+6;
+  case 'K':
+  case 'k':
+    return 1e+3;
+  case 'B':
+    return 1;
+  }
+  return 0;
+}
+
 /// Parse argv for command-line options.
 /// Returns an exit code, or -1 if Ninja should continue.
 int ReadFlags(int* argc, char*** argv,
@@ -1774,7 +1791,12 @@ int ReadFlags(int* argc, char*** argv,
       case OPT_FREE_MEM: {
         char * end;
         long value = strtol(optarg, &end, 10);
-        if (*end != 0 || value < 0)
+        long multiplier = GetUnitToByteRatio(*end);
+        value *= multiplier;
+        //last char was the unit
+        if(multiplier > 0)
+          end++;
+        if (*end != 0 || value < 0 || multiplier == 0)
           Fatal("invalid --keep-free-memory parameter");
         config->desired_free_ram = value;
         break;

--- a/src/real_command_runner.cc
+++ b/src/real_command_runner.cc
@@ -81,7 +81,7 @@ size_t RealCommandRunner::CanRunMore() const {
     // Ensure that we make progress.
     capacity = 1;
 
-  //this just pause the creation of new processes when we run out of ran, there is no way to estimate the number of process we can run.
+  //this just pause the creation of new processes when we run out of ram, there is no way to estimate the number of process we can run.
   if (config_.desired_free_ram > 0 && GetFreeMemory() < config_.desired_free_ram ) {
     capacity = 0;
   }

--- a/src/real_command_runner.cc
+++ b/src/real_command_runner.cc
@@ -81,6 +81,11 @@ size_t RealCommandRunner::CanRunMore() const {
     // Ensure that we make progress.
     capacity = 1;
 
+  //this just pause the creation of new processes when we run out of ran, there is no way to estimate the number of process we can run.
+  if (config_.desired_free_ram > 0 && GetFreeMemory() < config_.desired_free_ram ) {
+    capacity = 0;
+  }
+
   return capacity;
 }
 

--- a/src/real_command_runner.cc
+++ b/src/real_command_runner.cc
@@ -77,7 +77,6 @@ size_t RealCommandRunner::CanRunMore() const {
   //this just pause the creation of new processes when we run out of ram
   if (config_.desired_free_ram > 0) {
     long memory_capacity = GetFreeMemory() / config_.desired_free_ram;
-    fprintf(stderr, "Mem cap=%ld\n", memory_capacity);
     if (memory_capacity < capacity)
       capacity = memory_capacity;
   }

--- a/src/real_command_runner.cc
+++ b/src/real_command_runner.cc
@@ -74,17 +74,20 @@ size_t RealCommandRunner::CanRunMore() const {
       capacity = load_capacity;
   }
 
+  //this just pause the creation of new processes when we run out of ram
+  if (config_.desired_free_ram > 0) {
+    long memory_capacity = GetFreeMemory() / config_.desired_free_ram;
+    fprintf(stderr, "Mem cap=%ld\n", memory_capacity);
+    if (memory_capacity < capacity)
+      capacity = memory_capacity;
+  }
+
   if (capacity < 0)
     capacity = 0;
 
   if (capacity == 0 && subprocs_.running_.empty())
     // Ensure that we make progress.
     capacity = 1;
-
-  //this just pause the creation of new processes when we run out of ram, there is no way to estimate the number of process we can run.
-  if (config_.desired_free_ram > 0 && GetFreeMemory() < config_.desired_free_ram ) {
-    capacity = 0;
-  }
 
   return capacity;
 }

--- a/src/util.cc
+++ b/src/util.cc
@@ -1030,16 +1030,16 @@ int platformAwareUnlink(const char* filename) {
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 long GetFreeMemory() {
-    static long commited_idle = LONG_MAX;
+    static long committed_idle = LONG_MAX;
     MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
     GlobalMemoryStatusEx(&status);
-    const long commited = (status.ullTotalPageFile - status.ullAvailPageFile);
-    //since system use commited memory normaly, we store the smallest amount we have seen to guess how much
+    const long committed = (status.ullTotalPageFile - status.ullAvailPageFile);
+    //since system use committed memory normaly, we store the smallest amount we have seen to guess how much
     // paging is non-ninja related
-    commited_idle = std::min(commited_idle, commited);
+    committed_idle = std::min(committed_idle, committed);
 
-    return status.ullAvailPhys - (commited - commited_idle);
+    return status.ullAvailPhys - (committed - committed_idle);
 }
 #elif defined(__UCLIBC__) || defined (__GNUC__)
 long GetFreeMemory() {

--- a/src/util.cc
+++ b/src/util.cc
@@ -1026,3 +1026,23 @@ int platformAwareUnlink(const char* filename) {
 		return unlink(filename);
 	#endif
 }
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+double GetFreeMemory() {
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    GlobalMemoryStatusEx(&status);
+    return status.ullAvailPhys - (status.ullTotalPageFile - status.ullAvailPageFile);
+}
+#elif defined(__UCLIBC__) || defined (__GNUC__)
+double GetFreeMemory() {
+  struct sysinfo infos;
+  sysinfo(&infos);
+
+  return infos.freeram - (infos.totalswap - infos.freeswap);
+}
+#else
+double GetFreeMemory() {
+    return std::numeric_limits<double>::max();
+}
+#endif

--- a/src/util.cc
+++ b/src/util.cc
@@ -1041,7 +1041,7 @@ long GetFreeMemory() {
 
     return status.ullAvailPhys - (committed - committed_idle);
 }
-#elif defined(__UCLIBC__) || defined (__GNUC__)
+#elif !defined(__APPLE__) && ( defined(__UCLIBC__) || defined (__GNUC__) )
 long GetFreeMemory() {
   static long swapped_idle = LONG_MAX;
   struct sysinfo infos;

--- a/src/util.cc
+++ b/src/util.cc
@@ -41,6 +41,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <climits>
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/sysctl.h>
@@ -1028,7 +1029,7 @@ int platformAwareUnlink(const char* filename) {
 }
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-double GetFreeMemory() {
+long GetFreeMemory() {
     static long commited_idle = LONG_MAX;
     MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
@@ -1036,23 +1037,23 @@ double GetFreeMemory() {
     const long commited = (status.ullTotalPageFile - status.ullAvailPageFile);
     //since system use commited memory normaly, we store the smallest amount we have seen to guess how much
     // paging is non-ninja related
-    commited_idle = min(commited_idle, commited);
+    commited_idle = std::min(commited_idle, commited);
 
     return status.ullAvailPhys - (commited - commited_idle);
 }
 #elif defined(__UCLIBC__) || defined (__GNUC__)
-double GetFreeMemory() {
+long GetFreeMemory() {
   static long swapped_idle = LONG_MAX;
   struct sysinfo infos;
   sysinfo(&infos);
   const long swapped = (infos.totalswap - infos.freeswap);
   //since system use commited memory normaly, we store the smallest amount we have seen to guess how much
   // paging is non-ninja related
-  swapped_idle = min(swapped_idle, swapped);
+  swapped_idle = std::min(swapped_idle, swapped);
   return infos.freeram - (swapped - swapped_idle);
 }
 #else
-double GetFreeMemory() {
-    return std::numeric_limits<double>::max();
+long GetFreeMemory() {
+    return std::numeric_limits<long>::max();
 }
 #endif

--- a/src/util.cc
+++ b/src/util.cc
@@ -1032,7 +1032,10 @@ double GetFreeMemory() {
     MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
     GlobalMemoryStatusEx(&status);
-    return status.ullAvailPhys - (status.ullTotalPageFile - status.ullAvailPageFile);
+    //we can't measure the amount of process memory in the pagefile
+    //on my system the MEMORYSTATUSEX's paging info reports that im using 40GB or am at idle,
+    // so this is clearly not the information we want here
+    return status.ullAvailPhys;
 }
 #elif defined(__UCLIBC__) || defined (__GNUC__)
 double GetFreeMemory() {

--- a/src/util.h
+++ b/src/util.h
@@ -102,6 +102,11 @@ int GetProcessorCount();
 /// on error.
 double GetLoadAverage();
 
+//Swapped or Paged memory is very likely caused by the compiler process running out of ram,
+//as such we consider paged memory as used memory, therefore negative values are to be expected
+/// @return the Available memory on the machine. If no supported it will return std::numeric_limits<double>::max()
+double GetFreeMemory();
+
 /// a wrapper for getcwd()
 std::string GetWorkingDirectory();
 

--- a/src/util.h
+++ b/src/util.h
@@ -104,8 +104,8 @@ double GetLoadAverage();
 
 //Swapped memory is very likely caused by the compiler process running out of ram,
 //as such we consider swapped memory as used memory, therefore negative values are to be expected
-/// @return the Available memory on the machine. If no supported it will return std::numeric_limits<double>::max()
-double GetFreeMemory();
+/// @return the Available memory on the machine. If no supported it will return LONG_MAX
+long GetFreeMemory();
 
 /// a wrapper for getcwd()
 std::string GetWorkingDirectory();

--- a/src/util.h
+++ b/src/util.h
@@ -102,8 +102,8 @@ int GetProcessorCount();
 /// on error.
 double GetLoadAverage();
 
-//Swapped or Paged memory is very likely caused by the compiler process running out of ram,
-//as such we consider paged memory as used memory, therefore negative values are to be expected
+//Swapped memory is very likely caused by the compiler process running out of ram,
+//as such we consider swapped memory as used memory, therefore negative values are to be expected
 /// @return the Available memory on the machine. If no supported it will return std::numeric_limits<double>::max()
 double GetFreeMemory();
 


### PR DESCRIPTION
Inspired by https://github.com/ninja-build/ninja/issues/1571

this adds a new option: --keep-free-memory AMOUNT
and the amount can be specified with G/M/m/K/k/B units (defaulting to byte)

If the amount specified is greater than the available memory then we stop starting new build jobs.

Most importantly, this doesn't solve all memory issues you will need to swap if you don't put a great enough value, too big of a value will result in having very few core being used. This is purely here to stop the problem from getting worse and not fix it.