### PR TITLE
workflows - updates linux.yml so aarch64 builds use ubuntu-22.04-arm instead ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -171,7 +171,7 @@ jobs:
 
   build-aarch64:
     name: Build Linux ARM64
-    runs-on: [ubuntu-24.04-arm]
+    runs-on: [ubuntu-22.04-arm]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
fixes https://github.com/ninja-build/ninja/issues/2619 - link to glibc on Ubuntu Jammy so that released binaries work on a wider range glibc distros like Ubuntu Jammy.