### PR TITLE
prevent duplicate runs being triggered when a release tag is published via webui

### DIFF
--- a/.github/workflows/linux-musl.yml
+++ b/.github/workflows/linux-musl.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches: ['**']
+    tags-ignore: ['**']  # Don't trigger on tag pushes
   release:
     types: [published]
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,8 +3,10 @@ name: Linux
 on:
   pull_request:
   push:
+    branches: ['**']
+    tags-ignore: ['**']  # Don't trigger on tag pushes
   release:
-    types: published
+    types: [published]
 
 jobs:
   fedora:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,8 +3,10 @@ name: macOS
 on:
   pull_request:
   push:
+    branches: ['**']
+    tags-ignore: ['**']  # Don't trigger on tag pushes
   release:
-    types: published
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,8 +3,10 @@ name: Windows
 on:
   pull_request:
   push:
+    branches: ['**']
+    tags-ignore: ['**']  # Don't trigger on tag pushes
   release:
-    types: published
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
creating a release through the webui would trigger a non release run alongside the release run. It's not needed.

The release run fulfils alone is enough in this scenario.

before 

![image](https://github.com/user-attachments/assets/5ee91394-4f59-4130-9f36-5146b1b6025e)

after

![image](https://github.com/user-attachments/assets/f00d08a0-43da-4af9-b7a2-3c675829eb2f)
