### PR TITLE
replace archived in 2021 release action for currently maintained one

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,10 +58,9 @@ jobs:
           ignore_words_list: fo,wee,addin,notin
       - name: Install dependencies
         run: |
-          dnf update -y
-          dnf install -y dnf-plugins-core epel-release
+          dnf install -y make gcc-c++ libasan clang-analyzer cmake dnf-plugins-core epel-release
           dnf config-manager --set-enabled powertools
-          dnf install -y clang-analyzer cmake gcc-c++ gtest-devel libasan make ninja-build p7zip p7zip-plugins re2c
+          dnf install -y gtest-devel p7zip p7zip-plugins ninja-build
 
       - name: Build debug ninja
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,9 +58,10 @@ jobs:
           ignore_words_list: fo,wee,addin,notin
       - name: Install dependencies
         run: |
-          dnf install -y make gcc-c++ libasan clang-analyzer cmake dnf-plugins-core epel-release
+          dnf update -y
+          dnf install -y dnf-plugins-core epel-release
           dnf config-manager --set-enabled powertools
-          dnf install -y gtest-devel p7zip p7zip-plugins ninja-build
+          dnf install -y clang-analyzer cmake gcc-c++ gtest-devel libasan make ninja-build p7zip p7zip-plugins re2c
 
       - name: Build debug ninja
         env:
@@ -98,14 +99,13 @@ jobs:
 
       - name: Upload release asset
         if: github.event.action == 'published'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./artifact/ninja-linux${{ matrix.arch }}.zip
-          asset_name: ninja-linux${{ matrix.arch }}.zip
-          asset_content_type: application/zip
+          allowUpdates: true # if release exists it will edit it.
+          artifactContentType: "application/zip" # if empty defaults to raw
+          replacesArtifacts: true # will update existing release assets if needed.
+          omitBodyDuringUpdate: true # don't edit release body when published via webui
+          artifacts: ./artifact/ninja-linux${{ matrix.arch }}.zip # release asset
 
   test:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,11 +43,10 @@ jobs:
 
     - name: Upload release asset
       if: github.event.action == 'published'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: ncipollo/release-action@v1
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./artifact/ninja-mac.zip
-        asset_name: ninja-mac.zip
-        asset_content_type: application/zip
+        allowUpdates: true # if release exists it will edit it.
+        artifactContentType: "application/zip" # if empty defaults to raw
+        replacesArtifacts: true # will update existing release assets if needed.
+        omitBodyDuringUpdate: true # don't edit release body when published via webui
+        artifacts: ./artifact/ninja-mac.zip # release asset

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,11 +57,10 @@ jobs:
 
     - name: Upload release asset
       if: github.event.action == 'published'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: ncipollo/release-action@v1
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./artifact/ninja-win${{ matrix.suffix }}.zip
-        asset_name: ninja-win${{ matrix.suffix }}.zip
-        asset_content_type: application/zip
+        allowUpdates: true # if release exists it will edit it.
+        artifactContentType: "application/zip" # if empty defaults to raw
+        replacesArtifacts: true # will update existing release assets if needed.
+        omitBodyDuringUpdate: true # don't edit release body when published via webui
+        artifacts: ./artifact/ninja-win${{ matrix.suffix }}.zip # release asset


### PR DESCRIPTION
actions/upload-release-asset is archived in 2021 but ncipollo/release-action is actively maintained a suitable drop in replacement with feature parity.

It can also be adapted to work the same when triggering aa release via a pushed  tag, should the need arise.

linux.yml only - tidied up dependency install commands.

note: As I understand the release process it goes:
- you create the release via the webui, 
- you create the tag select which branch, 
- create the body and add the changelog link
- you publish the release
- it triggers the workflows to build and upload the assets.

Here is a demonstration to show it should mimic that process.

https://github.com/userdocs/ninja/releases/tag/v1.13.19
