### PR TITLE
linux.yml - build-with-python - add matrix to job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -157,19 +157,27 @@ jobs:
         working-directory: build-clang/Release
 
   build-with-python:
-    runs-on: [ubuntu-latest]
-    container:
-      image: ${{ matrix.image }}
+    permissions: # https://docs.zizmor.sh/audits/#excessive-permissions
+      contents: read
     strategy:
       matrix:
-        image: ["ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04"]
+        host-os: ["ubuntu-latest", "ubuntu-24.04-arm"]
+        image: ["ubuntu:22.04", "ubuntu:24.04"]
+      fail-fast: false
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.host-os }}
+    container: ${{ matrix.image }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false #https://docs.zizmor.sh/audits/#artipacked
       - name: Install dependencies
         run: |
           apt update
           apt install -y g++ python3
-      - name: ${{ matrix.image }}
+      - name: ${{ matrix.host-os }} ${{ matrix.image }}
         run: |
           # Do not set --warnings-as-errors here as that triggers an irrelevant
           # compiler warnings in <stdio.h> with ubuntu:24.04. See issue #2615


### PR DESCRIPTION
add matrix to this job to test on amd64/arm64 on jammy and noble LTS releases instead of only amd64 focal which is EOL.

Applied two zizmor audits commented in the changes.