### PR TITLE
Update CMakeLists.txt to use C++14 too.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,8 +191,8 @@ else()
 	endif()
 endif()
 
-target_compile_features(libninja PUBLIC cxx_std_11)
-target_compile_features(libninja-re2c PUBLIC cxx_std_11)
+target_compile_features(libninja PUBLIC cxx_std_14)
+target_compile_features(libninja-re2c PUBLIC cxx_std_14)
 
 #Fixes GetActiveProcessorCount on MinGW
 if(MINGW)


### PR DESCRIPTION
In PR #2560, configure.py was changed to force -std=c++14, but this was not done in the corresponding CMakeLists.txt, which still compiled Ninja for C++11.

This PR simply fixes the situation.