### PR TITLE
Convert \n to \r\n on Windows in rsp files, fix #2616

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -840,7 +840,7 @@ bool Builder::StartEdge(Edge* edge, string* err) {
     if (!disk_interface_->MakeDirs((*o)->path()))
       return false;
     if (build_start == -1) {
-      disk_interface_->WriteFile(lock_file_path_, "");
+      disk_interface_->WriteFile(lock_file_path_, "", false);
       build_start = disk_interface_->Stat(lock_file_path_, err);
       if (build_start == -1)
         build_start = 0;
@@ -860,7 +860,7 @@ bool Builder::StartEdge(Edge* edge, string* err) {
   string rspfile = edge->GetUnescapedRspfile();
   if (!rspfile.empty()) {
     string content = edge->GetBinding("rspfile_content");
-    if (!disk_interface_->WriteFile(rspfile, content))
+    if (!disk_interface_->WriteFile(rspfile, content, true))
       return false;
   }
 

--- a/src/build_log_test.cc
+++ b/src/build_log_test.cc
@@ -227,23 +227,24 @@ TEST_F(BuildLogTest, DuplicateVersionHeader) {
 }
 
 struct TestDiskInterface : public DiskInterface {
-  virtual TimeStamp Stat(const std::string& path, std::string* err) const {
+  TimeStamp Stat(const std::string& path, std::string* err) const override {
     return 4;
   }
-  virtual bool WriteFile(const std::string& path, const std::string& contents) {
+  bool WriteFile(const std::string& path, const std::string& contents,
+                 bool crlf_on_windows) override {
     assert(false);
     return true;
   }
-  virtual bool MakeDir(const std::string& path) {
+  bool MakeDir(const std::string& path) override {
     assert(false);
     return false;
   }
-  virtual Status ReadFile(const std::string& path, std::string* contents,
-                          std::string* err) {
+  Status ReadFile(const std::string& path, std::string* contents,
+                  std::string* err) override {
     assert(false);
     return NotFound;
   }
-  virtual int RemoveFile(const std::string& path) {
+  int RemoveFile(const std::string& path) override {
     assert(false);
     return 0;
   }

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -660,7 +660,7 @@ bool FakeCommandRunner::StartCommand(Edge* edge) {
     string err;
     if (fs_->ReadFile(edge->inputs_[0]->path(), &content, &err) ==
         DiskInterface::Okay)
-      fs_->WriteFile(edge->outputs_[0]->path(), content);
+      fs_->WriteFile(edge->outputs_[0]->path(), content, false);
   } else if (edge->rule().name() == "touch-implicit-dep-out") {
     string dep = edge->GetBinding("test_dependency");
     fs_->Tick();

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -610,7 +610,7 @@ TEST_F(DepsLogTest, MalformedDepsLog) {
   auto write_bad_log_file =
       [&disk, &kBadLogFile](const std::string& bad_contents) -> bool {
     (void)disk.RemoveFile(kBadLogFile);
-    return disk.WriteFile(kBadLogFile, bad_contents);
+    return disk.WriteFile(kBadLogFile, bad_contents, false);
   };
 
   // First, corrupt the header.

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -245,8 +245,15 @@ TimeStamp RealDiskInterface::Stat(const string& path, string* err) const {
 #endif
 }
 
-bool RealDiskInterface::WriteFile(const string& path, const string& contents) {
-  FILE* fp = fopen(path.c_str(), "wb");
+bool RealDiskInterface::WriteFile(const string& path, const string& contents,
+                                  bool crlf_on_windows) {
+  FILE* fp = fopen(path.c_str(),
+#ifdef _WIN32
+                   crlf_on_windows ? "w" : "wb");
+#else
+                   "wb");
+  (void)crlf_on_windows;
+#endif
   if (fp == NULL) {
     Error("WriteFile(%s): Unable to create file. %s",
           path.c_str(), strerror(errno));

--- a/src/disk_interface.h
+++ b/src/disk_interface.h
@@ -51,9 +51,11 @@ struct DiskInterface: public FileReader {
   virtual bool MakeDir(const std::string& path) = 0;
 
   /// Create a file, with the specified name and contents
+  /// If \a crlf_on_windows is true, \n will be converted to \r\n (only on
+  /// Windows builds of Ninja).
   /// Returns true on success, false on failure
-  virtual bool WriteFile(const std::string& path,
-                         const std::string& contents) = 0;
+  virtual bool WriteFile(const std::string& path, const std::string& contents,
+                         bool crlf_on_windows) = 0;
 
   /// Remove the file named @a path. It behaves like 'rm -f path' so no errors
   /// are reported if it does not exists.
@@ -71,12 +73,13 @@ struct DiskInterface: public FileReader {
 struct RealDiskInterface : public DiskInterface {
   RealDiskInterface();
   virtual ~RealDiskInterface() {}
-  virtual TimeStamp Stat(const std::string& path, std::string* err) const;
-  virtual bool MakeDir(const std::string& path);
-  virtual bool WriteFile(const std::string& path, const std::string& contents);
-  virtual Status ReadFile(const std::string& path, std::string* contents,
-                          std::string* err);
-  virtual int RemoveFile(const std::string& path);
+  TimeStamp Stat(const std::string& path, std::string* err) const override;
+  bool MakeDir(const std::string& path) override;
+  bool WriteFile(const std::string& path, const std::string& contents,
+                 bool crlf_on_windows) override;
+  Status ReadFile(const std::string& path, std::string* contents,
+                  std::string* err) override;
+  int RemoveFile(const std::string& path) override;
 
   /// Whether stat information can be cached.  Only has an effect on Windows.
   void AllowStatCache(bool allow);

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -262,20 +262,21 @@ struct StatTest : public StateTestWithBuiltinRules,
   StatTest() : scan_(&state_, NULL, NULL, this, NULL, NULL) {}
 
   // DiskInterface implementation.
-  virtual TimeStamp Stat(const string& path, string* err) const;
-  virtual bool WriteFile(const string& path, const string& contents) {
+  TimeStamp Stat(const string& path, string* err) const override;
+  bool WriteFile(const string& path, const string& contents,
+                 bool /*crlf_on_windows*/) override {
     assert(false);
     return true;
   }
-  virtual bool MakeDir(const string& path) {
+  bool MakeDir(const string& path) override {
     assert(false);
     return false;
   }
-  virtual Status ReadFile(const string& path, string* contents, string* err) {
+  Status ReadFile(const string& path, string* contents, string* err) override {
     assert(false);
     return NotFound;
   }
-  virtual int RemoveFile(const string& path) {
+  int RemoveFile(const string& path) override {
     assert(false);
     return 0;
   }

--- a/src/test.cc
+++ b/src/test.cc
@@ -158,7 +158,8 @@ TimeStamp VirtualFileSystem::Stat(const string& path, string* err) const {
   return 0;
 }
 
-bool VirtualFileSystem::WriteFile(const string& path, const string& contents) {
+bool VirtualFileSystem::WriteFile(const string& path, const string& contents,
+                                  bool /*crlf_on_windows*/) {
   Create(path, contents);
   return true;
 }

--- a/src/test.h
+++ b/src/test.h
@@ -61,12 +61,13 @@ struct VirtualFileSystem : public DiskInterface {
   }
 
   // DiskInterface
-  virtual TimeStamp Stat(const std::string& path, std::string* err) const;
-  virtual bool WriteFile(const std::string& path, const std::string& contents);
-  virtual bool MakeDir(const std::string& path);
-  virtual Status ReadFile(const std::string& path, std::string* contents,
-                          std::string* err);
-  virtual int RemoveFile(const std::string& path);
+  TimeStamp Stat(const std::string& path, std::string* err) const override;
+  bool WriteFile(const std::string& path, const std::string& contents,
+                 bool /*crlf_on_windows*/) override;
+  bool MakeDir(const std::string& path) override;
+  Status ReadFile(const std::string& path, std::string* contents,
+                  std::string* err) override;
+  int RemoveFile(const std::string& path) override;
 
   /// An entry for a single in-memory file.
   struct Entry {


### PR DESCRIPTION
Other files written will still use "wb" as introduced in 46f272d.