### PR TITLE
Do not treat dummy targets as missing dependencies.

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -282,7 +282,7 @@ bool DependencyScan::RecomputeOutputDirty(const Edge* edge,
   if (edge->is_phony()) {
     // Phony edges don't write any output.  Outputs are only dirty if
     // there are no inputs and we're missing the output.
-    if (edge->inputs_.empty() && !output->exists()) {
+    if (edge->has_dummy_outputs() && !output->exists()) {
       explanations_.Record(
           output, "output %s of phony edge with no inputs doesn't exist",
           output->path().c_str());

--- a/src/graph.h
+++ b/src/graph.h
@@ -264,6 +264,11 @@ struct Edge {
   bool use_console() const;
   bool maybe_phonycycle_diagnostic() const;
 
+  /// Return true if this edge is phony and has no inputs, its outputs
+  /// are treated specially by Ninja: when they do not exist, they are
+  /// considered out-of-date instead of missing.
+  bool has_dummy_outputs() const { return is_phony() && inputs_.empty(); }
+
   /// A Jobserver slot instance. Invalid by default.
   Jobserver::Slot job_slot_;
 

--- a/src/missing_deps_test.cc
+++ b/src/missing_deps_test.cc
@@ -117,6 +117,17 @@ TEST_F(MissingDependencyScannerTest, MissingDepPresent) {
                                  &generator_rule_);
 }
 
+TEST_F(MissingDependencyScannerTest, MissingDepDummyTarget) {
+  CreateInitialState();
+  Edge* phony_edge = state_.AddEdge(state_.bindings_.LookupRule("phony"));
+  state_.AddOut(phony_edge, "dummy_output", 0, nullptr);
+  // compiled_object depends on dummy_output, which does not exist
+  // but will not be reported as a missing dependency.
+  RecordDepsLogDep("compiled_object", "dummy_output");
+  ProcessAllNodes();
+  ASSERT_FALSE(scanner().HadMissingDeps());
+}
+
 TEST_F(MissingDependencyScannerTest, MissingDepFixedDirect) {
   CreateInitialState();
   // Adding the direct dependency fixes the missing dep


### PR DESCRIPTION
Dummy targets are outputs of phony edges that have no inputs. They are treated specially by Ninja at build time: if they do not exist, they are simply considered out-of-date, instead of a missing-input error.

This fixes issue #2454, where the `missingdeps` tool, did not treat dummy targets properly,
always reporting them as missing.

- Add Edge::has_dummy_outputs() method and use it in DependencyScan::RecomputeOutputsDirty() for clarity.
- Modify MissingDependencyScanner::ProcessNodeDeps() to ignore edges with dummy outputs.
- Add a corresponding unit-test.