### PR TITLE
feat: `zero` deps format

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -786,7 +786,7 @@ Ninja 1.3 can instead process dependencies just after they're generated
 and save a compacted form of the same information in a Ninja-internal
 database.
 
-Ninja supports this processing in two forms.
+Ninja supports this processing in three forms.
 
 1. `deps = gcc` specifies that the tool outputs `gcc`-style dependencies
    in the form of Makefiles.  Adding this to the above example will
@@ -810,6 +810,11 @@ rule cc
   deps = msvc
   command = cl /showIncludes -c $in /Fo$out
 ----
+
+3. `deps = zero` specifies that the tool outputs the dependencies as a list of
+   NUL-terminated paths, like what `find . -print0` would produce.
+   Although this format is not used by any known C/C++ compilers, it is
+   the easiest to produce from a script, so it works in ad hoc scenarios.
 
 If the include directory directives are using absolute paths, your depfile
 may result in a mixture of relative and absolute paths. Paths used by other

--- a/src/build.cc
+++ b/src/build.cc
@@ -1024,10 +1024,10 @@ bool Builder::ExtractDeps(BuildResult::CommandCompleted& result,
       // complexity in IncludesNormalize::Relativize.
       deps_nodes->push_back(state_->GetNode(*i, ~0u));
     }
-  } else if (deps_type == "gcc") {
+  } else if (deps_type == "gcc" || deps_type == "zero") {
     string depfile = result.edge->GetUnescapedDepfile();
     if (depfile.empty()) {
-      *err = string("edge with deps=gcc but no depfile makes no sense");
+      *err = string("edge with deps=") + deps_type + string(" but no depfile makes no sense");
       return false;
     }
 
@@ -1045,17 +1045,30 @@ bool Builder::ExtractDeps(BuildResult::CommandCompleted& result,
     if (content.empty())
       return true;
 
-    DepfileParser deps(config_.depfile_parser_options);
-    if (!deps.Parse(&content, err))
-      return false;
+    if (deps_type == "gcc") {
+      DepfileParser deps(config_.depfile_parser_options);
+      if (!deps.Parse(&content, err))
+        return false;
 
-    // XXX check depfile matches expected output.
-    deps_nodes->reserve(deps.ins_.size());
-    for (vector<StringPiece>::iterator i = deps.ins_.begin();
-         i != deps.ins_.end(); ++i) {
-      uint64_t slash_bits;
-      CanonicalizePath(const_cast<char*>(i->str_), &i->len_, &slash_bits);
-      deps_nodes->push_back(state_->GetNode(*i, slash_bits));
+      // XXX check depfile matches expected output.
+      deps_nodes->reserve(deps.ins_.size());
+      for (vector<StringPiece>::iterator i = deps.ins_.begin();
+           i != deps.ins_.end(); ++i) {
+        uint64_t slash_bits;
+        CanonicalizePath(const_cast<char*>(i->str_), &i->len_, &slash_bits);
+        deps_nodes->push_back(state_->GetNode(*i, slash_bits));
+      }
+    } else {
+      const char* ptr = content.c_str();
+      const char* const end = &content.back() + 1;
+      while (ptr < end) {
+        StringPiece piece = ptr;
+        // ptr is advanced first, because `piece.len_` is modified by `CanonicalizePath`
+        ptr += piece.size() + 1;
+        uint64_t slash_bits;
+        CanonicalizePath(const_cast<char*>(piece.str_), &piece.len_, &slash_bits);
+        deps_nodes->push_back(state_->GetNode(piece, slash_bits));
+      }
     }
 
     if (!g_keep_depfile) {

--- a/src/build.cc
+++ b/src/build.cc
@@ -1024,10 +1024,10 @@ bool Builder::ExtractDeps(BuildResult::CommandCompleted& result,
       // complexity in IncludesNormalize::Relativize.
       deps_nodes->push_back(state_->GetNode(*i, ~0u));
     }
-  } else if (deps_type == "gcc") {
+  } else if (deps_type == "gcc" || deps_type == "zero") {
     string depfile = result.edge->GetUnescapedDepfile();
     if (depfile.empty()) {
-      *err = string("edge with deps=gcc but no depfile makes no sense");
+      *err = string("edge with deps=") + deps_type + string(" but no depfile makes no sense");
       return false;
     }
 
@@ -1045,17 +1045,31 @@ bool Builder::ExtractDeps(BuildResult::CommandCompleted& result,
     if (content.empty())
       return true;
 
-    DepfileParser deps(config_.depfile_parser_options);
-    if (!deps.Parse(&content, err))
-      return false;
+    if (deps_type == "gcc") {
+      DepfileParser deps(config_.depfile_parser_options);
+      if (!deps.Parse(&content, err))
+        return false;
 
-    // XXX check depfile matches expected output.
-    deps_nodes->reserve(deps.ins_.size());
-    for (vector<StringPiece>::iterator i = deps.ins_.begin();
-         i != deps.ins_.end(); ++i) {
-      uint64_t slash_bits;
-      CanonicalizePath(const_cast<char*>(i->str_), &i->len_, &slash_bits);
-      deps_nodes->push_back(state_->GetNode(*i, slash_bits));
+      // XXX check depfile matches expected output.
+      deps_nodes->reserve(deps.ins_.size());
+      for (vector<StringPiece>::iterator i = deps.ins_.begin();
+           i != deps.ins_.end(); ++i) {
+        uint64_t slash_bits;
+        CanonicalizePath(const_cast<char*>(i->str_), &i->len_, &slash_bits);
+        deps_nodes->push_back(state_->GetNode(*i, slash_bits));
+      }
+    } else {
+      /* deps_type == "zero" */
+      const char* ptr = content.c_str();
+      const char* const end = &content.back() + 1;
+      while (ptr < end) {
+        StringPiece piece = ptr;
+        // ptr is advanced first, because `piece.len_` is modified by `CanonicalizePath`
+        ptr += piece.size() + 1;
+        uint64_t slash_bits;
+        CanonicalizePath(const_cast<char*>(piece.str_), &piece.len_, &slash_bits);
+        deps_nodes->push_back(state_->GetNode(piece, slash_bits));
+      }
     }
 
     if (!g_keep_depfile) {

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -654,6 +654,8 @@ bool FakeCommandRunner::StartCommand(Edge* edge) {
       edge->rule().name() == "cp_multi_msvc" ||
       edge->rule().name() == "cp_multi_gcc" ||
       edge->rule().name() == "cp_other" ||
+      edge->rule().name() == "cp_multi_zero" ||
+      edge->rule().name() == "cp_multi_zero_del" ||
       edge->rule().name() == "touch" ||
       edge->rule().name() == "touch-interrupt" ||
       edge->rule().name() == "touch-fail-tick2") {
@@ -2550,6 +2552,79 @@ TEST_F(BuildWithQueryDepsLogTest, TwoOutputsDepFileGCCOnlySecondaryOutput) {
   EXPECT_EQ("", err);
   ASSERT_EQ(1u, command_runner_.commands_ran_.size());
   EXPECT_EQ("echo 'out2: in1 in2' > in.d && for file in out1 out2; do cp in1 $file; done", command_runner_.commands_ran_[0]);
+
+  Node* out1_node = state_.LookupNode("out1");
+  DepsLog::Deps* out1_deps = log_.GetDeps(out1_node);
+  EXPECT_EQ(2, out1_deps->node_count);
+  EXPECT_EQ("in1", out1_deps->nodes[0]->path());
+  EXPECT_EQ("in2", out1_deps->nodes[1]->path());
+
+  Node* out2_node = state_.LookupNode("out2");
+  DepsLog::Deps* out2_deps = log_.GetDeps(out2_node);
+  EXPECT_EQ(2, out2_deps->node_count);
+  EXPECT_EQ("in1", out2_deps->nodes[0]->path());
+  EXPECT_EQ("in2", out2_deps->nodes[1]->path());
+}
+
+/// Test nul-separated deps log with multiple outputs.
+TEST_F(BuildWithQueryDepsLogTest, TwoOutputsDepFileZero) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule cp_multi_zero\n"
+"    command = printf 'in1\\0in2\\0' > in.d && for file in $out; do cp in1 $$file; done\n"
+"    deps = zero\n"
+"    depfile = in.d\n"
+"build out1 out2: cp_multi_zero in1 in2\n"));
+
+  std::string err;
+  EXPECT_TRUE(builder_.AddTarget("out1", &err));
+  ASSERT_EQ("", err);
+
+  std::string cont = "in1";
+  cont.push_back('\0');
+  cont.append("in2");
+  cont.push_back('\0');
+
+  fs_.Create("in.d", cont);
+  EXPECT_EQ(builder_.Build(&err), ExitSuccess);
+  EXPECT_EQ("", err);
+  ASSERT_EQ(1u, command_runner_.commands_ran_.size());
+  EXPECT_EQ("printf 'in1\\0in2\\0' > in.d && for file in out1 out2; do cp in1 $file; done", command_runner_.commands_ran_[0]);
+
+  Node* out1_node = state_.LookupNode("out1");
+  DepsLog::Deps* out1_deps = log_.GetDeps(out1_node);
+  EXPECT_EQ(2, out1_deps->node_count);
+  EXPECT_EQ("in1", out1_deps->nodes[0]->path());
+  EXPECT_EQ("in2", out1_deps->nodes[1]->path());
+
+  Node* out2_node = state_.LookupNode("out2");
+  DepsLog::Deps* out2_deps = log_.GetDeps(out2_node);
+  EXPECT_EQ(2, out2_deps->node_count);
+  EXPECT_EQ("in1", out2_deps->nodes[0]->path());
+  EXPECT_EQ("in2", out2_deps->nodes[1]->path());
+}
+
+/// Test nul-separated deps log with multiple outputs and no trailing nul.
+TEST_F(BuildWithQueryDepsLogTest, TwoOutputsDepFileZeroDel) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule cp_multi_zero_del\n"
+"    command = printf 'in1\\0in2' > in.d && for file in $out; do cp in1 $$file; done\n"
+"    deps = zero\n"
+"    depfile = in.d\n"
+"build out1 out2: cp_multi_zero_del in1 in2\n"));
+
+  std::string err;
+  EXPECT_TRUE(builder_.AddTarget("out1", &err));
+  ASSERT_EQ("", err);
+
+  std::string cont = "in1";
+  cont.push_back('\0');
+  cont.append("in2");
+
+  fs_.Create("in.d", cont);
+  EXPECT_EQ(builder_.Build(&err), ExitSuccess);
+  EXPECT_EQ("", err);
+  ASSERT_EQ(1u, command_runner_.commands_ran_.size());
+  EXPECT_EQ("printf 'in1\\0in2' > in.d && for file in out1 out2; do cp in1 $file; done", command_runner_.commands_ran_[0]);
 
   Node* out1_node = state_.LookupNode("out1");
   DepsLog::Deps* out1_deps = log_.GetDeps(out1_node);


### PR DESCRIPTION
This patch adds support for NUL-delimited dependency files, which is quite a simple format avoiding all the issues possible with `gcc`/`msvc` formats. It requires almost no parsing: just read NUL-terminated strings until the file is empty. Because of this, it doesn't depend on file paths being "nice" in any way and doesn't require any escaping for special characters like `$` or `\`. It is quite common in shell tooling, like `find -print0`, `xargs -0` and others.
GCC format, which should more accurately be described as "GCC version of Makefile subset", is quite problematic: #2599, #2590, #2568, #2357, #1856, #1825, #1774, #1542, #1227 and probably more. Compared to this, the only possible issue with the proposed format is lack of a NUL after the last entry, which I handled by adding a NUL if the file doesn't end in one.
The parser itself is implemented in 8 logical lines of code, compared to hundreds of lines MSVC and GCC need. Because of this simplicity, any project can easily implement a reader or a writer without any shortcomings. GCC format is impossible to get right, as even GCC itself was unable to do so (quoted from `libcpp/mkdeps.cc` from GCC 14.3.0):
```cpp
/* Apply Make quoting to STR, TRAIL.  Note that it's not possible to
   quote all such characters - e.g. \n, %, *, ?, [, \ (in some
   contexts), and ~ are not properly handled.  It isn't possible to
   get this right in any current version of Make.  (??? Still true?
   Old comment referred to 3.76.1.)  */
```
Typst contains a similar remark: https://github.com/typst/typst/blob/880e69b0c840cd0d2f0c51e72966ab72c008e713/crates/typst-cli/src/compile.rs#L524-L525
That led me to creating ~~typst/typst#6648~~ typst/typst#7022, adding NUL-delimited format, and that in turn led me here.

Note that the proposed format has no "official" standard, RFC or otherwise. Due to its simplicity, though, there are only two flavors: either you terminate your fail with a NUL (e.g. `foo␀bar␀baz␀`) or you don't (e.g. `foo␀bar␀baz`). The former is usually easier to implement due to being more consistent, and this situation is similar to how some old tools require that a text file ends with an LF and some don't. To be honest, I haven't seen any tools that omit the trailing NUL, but they might still exist. Anyway, the implementation here supports both "flavors" without any compatibility cost.