### PR TITLE
Fix MacOS github builds.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: brew install re2c p7zip cmake
+      run: brew install re2c
 
     - name: Build ninja
       shell: bash


### PR DESCRIPTION
MacOS builds are now failing at the "Install dependencies" step because Homebrew is now complaining that cmake is already installed on the system. It also warns about p7zip, so remove them both from the list of installed packages to resolve the problem.

The macos.yml workflow file uses the macos-13 image that was updated recently. The latest succesful MacOS action on
https://github.com/ninja-build/ninja [1] used release 20250818.1405, while the failing ones are using release 20250901.1455 [2].

From the corresponding image release pages, it seems that Homebrew was updated from 4.5.13 to 4.6.7 between the two, so assuming here this is why this started to happen.

[1] https://github.com/ninja-build/ninja/actions/runs/17216151150/job/48840158004#step:1:15
[2] https://github.com/ninja-build/ninja/actions/runs/17460573439/job/49584121159#step:1:15