### PR TITLE
Print an entry in the compilation database for each input file

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -513,8 +513,20 @@ options:
   }},
   {{
     "directory": "{b.path}",
+    "command": "cat in2 out1 out2",
+    "file": "out1",
+    "output": "out2"
+  }},
+  {{
+    "directory": "{b.path}",
     "command": "cat out2 out1 out3",
     "file": "out2",
+    "output": "out3"
+  }},
+  {{
+    "directory": "{b.path}",
+    "command": "cat out2 out1 out3",
+    "file": "out1",
     "output": "out3"
   }}
 ]

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1011,17 +1011,27 @@ std::string EvaluateCommandWithRspfile(const Edge* edge,
   return command;
 }
 
-void PrintOneCompdbObject(std::string const& directory, const Edge* const edge,
-                          const EvaluateCommandMode eval_mode) {
-  printf("\n  {\n    \"directory\": \"");
-  PrintJSONString(directory);
-  printf("\",\n    \"command\": \"");
-  PrintJSONString(EvaluateCommandWithRspfile(edge, eval_mode));
-  printf("\",\n    \"file\": \"");
-  PrintJSONString(edge->inputs_[0]->path());
-  printf("\",\n    \"output\": \"");
-  PrintJSONString(edge->outputs_[0]->path());
-  printf("\"\n  }");
+void PrintCompdbObjectsForEdge(std::string const& directory, const Edge* const edge,
+                               const EvaluateCommandMode eval_mode) {
+  const auto& command = EvaluateCommandWithRspfile(edge, eval_mode);
+  bool first = true;
+
+  for (const Node* input : edge->inputs_) {
+    if (!first) {
+      putchar(',');
+    }
+
+    printf("\n  {\n    \"directory\": \"");
+    PrintJSONString(directory);
+    printf("\",\n    \"command\": \"");
+    PrintJSONString(command);
+    printf("\",\n    \"file\": \"");
+    PrintJSONString(input->path());
+    printf("\",\n    \"output\": \"");
+    PrintJSONString(edge->outputs_[0]->path());
+    printf("\"\n  }");
+    first = false;
+  }
 }
 
 int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
@@ -1066,7 +1076,7 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
       if (!first) {
         putchar(',');
       }
-      PrintOneCompdbObject(directory, edge, eval_mode);
+      PrintCompdbObjectsForEdge(directory, edge, eval_mode);
       first = false;
     } else {
       for (int i = 0; i != argc; ++i) {
@@ -1074,7 +1084,7 @@ int NinjaMain::ToolCompilationDatabase(const Options* options, int argc,
           if (!first) {
             putchar(',');
           }
-          PrintOneCompdbObject(directory, edge, eval_mode);
+          PrintCompdbObjectsForEdge(directory, edge, eval_mode);
           first = false;
         }
       }
@@ -1217,7 +1227,7 @@ void PrintCompdb(std::string const& directory, std::vector<Edge*> const& edges,
       continue;
     if (!first)
       putchar(',');
-    PrintOneCompdbObject(directory, edge, eval_mode);
+    PrintCompdbObjectsForEdge(directory, edge, eval_mode);
     first = false;
   }
 


### PR DESCRIPTION
Targets which use multiple input files only have their first input file show up in the compilation database. This can cause issues with tools that build a list of files to inspect from the compilation database. For example, when using the Swift programming language together with the SourceKit-LSP language server, only one source file from each Swift module gets processed correctly by the language server using the current compilation database output from Ninja, because Swift modules are compiled with one compiler invocation and therefore one Ninja target for the whole module.

This changes the compilation database formatter to emit one entry for each input file of a target instead of just the first input file, which makes tools able to pick up all the input files used in the build.

Fixes #1590.
See also https://github.com/mesonbuild/meson/pull/14264.