### PR TITLE
This commit will fix issue#2653.

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -4405,3 +4405,109 @@ TEST_F(BuildTest, ValidationWithCircularDependency) {
   EXPECT_FALSE(builder_.AddTarget("out", &err));
   EXPECT_EQ("dependency cycle: validate -> validate_in -> validate", err);
 }
+
+// Test case: Late dyndep merges two initially separate dependency graphs into a
+// single unified graph. This verifies 'dirty propagation' once a dyndep file
+// introduces a new dependency edge at build time.
+// https://github.com/ninja-build/ninja/issues/2653
+TEST_F(BuildTest, LateDynDepPropagateDirty) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_, R"ninja(
+rule mkdyn
+  command = printf 'ninja_dyndep_version = 1\nbuild  a3 | input_b: dyndep |\n' > dd
+
+rule cp
+  command = cp $in $out
+
+rule cc
+  command = cp $in $out && touch input_b
+
+build dd: mkdyn
+
+build b1: cp input_b
+build b2: cp b1
+build b3: cp b2
+build b4: cp b3
+build b5: cp b4
+
+build a1: cp input_a
+build a2: cp a1
+build a3: cc a2 || dd
+  dyndep = dd
+build a4: cp a3
+build a5: cp a4
+)ninja"));
+
+  fs_.Create("input_b", "");
+  fs_.Create("b1", "");
+  fs_.Create("b2", "");
+  fs_.Create("b3", "");
+  fs_.Create("b4", "");
+  fs_.Create("b5", "");
+
+  fs_.Create("input_a", "");
+  fs_.Create("a1", "");
+  fs_.Create("a2", "");
+  fs_.Create("a3", "");
+  fs_.Create("a4", "");
+  fs_.Create("a5", "");
+  fs_.Create("dd",
+             "ninja_dyndep_version = 1\n"
+             "build  a3 | input_b: dyndep |\n");
+
+  string err;
+
+  fs_.Tick();
+  fs_.Create("input_a", "");
+
+  command_runner_.commands_ran_.clear();
+  state_.Reset();
+
+  EXPECT_TRUE(builder_.AddTarget("b5", &err));
+  EXPECT_EQ("", err);
+  err.clear();
+  EXPECT_TRUE(builder_.AddTarget("a5", &err));
+  EXPECT_EQ("", err);
+  err.clear();
+
+  EXPECT_TRUE(GetNode("a5")->dirty());
+  // After loading dyndep, dirty propagation should mark the entire B chain dirty.
+  EXPECT_TRUE(GetNode("b5")->dirty());
+  EXPECT_TRUE(GetNode("b4")->dirty());
+  EXPECT_TRUE(GetNode("b3")->dirty());
+  EXPECT_TRUE(GetNode("b2")->dirty());
+  EXPECT_TRUE(GetNode("b1")->dirty());
+
+  EXPECT_EQ(builder_.Build(&err), ExitSuccess);
+  EXPECT_EQ("", err);
+
+  EXPECT_EQ(10u, command_runner_.commands_ran_.size());
+
+  // Second scenario: test top‑level node detection in PropagateDirty.
+  // Now we only request b4 (not b5).
+  // This checks that PropagateDirty correctly identifies top‑level nodes
+  // even when they still have dependent edges.
+  command_runner_.commands_ran_.clear();
+  state_.Reset();
+
+  fs_.Tick();
+  fs_.Create("input_a", "");
+
+  EXPECT_TRUE(builder_.AddTarget("b4", &err));
+  EXPECT_EQ("", err);
+  err.clear();
+  EXPECT_TRUE(builder_.AddTarget("a5", &err));
+  EXPECT_EQ("", err);
+  err.clear();
+
+  EXPECT_TRUE(GetNode("a5")->dirty());
+  EXPECT_FALSE(GetNode("b5")->dirty());
+  EXPECT_TRUE(GetNode("b4")->dirty());
+  EXPECT_TRUE(GetNode("b3")->dirty());
+  EXPECT_TRUE(GetNode("b2")->dirty());
+  EXPECT_TRUE(GetNode("b1")->dirty());
+
+  EXPECT_EQ(builder_.Build(&err), ExitSuccess);
+  EXPECT_EQ("", err);
+
+  EXPECT_EQ(9u, command_runner_.commands_ran_.size());
+}

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -79,6 +79,67 @@ bool DependencyScan::RecomputeDirty(Node* initial_node,
   return true;
 }
 
+namespace {
+class PropagateDirty {
+ public:
+  /// Propagate "dirty" status through all given edges.
+  /// Any node that becomes dirty and has no further outgoing edges
+  /// is added to 'topLevelNodes'.
+  static void call(const std::vector<Edge*>& edges,
+                   std::vector<Node*>* topLevelNodes);
+
+ private:
+  PropagateDirty(std::vector<Node*>* topLevelNodes)
+      : top_level_nodes_(topLevelNodes) {}
+
+  /// returns true if at least one of its outputs was originally marked 'clean'.
+  bool process(Edge* edge);
+
+  std::vector<Node*>* top_level_nodes_;
+};
+
+void PropagateDirty::call(const std::vector<Edge*>& edges,
+                          std::vector<Node*>* topLevelNodes) {
+  PropagateDirty propagateDirtyDyndep(topLevelNodes);
+  for (Edge* outedges : edges)
+    propagateDirtyDyndep.process(outedges);
+}
+
+bool PropagateDirty::process(Edge* const edge) {
+  bool clean_out = false;
+  for (Node* const out : edge->outputs_) {
+    // Only propagate if the node is currently clean.
+    if (out->clean()) {
+      clean_out = true;
+      out->MarkDirty();
+      edge->outputs_ready_ = false;
+
+      // If the node has no outgoing edges, it is a top‑level target.
+      if (out->out_edges().empty()) {
+        top_level_nodes_->push_back(out);
+        continue;
+      }
+
+      // Track whether any dependent edges had clean outputs.
+      bool dependent_clean = false;
+
+      for (Edge* outEdge : out->out_edges()) {
+        if (outEdge && process(outEdge)) {
+          dependent_clean = true;
+        }
+      }
+
+      // If this node have outgoing edges, but none of those edges produced
+      // clean outputs, then this node is effectively a top‑level node in the
+      // dirty propagation chain.
+      if (!out->out_edges().empty() && !dependent_clean)
+        top_level_nodes_->push_back(out);
+    }
+  }
+  return clean_out;
+}
+}  // namespace
+
 bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
                                         std::vector<Node*>* validation_nodes,
                                         string* err) {
@@ -112,6 +173,7 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
   bool dirty = false;
   edge->outputs_ready_ = true;
   edge->deps_missing_ = false;
+  bool dyndepLoaded = false;
 
   if (!edge->deps_loaded_) {
     // This is our first encounter with this edge.
@@ -134,6 +196,8 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
         // The dyndep file is ready, so load it now.
         if (!LoadDyndeps(edge->dyndep_, err))
           return false;
+        else
+          dyndepLoaded = true;
       }
     }
   }
@@ -203,10 +267,17 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
       return false;
 
   // Finally, visit each output and update their dirty state if necessary.
-  for (vector<Node*>::iterator o = edge->outputs_.begin();
-       o != edge->outputs_.end(); ++o) {
-    if (dirty)
-      (*o)->MarkDirty();
+  for (Node* out : edge->outputs_) {
+    if (dirty) {
+      out->MarkDirty();
+
+      // Only if a dyndep file was loaded, propagate the dirty state
+      // through all dependent edges of this output node.
+      if (dyndepLoaded)
+        PropagateDirty::call(out->out_edges(), validation_nodes);
+    } else {
+      out->MarkClean();
+    }
   }
 
   // If an edge is dirty, its outputs are normally not ready.  (It's

--- a/src/graph.h
+++ b/src/graph.h
@@ -37,6 +37,12 @@ struct Node;
 struct Pool;
 struct State;
 
+enum class DirtyState : char {
+  SPARE = 0,
+  DIRTY = 1,
+  CLEAN = 2,
+};
+
 /// Information about a node in the dependency graph: the file, whether
 /// it's dirty, mtime, etc.
 struct Node {
@@ -60,7 +66,7 @@ struct Node {
   void ResetState() {
     mtime_ = -1;
     exists_ = ExistenceStatusUnknown;
-    dirty_ = false;
+    dirty_ = DirtyState::SPARE;
   }
 
   /// Mark the Node as already-stat()ed and missing.
@@ -90,9 +96,18 @@ struct Node {
 
   TimeStamp mtime() const { return mtime_; }
 
-  bool dirty() const { return dirty_; }
-  void set_dirty(bool dirty) { dirty_ = dirty; }
-  void MarkDirty() { dirty_ = true; }
+  bool dirty() const { return dirty_ == DirtyState::DIRTY; }
+  void set_dirty(bool dirty) {
+    if (dirty) {
+      dirty_ = DirtyState::DIRTY;
+    } else if (dirty_ == DirtyState::DIRTY) {
+      dirty_ = DirtyState::CLEAN;
+    }
+  }
+  void MarkDirty() { dirty_ = DirtyState::DIRTY; }
+
+  bool clean() const { return dirty_ == DirtyState::CLEAN; }
+  void MarkClean() { dirty_ = DirtyState::CLEAN; }
 
   bool dyndep_pending() const { return dyndep_pending_; }
   void set_dyndep_pending(bool pending) { dyndep_pending_ = pending; }
@@ -144,7 +159,7 @@ private:
   /// Dirty is true when the underlying file is out-of-date.
   /// But note that Edge::outputs_ready_ is also used in judging which
   /// edges to build.
-  bool dirty_ = false;
+  DirtyState dirty_ = DirtyState::SPARE;
 
   /// Store whether dyndep information is expected from this node but
   /// has not yet been loaded.


### PR DESCRIPTION
This Pull request will reflect that dynamic dependencies may change the graph during recomputeDirty of nodes. A newly added dyndep output may be dirty and can cause other targets to be dirty as well. This shall take effect if those nodes has been visited before. A new algorithm to iterate over the graph to make nodes dirty has been added.
For a detailed problem description, see [issue#2653](https://github.com/ninja-build/ninja/issues/2653)