### PR TITLE
Fix Ninja exit code when interrupted (issue #2681)

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -154,9 +154,8 @@ struct CommandRunner {
 
   /// The result of waiting for a command.
   struct Result {
-    Result() : edge(NULL) {}
-    Edge* edge;
-    ExitStatus status;
+    Edge* edge = nullptr;
+    ExitStatus status = ExitFailure;
     std::string output;
     bool success() const { return status == ExitSuccess; }
   };

--- a/src/real_command_runner.cc
+++ b/src/real_command_runner.cc
@@ -98,8 +98,10 @@ bool RealCommandRunner::WaitForCommand(Result* result) {
   Subprocess* subproc;
   while ((subproc = subprocs_.NextFinished()) == NULL) {
     bool interrupted = subprocs_.DoWork();
-    if (interrupted)
+    if (interrupted) {
+      result->status = ExitInterrupted;
       return false;
+    }
   }
 
   result->status = subproc->Finish();


### PR DESCRIPTION
This fixes ##2681, a regression that was introduced during PR #2540 where Ninja would return a status code of 0 when interrupted.

The problem comes from RealCommandRunner::WaitForCommand() not updating the result->status field in case of interrupt being detected in Subprocess::DoWork().

This fixes the issue and adds a regression test for it.