### PR TITLE
Don't require a FIFO to be identifiable as such

### DIFF
--- a/src/jobserver-posix.cc
+++ b/src/jobserver-posix.cc
@@ -26,11 +26,12 @@
 
 namespace {
 
-// Return true if |fd| is a fifo or pipe descriptor.
-bool IsFifoDescriptor(int fd) {
+// Return true if |fd| is a fifo or character device.
+bool IsJobserverDescriptor(int fd) {
   struct stat info;
   int ret = ::fstat(fd, &info);
-  return (ret == 0) && ((info.st_mode & S_IFMT) == S_IFIFO);
+  return (ret == 0) && (((info.st_mode & S_IFMT) == S_IFIFO) ||
+                        ((info.st_mode & S_IFMT) == S_IFCHR));
 }
 
 // Implementation of Jobserver::Client for Posix systems
@@ -89,7 +90,7 @@ class PosixJobserverClient : public Jobserver::Client {
           std::string("Error opening fifo for reading: ") + strerror(errno);
       return false;
     }
-    if (!IsFifoDescriptor(read_fd_)) {
+    if (!IsJobserverDescriptor(read_fd_)) {
       *error = "Not a fifo path: " + fifo_path;
       // Let destructor close read_fd_.
       return false;


### PR DESCRIPTION
The jobserver specification [0] currently suggests that the FIFO must be a genuine FIFO.

For some work we're doing [1][2], we're emulating a FIFO using CUSE/FUSE to allow tracking when consumers disappear to avoid lost tokens. nixos had a similar idea in the past too [3].

There doesn't seem to be a good reason to check that any FIFO passed by the user is actually identifiable as such by `stat()`, so drop the check.

make already does not perform such a check, just the specification isn't clear about it, so we've asked them to clarify it [4].

[0] https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html
[1] https://codeberg.org/amonakov/guildmaster
[2] https://gitweb.gentoo.org/proj/steve.git/
[3] https://github.com/NixOS/nixpkgs/pull/314888
[4] https://savannah.gnu.org/bugs/index.php?67726