### PR TITLE
Speed up methods in `State`

### DIFF
--- a/src/graph.h
+++ b/src/graph.h
@@ -19,6 +19,7 @@
 #include <queue>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "dyndep.h"
@@ -42,6 +43,8 @@ struct State;
 struct Node {
   Node(const std::string& path, uint64_t slash_bits)
       : path_(path), slash_bits_(slash_bits) {}
+  Node(std::string&& path, uint64_t slash_bits)
+      : path_(std::move(path)), slash_bits_(slash_bits) {}
 
   /// Return false on error.
   bool Stat(DiskInterface* disk_interface, std::string* err);

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -339,7 +339,8 @@ bool ManifestParser::ParseEdge(string* err) {
       return lexer_.Error("empty path", err);
     uint64_t slash_bits;
     CanonicalizePath(&path, &slash_bits);
-    if (!state_->AddOut(edge, path, slash_bits, err)) {
+    Node *node = state_->GetNode(std::move(path), slash_bits);
+    if (!state_->AddOut(edge, node, err)) {
       lexer_.Error(std::string(*err), err);
       return false;
     }
@@ -361,7 +362,8 @@ bool ManifestParser::ParseEdge(string* err) {
       return lexer_.Error("empty path", err);
     uint64_t slash_bits;
     CanonicalizePath(&path, &slash_bits);
-    state_->AddIn(edge, path, slash_bits);
+    Node *node = state_->GetNode(std::move(path), slash_bits);
+    state_->AddIn(edge, node);
   }
   edge->implicit_deps_ = implicit;
   edge->order_only_deps_ = order_only;
@@ -374,7 +376,8 @@ bool ManifestParser::ParseEdge(string* err) {
       return lexer_.Error("empty path", err);
     uint64_t slash_bits;
     CanonicalizePath(&path, &slash_bits);
-    state_->AddValidation(edge, path, slash_bits);
+    Node *node = state_->GetNode(std::move(path), slash_bits);
+    state_->AddValidation(edge, node);
   }
 
   if (options_.phony_cycle_action_ == kPhonyCycleActionWarn &&

--- a/src/missing_deps_test.cc
+++ b/src/missing_deps_test.cc
@@ -64,15 +64,15 @@ struct MissingDependencyScannerTest : public testing::Test {
     compile_rule_.AddBinding("deps", deps_type);
     generator_rule_.AddBinding("deps", deps_type);
     Edge* header_edge = state_.AddEdge(&generator_rule_);
-    state_.AddOut(header_edge, "generated_header", 0, nullptr);
+    state_.AddOut(header_edge, state_.GetNode("generated_header", 0), nullptr);
     Edge* compile_edge = state_.AddEdge(&compile_rule_);
-    state_.AddOut(compile_edge, "compiled_object", 0, nullptr);
+    state_.AddOut(compile_edge, state_.GetNode("compiled_object", 0), nullptr);
   }
 
   void CreateGraphDependencyBetween(const char* from, const char* to) {
     Node* from_node = state_.LookupNode(from);
     Edge* from_edge = from_node->in_edge();
-    state_.AddIn(from_edge, to, 0);
+    state_.AddIn(from_edge, state_.GetNode(to, 0));
   }
 
   void AssertMissingDependencyBetween(const char* flaky, const char* generated,
@@ -130,7 +130,7 @@ TEST_F(MissingDependencyScannerTest, MissingDepFixedIndirect) {
   CreateInitialState();
   // Adding an indirect dependency also fixes the issue
   Edge* intermediate_edge = state_.AddEdge(&generator_rule_);
-  state_.AddOut(intermediate_edge, "intermediate", 0, nullptr);
+  state_.AddOut(intermediate_edge, state_.GetNode("intermediate", 0), nullptr);
   CreateGraphDependencyBetween("compiled_object", "intermediate");
   CreateGraphDependencyBetween("intermediate", "generated_header");
   RecordDepsLogDep("compiled_object", "generated_header");

--- a/src/state.h
+++ b/src/state.h
@@ -103,16 +103,18 @@ struct State {
 
   Edge* AddEdge(const Rule* rule);
 
+  Node* GetNode(const char* path, uint64_t slash_bits);
   Node* GetNode(StringPiece path, uint64_t slash_bits);
+  Node* GetNode(std::string&& path, uint64_t slash_bits);
   Node* LookupNode(StringPiece path) const;
   Node* SpellcheckNode(const std::string& path);
 
   /// Add input / output / validation nodes to a given edge. This also
   /// ensures that the generated_by_dep_loader() flag for all these nodes
   /// is set to false, to indicate that they come from the input manifest.
-  void AddIn(Edge* edge, StringPiece path, uint64_t slash_bits);
-  bool AddOut(Edge* edge, StringPiece path, uint64_t slash_bits, std::string* err);
-  void AddValidation(Edge* edge, StringPiece path, uint64_t slash_bits);
+  void AddIn(Edge* edge, Node *node);
+  bool AddOut(Edge* edge, Node *node, std::string* err);
+  void AddValidation(Edge* edge, Node *node);
   bool AddDefault(StringPiece path, std::string* error);
 
   /// Reset state.  Keeps all nodes and edges, but restores them to the

--- a/src/state_test.cc
+++ b/src/state_test.cc
@@ -34,9 +34,9 @@ TEST(State, Basic) {
   state.bindings_.AddRule(std::unique_ptr<Rule>(rule));
 
   Edge* edge = state.AddEdge(rule);
-  state.AddIn(edge, "in1", 0);
-  state.AddIn(edge, "in2", 0);
-  state.AddOut(edge, "out", 0, nullptr);
+  state.AddIn(edge, state.GetNode("in1", 0));
+  state.AddIn(edge, state.GetNode("in2", 0));
+  state.AddOut(edge, state.GetNode("out", 0), nullptr);
 
   EXPECT_EQ("cat in1 in2 > out", edge->EvaluateCommand());
 


### PR DESCRIPTION
Remove the double-lookup inside `paths_` in `State::GetNode` in the case where we are first calling this for a particular `path`.

Add overloads of `GetNode` that can take ownership of a `std::string`, which is the common case when calling from `ManifestParser` and we have a `std::string` returned by the `Evaluate` method going to waste.

To avoid writing an overload of `AddIn`, `AddOut`, and `AddValidation` taking a `std::string&&` by changing the signature to instead take a `Node *` and require caller to get this through `State::GetNode`.