### PR TITLE
Make sure to carry the old uid and gid on file replace

### DIFF
--- a/src/build_log.cc
+++ b/src/build_log.cc
@@ -373,17 +373,8 @@ bool BuildLog::Recompact(const std::string& path, const BuildLogUser& user,
     entries_.erase(output);
 
   fclose(f);
-  if (platformAwareUnlink(path.c_str()) < 0) {
-    *err = strerror(errno);
-    return false;
-  }
 
-  if (rename(temp_path.c_str(), path.c_str()) < 0) {
-    *err = strerror(errno);
-    return false;
-  }
-
-  return true;
+  return ReplaceContent(path, temp_path, err);
 }
 
 bool BuildLog::Restat(const StringPiece path,
@@ -430,15 +421,6 @@ bool BuildLog::Restat(const StringPiece path,
   }
 
   fclose(f);
-  if (platformAwareUnlink(path.str_) < 0) {
-    *err = strerror(errno);
-    return false;
-  }
 
-  if (rename(temp_path.c_str(), path.str_) < 0) {
-    *err = strerror(errno);
-    return false;
-  }
-
-  return true;
+  return ReplaceContent(path.AsString(), temp_path, err);
 }

--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -363,17 +363,7 @@ bool DepsLog::Recompact(const string& path, string* err) {
   deps_.swap(new_log.deps_);
   nodes_.swap(new_log.nodes_);
 
-  if (platformAwareUnlink(path.c_str()) < 0) {
-    *err = strerror(errno);
-    return false;
-  }
-
-  if (rename(temp_path.c_str(), path.c_str()) < 0) {
-    *err = strerror(errno);
-    return false;
-  }
-
-  return true;
+  return ReplaceContent(path, temp_path, err);
 }
 
 bool DepsLog::IsDepsEntryLiveFor(const Node* node) {

--- a/src/util.h
+++ b/src/util.h
@@ -117,6 +117,16 @@ bool Truncate(const std::string& path, size_t size, std::string* err);
 #define PATH_MAX _MAX_PATH
 #endif
 
+
+/// ReplaceContent the content of \a file_dst with the content of \a
+/// new_content. On platforms other than Windows, the file pointed to by \a
+/// file_dst will keep the same uid and gid, if possible. Reason for this is
+/// that permissions on Windows are more complex than on Linux, fetching
+/// permissions on Windows would involve an non-trivial amount of code to fetch
+/// users and have fallback paths
+bool ReplaceContent(const std::string& file_dst, const std::string& new_content,
+                    std::string* err);
+
 #ifdef _WIN32
 /// Convert the value returned by GetLastError() into a string.
 std::string GetLastErrorString();


### PR DESCRIPTION
This is a refresh of https://github.com/ninja-build/ninja/pull/1588 opened in 2019 (but the bug is still there).

The normal workflow is to run "ninja all && sudo ninja install". Unfortunately, ninja may rebuild .ninja_log or .ninja_deps. In this case, they are created with root as owner. Once done, user can't build without being root.

The patch below carry the original owner of the file (as "cp -a" does).

Fixes: #1302