### PR TITLE
expand response file for subtool commands

### DIFF
--- a/src/graph.h
+++ b/src/graph.h
@@ -278,7 +278,7 @@ struct EdgeCmp {
   }
 };
 
-typedef std::set<Edge*, EdgeCmp> EdgeSet;
+typedef std::set<const Edge*, EdgeCmp> EdgeSet;
 
 /// ImplicitDepLoader loads implicit dependencies, as referenced via the
 /// "depfile" attribute in build files.


### PR DESCRIPTION
## Related PRs
#1760 #2698 

## Problem description and current master branch
Ninja does not expand response files in the subtool `commands`.
```ninja
# build.ninja
rule cc
  command = gcc @${out}.rsp -o ${out}
  rspfile = ${out}.rsp
  rspfile_content = -Iinclude -O2 $in

build myprog: cc file1.c file2.c file3.c
```

```
$ninja -t commands
gcc @myprog.rsp -o myprog
```
## Proposed Solution

```
$ninja -t commands -x
gcc -Iinclude -O2 file1.c file2.c file3.c -o myprog
```
### option or default
https://github.com/ninja-build/ninja/issues/1760#issuecomment-615459297
This can be done as the default without a flag, but to be consistent with compdb I used the flag `-x`