### PR TITLE
Speed up `/showIncludes` parsing

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -988,10 +988,8 @@ bool Builder::ExtractDeps(CommandRunner::Result* result,
                           string* err) {
   if (deps_type == "msvc") {
     CLParser parser;
-    string output;
-    if (!parser.Parse(result->output, deps_prefix, &output, err))
+    if (!parser.Parse(&result->output, deps_prefix, err))
       return false;
-    result->output = output;
     for (set<string>::iterator i = parser.includes_.begin();
          i != parser.includes_.end(); ++i) {
       // ~0 is assuming that with MSVC-parsed headers, it's ok to always make

--- a/src/clparser.h
+++ b/src/clparser.h
@@ -18,6 +18,8 @@
 #include <set>
 #include <string>
 
+struct StringPiece;
+
 /// Visual Studio's cl.exe requires some massaging to work with Ninja;
 /// for example, it emits include information on stderr in a funny
 /// format when building with /showIncludes.  This class parses this
@@ -26,26 +28,28 @@ struct CLParser {
   /// Parse a line of cl.exe output and extract /showIncludes info.
   /// If a dependency is extracted, returns a nonempty string.
   /// Exposed for testing.
-  static std::string FilterShowIncludes(const std::string& line,
-                                        const std::string& deps_prefix);
+  static StringPiece FilterShowIncludes(const StringPiece& line,
+                                        const StringPiece& deps_prefix);
 
   /// Return true if a mentioned include file is a system path.
+  /// Use \@ temp to store temporary data if needed.
   /// Filtering these out reduces dependency information considerably.
-  static bool IsSystemInclude(std::string path);
+  static bool IsSystemInclude(StringPiece path, std::string* temp);
 
   /// Parse a line of cl.exe output and return true if it looks like
   /// it's printing an input filename.  This is a heuristic but it appears
   /// to be the best we can do.
   /// Exposed for testing.
-  static bool FilterInputFilename(std::string line);
+  static bool FilterInputFilename(const StringPiece& line);
 
-  /// Parse the full output of cl, filling filtered_output with the text that
+  /// Parse the full output of cl, updating /a output with the text that
   /// should be printed (if any). Returns true on success, or false with err
-  /// filled. output must not be the same object as filtered_object.
-  bool Parse(const std::string& output, const std::string& deps_prefix,
-             std::string* filtered_output, std::string* err);
+  /// filled.
+  bool Parse(std::string *output, const StringPiece& deps_prefix,
+             std::string* err);
 
   std::set<std::string> includes_;
+  std::string temp_;
 };
 
 #endif  // NINJA_CLPARSER_H_

--- a/src/clparser_perftest.cc
+++ b/src/clparser_perftest.cc
@@ -17,12 +17,13 @@
 
 #include "clparser.h"
 #include "metrics.h"
+#include "string_piece.h"
 
 using namespace std;
 
 int main(int argc, char* argv[]) {
   // Output of /showIncludes from #include <iostream>
-  string perf_testdata =
+  const StringPiece perf_testdata =
       "Note: including file: C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE\\iostream\r\n"
       "Note: including file:  C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE\\istream\r\n"
       "Note: including file:   C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\INCLUDE\\ostream\r\n"
@@ -136,11 +137,11 @@ int main(int argc, char* argv[]) {
   for (int limit = 1 << 10; limit < (1<<20); limit *= 2) {
     int64_t start = GetTimeMillis();
     for (int rep = 0; rep < limit; ++rep) {
-      string output;
+      string data = perf_testdata.AsString();
       string err;
 
       CLParser parser;
-      if (!parser.Parse(perf_testdata, "", &output, &err)) {
+      if (!parser.Parse(&data, "", &err)) {
         printf("%s\n", err.c_str());
         return 1;
       }

--- a/src/clparser_test.cc
+++ b/src/clparser_test.cc
@@ -48,13 +48,12 @@ TEST(CLParserTest, FilterInputFilename) {
 
 TEST(CLParserTest, ParseSimple) {
   CLParser parser;
-  string output, err;
-  ASSERT_TRUE(parser.Parse(
+  string output =
       "foo\r\n"
       "Note: inc file prefix:  foo.h\r\n"
-      "bar\r\n",
-      "Note: inc file prefix:", &output, &err));
-
+      "bar\r\n";
+  string err;
+  ASSERT_TRUE(parser.Parse(&output, "Note: inc file prefix:", &err));
   ASSERT_EQ("foo\nbar\n", output);
   ASSERT_EQ(1u, parser.includes_.size());
   ASSERT_EQ("foo.h", *parser.includes_.begin());
@@ -62,33 +61,33 @@ TEST(CLParserTest, ParseSimple) {
 
 TEST(CLParserTest, ParseFilenameFilter) {
   CLParser parser;
-  string output, err;
-  ASSERT_TRUE(parser.Parse(
+  string output =
       "foo.cc\r\n"
-      "cl: warning\r\n",
-      "", &output, &err));
+      "cl: warning\r\n";
+  string err;
+  ASSERT_TRUE(parser.Parse(&output, "", &err));
   ASSERT_EQ("cl: warning\n", output);
 }
 
 TEST(CLParserTest, NoFilenameFilterAfterShowIncludes) {
   CLParser parser;
-  string output, err;
-  ASSERT_TRUE(parser.Parse(
+  string output =
       "foo.cc\r\n"
       "Note: including file: foo.h\r\n"
-      "something something foo.cc\r\n",
-      "", &output, &err));
+      "something something foo.cc\r\n";
+  string err;
+  ASSERT_TRUE(parser.Parse(&output, "", &err));
   ASSERT_EQ("something something foo.cc\n", output);
 }
 
 TEST(CLParserTest, ParseSystemInclude) {
   CLParser parser;
-  string output, err;
-  ASSERT_TRUE(parser.Parse(
+  string output =
       "Note: including file: c:\\Program Files\\foo.h\r\n"
       "Note: including file: d:\\Microsoft Visual Studio\\bar.h\r\n"
-      "Note: including file: path.h\r\n",
-      "", &output, &err));
+      "Note: including file: path.h\r\n";
+  string err;
+  ASSERT_TRUE(parser.Parse(&output, "", &err));
   // We should have dropped the first two includes because they look like
   // system headers.
   ASSERT_EQ("", output);
@@ -98,12 +97,12 @@ TEST(CLParserTest, ParseSystemInclude) {
 
 TEST(CLParserTest, DuplicatedHeader) {
   CLParser parser;
-  string output, err;
-  ASSERT_TRUE(parser.Parse(
+  string output =
       "Note: including file: foo.h\r\n"
       "Note: including file: bar.h\r\n"
-      "Note: including file: foo.h\r\n",
-      "", &output, &err));
+      "Note: including file: foo.h\r\n";
+  string err;
+  ASSERT_TRUE(parser.Parse(&output, "", &err));
   // We should have dropped one copy of foo.h.
   ASSERT_EQ("", output);
   ASSERT_EQ(2u, parser.includes_.size());
@@ -111,11 +110,11 @@ TEST(CLParserTest, DuplicatedHeader) {
 
 TEST(CLParserTest, DuplicatedHeaderPathConverted) {
   CLParser parser;
-  string output, err;
+  string err;
 
   // This isn't inline in the Parse() call below because the #ifdef in
   // a macro expansion would confuse MSVC2013's preprocessor.
-  const char kInput[] =
+  std::string output =
       "Note: including file: sub/./foo.h\r\n"
       "Note: including file: bar.h\r\n"
 #ifdef _WIN32
@@ -123,8 +122,28 @@ TEST(CLParserTest, DuplicatedHeaderPathConverted) {
 #else
       "Note: including file: sub/foo.h\r\n";
 #endif
-  ASSERT_TRUE(parser.Parse(kInput, "", &output, &err));
+  ASSERT_TRUE(parser.Parse(&output, "", &err));
   // We should have dropped one copy of foo.h.
   ASSERT_EQ("", output);
   ASSERT_EQ(2u, parser.includes_.size());
+}
+
+TEST(CLParserTest, DifferentNewLines) {
+  CLParser parser;
+  string output =
+      "Note: inc file prefix: lf.h\n"
+      "Note: inc file prefix: crlf.h\r\n"
+      "Note: inc file prefix: cr.h\r"
+      "CR\r"
+      "LF\n"
+      "LFCR\n\r"
+      "CRLF\r\n"
+      "END\n";
+  string err;
+  ASSERT_TRUE(parser.Parse(&output, "Note: inc file prefix:", &err));
+  ASSERT_EQ("CR\nLF\nLFCR\n\nCRLF\nEND\n", output);
+  ASSERT_EQ(3u, parser.includes_.size());
+  ASSERT_EQ("cr.h", *std::next(parser.includes_.begin(), 0));
+  ASSERT_EQ("crlf.h", *std::next(parser.includes_.begin(), 1));
+  ASSERT_EQ("lf.h", *std::next(parser.includes_.begin(), 2));
 }

--- a/src/includes_normalize.h
+++ b/src/includes_normalize.h
@@ -24,17 +24,17 @@ struct StringPiece;
 /// TODO: this likely duplicates functionality of CanonicalizePath; refactor.
 struct IncludesNormalize {
   /// Normalize path relative to |relative_to|.
-  IncludesNormalize(const std::string& relative_to);
+  IncludesNormalize(const StringPiece& relative_to);
 
   // Internal utilities made available for testing, maybe useful otherwise.
-  static std::string AbsPath(StringPiece s, std::string* err);
-  static std::string Relativize(StringPiece path,
-                                const std::vector<StringPiece>& start_list,
-                                std::string* err);
+  static void AbsPath(std::string* s, std::string* err);
+  static void Relativize(std::string* abs_path,
+                         const std::vector<StringPiece>& start_list,
+                         std::string* err);
 
   /// Normalize by fixing slashes style, fixing redundant .. and . and makes the
   /// path |input| relative to |this->relative_to_| and store to |result|.
-  bool Normalize(const std::string& input, std::string* result,
+  bool Normalize(const StringPiece& input, std::string* result,
                  std::string* err) const;
 
  private:

--- a/src/includes_normalize_test.cc
+++ b/src/includes_normalize_test.cc
@@ -33,7 +33,7 @@ string GetCurDir() {
   return parts[parts.size() - 1].AsString();
 }
 
-string NormalizeAndCheckNoError(const string& input) {
+string NormalizeAndCheckNoError(const StringPiece input) {
   string result, err;
   IncludesNormalize normalizer(".");
   EXPECT_TRUE(normalizer.Normalize(input, &result, &err));
@@ -41,8 +41,8 @@ string NormalizeAndCheckNoError(const string& input) {
   return result;
 }
 
-string NormalizeRelativeAndCheckNoError(const string& input,
-                                        const string& relative_to) {
+string NormalizeRelativeAndCheckNoError(const StringPiece& input,
+                                        const StringPiece& relative_to) {
   string result, err;
   IncludesNormalize normalizer(relative_to);
   EXPECT_TRUE(normalizer.Normalize(input, &result, &err));
@@ -62,9 +62,11 @@ TEST(IncludesNormalize, Simple) {
 TEST(IncludesNormalize, WithRelative) {
   string err;
   string currentdir = GetCurDir();
+
   EXPECT_EQ("c", NormalizeRelativeAndCheckNoError("a/b/c", "a/b"));
-  EXPECT_EQ("a",
-            NormalizeAndCheckNoError(IncludesNormalize::AbsPath("a", &err)));
+  string absA = "a";
+  IncludesNormalize::AbsPath(&absA, &err);
+  EXPECT_EQ("a", NormalizeAndCheckNoError(absA));
   EXPECT_EQ("", err);
   EXPECT_EQ(string("../") + currentdir + string("/a"),
             NormalizeRelativeAndCheckNoError("a", "../b"));

--- a/src/msvc_helper_main-win32.cc
+++ b/src/msvc_helper_main-win32.cc
@@ -20,6 +20,7 @@
 #include <windows.h>
 
 #include "clparser.h"
+#include "string_piece.h"
 #include "util.h"
 
 #include "getopt.h"
@@ -131,7 +132,7 @@ int MSVCHelperMain(int argc, char** argv) {
   if (output_filename) {
     CLParser parser;
     string err;
-    if (!parser.Parse(output, deps_prefix, &output, &err))
+    if (!parser.Parse(&output, deps_prefix, &err))
       Fatal("%s\n", err.c_str());
     WriteDepFileOrDie(output_filename, parser);
   }


### PR DESCRIPTION
Achieve a 3-4x speed-up in parsing MSVC's `/showIncludes` by
removing almost all temporary `std::string` values.

`clparser_perftest.exe` before:

    Parse 16384 times in 2777ms avg 169.5us

and after:

    Parse 65536 times in 3122ms avg 47.6us

In general, most `std::string` parameters were changed to either
`StringPiece` or `std::string*` and the algorithm changed to an in-place
one.  Occassionally we change to a `const std::string&` when we require
a null-terminated string, but this is on private methods that we call
only with a `std::string`.

Most of the algorithms are similar, the biggest changes are in
`CLParser::Parse`, where we reuse the same string to emit the filtered
output, and `CLParser::Relativize`, where we introduce
`StringPieceRange` that is a range that lazily splits a string by a
separator. This can be fed into `std::mismatch` to give the right place
where we need to edit the string.  Most of the time we can avoid
splitting the entire string and instead just update the prefix by
removing directories and inserting "../".

There is still a temporary string required in
`CLParser::IsSystemInclude`, until we have C++17 and can use
`std::search` with a custom equality predicate.  Until then, we pass in
a temporary string to use and store this as a member of `CLParser` so
that we can avoid most allocations and deallocations here.

`operator==` for `StringPiece` was made into a friend free function so
we can write `"" == StringPiece()` and hit this overload - previously we
could only write `StringPiece() == ""`.

Add `StringPiece::substr`, which has the same behavior as
`std::string::substr` when exceptions are disabled (i.e. aborting when
`pos > size()`.  This will make it easy to swap to `std::string_view` in
the future.