### PR TITLE
allow dry run for builds with regeneration

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1848,14 +1848,15 @@ NORETURN void real_main(int argc, char** argv) {
     if (options.tool && options.tool->when == Tool::RUN_AFTER_LOGS)
       exit((ninja.*options.tool->func)(&options, argc, argv));
 
+    // Note: NinjaMain::RebuildManifest() can return true even if "config.dry_run = true"
     // Attempt to rebuild the manifest before building anything else
     if (ninja.RebuildManifest(options.input_file, &err, status)) {
-      // In dry_run mode the regeneration will succeed without changing the
-      // manifest forever. Better to return immediately.
-      if (config.dry_run)
-        exit(0);
-      // Start the build over with the new manifest.
-      continue;
+      if (!config.dry_run) {
+        // Manifest has been rebuild
+        // Start the build over with the new manifest.
+        continue;
+      }
+      // Manifest has not been rebuild, continue to execute the dry run...
     } else if (!err.empty()) {
       status->Error("rebuilding '%s': %s", options.input_file, err.c_str());
       exit(1);


### PR DESCRIPTION
## Problem Description
The dry run `ninja -n` does not help very much if a regeneration is scheduled.
One common use case is globbing in cmake. See example below:
```cmake
# CMakeLists.txt
cmake_minimum_required(VERSION 3.19)
project(hallo_cpp) 

file(GLOB TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ) 
add_executable(tests ${TEST_SOURCES})
```
`main.cpp` is on the disk.

### Master branch

```
$ touch main.cpp && ninja | tee
[0/2] Re-checking globbed directories...
[1/3] Building CXX object CMakeFiles/tests.dir/main.cpp.o
[2/3] Linking CXX executable tests

$ touch main.cpp && ninja -n | tee
[0/2] Re-checking globbed directories...
[1/2] Re-running CMake...
```
The dry run option `-n` is not very useful anymore.
### Proposed solution

```
$ touch main.cpp && ninja -n | tee
[0/2] Re-checking globbed directories...
[1/2] Re-running CMake...
[1/4] Building CXX object CMakeFiles/tests.dir/main.cpp.o
[2/4] Linking CXX executable tests
```
The dry run is useful again.
