### PR TITLE
Add option to set idle priority

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -83,6 +83,9 @@ struct Options {
 
   /// Whether phony cycles should warn or print an error.
   bool phony_cycle_should_err;
+
+  /// Set build to idle (low) priority
+  bool idle_priority;
 };
 
 /// The Ninja main() loads up a series of data structures; various tools need
@@ -231,9 +234,10 @@ void Usage(const BuildConfig& config) {
 "if targets are unspecified, builds the 'default' target (see manual).\n"
 "\n"
 "options:\n"
-"  --version      print ninja version (\"%s\")\n"
-"  -v, --verbose  show all command lines while building\n"
-"  --quiet        don't show progress status, just command output\n"
+"  --version       print ninja version (\"%s\")\n"
+"  -v, --verbose   show all command lines while building\n"
+"  --quiet         don't show progress status, just command output\n"
+"  --idle-priority run jobs with idle (low) priority to keep system responsive\n"
 "\n"
 "  -C DIR   change to DIR before doing anything else\n"
 "  -f FILE  specify input build file [default=build.ninja]\n"
@@ -1700,12 +1704,13 @@ int ReadFlags(int* argc, char*** argv,
               Options* options, BuildConfig* config) {
   DeferGuessParallelism deferGuessParallelism(config);
 
-  enum { OPT_VERSION = 1, OPT_QUIET = 2 };
+  enum { OPT_VERSION = 1, OPT_QUIET = 2, OPT_IDLE_PRIO = 3 };
   const option kLongOptions[] = {
     { "help", no_argument, NULL, 'h' },
     { "version", no_argument, NULL, OPT_VERSION },
     { "verbose", no_argument, NULL, 'v' },
     { "quiet", no_argument, NULL, OPT_QUIET },
+    { "idle-priority", no_argument, NULL, OPT_IDLE_PRIO },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1720,6 +1725,9 @@ int ReadFlags(int* argc, char*** argv,
         break;
       case 'f':
         options->input_file = optarg;
+        break;
+      case OPT_IDLE_PRIO:
+        options->idle_priority = true;
         break;
       case 'j': {
         char* end;
@@ -1809,6 +1817,8 @@ NORETURN void real_main(int argc, char** argv) {
     exit(exit_code);
 
   Status* status = Status::factory(config);
+  bool show_info =
+      (!options.tool && config.verbosity != BuildConfig::NO_STATUS_UPDATE);
 
   if (options.working_dir) {
     // The formatting of this string, complete with funny quotes, is
@@ -1816,10 +1826,18 @@ NORETURN void real_main(int argc, char** argv) {
     // subsequent commands.
     // Don't print this if a tool is being used, so that tool output
     // can be piped into a file without this string showing up.
-    if (!options.tool && config.verbosity != BuildConfig::NO_STATUS_UPDATE)
+    if (show_info)
       status->Info("Entering directory `%s'", options.working_dir);
     if (chdir(options.working_dir) < 0) {
       Fatal("chdir to '%s' - %s", options.working_dir, strerror(errno));
+    }
+  }
+
+  if (options.idle_priority) {
+    if (show_info)
+      status->Info("Set idle priority");
+    if (SetIdlePriority() < 0) {
+      Fatal("Failed to set idle priority");
     }
   }
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -85,7 +85,7 @@ struct Options {
   bool phony_cycle_should_err;
 
   /// Set build to idle (low) priority
-  bool idle_priority;
+  bool low_priority;
 };
 
 /// The Ninja main() loads up a series of data structures; various tools need
@@ -1704,13 +1704,13 @@ int ReadFlags(int* argc, char*** argv,
               Options* options, BuildConfig* config) {
   DeferGuessParallelism deferGuessParallelism(config);
 
-  enum { OPT_VERSION = 1, OPT_QUIET = 2, OPT_IDLE_PRIO = 3 };
+  enum { OPT_VERSION = 1, OPT_QUIET = 2, OPT_LOW_PRIO = 3 };
   const option kLongOptions[] = {
     { "help", no_argument, NULL, 'h' },
     { "version", no_argument, NULL, OPT_VERSION },
     { "verbose", no_argument, NULL, 'v' },
     { "quiet", no_argument, NULL, OPT_QUIET },
-    { "idle-priority", no_argument, NULL, OPT_IDLE_PRIO },
+    { "low-priority", no_argument, NULL, OPT_LOW_PRIO },
     { NULL, 0, NULL, 0 }
   };
 
@@ -1726,8 +1726,8 @@ int ReadFlags(int* argc, char*** argv,
       case 'f':
         options->input_file = optarg;
         break;
-      case OPT_IDLE_PRIO:
-        options->idle_priority = true;
+      case OPT_LOW_PRIO:
+        options->low_priority = true;
         break;
       case 'j': {
         char* end;
@@ -1833,11 +1833,11 @@ NORETURN void real_main(int argc, char** argv) {
     }
   }
 
-  if (options.idle_priority) {
+  if (options.low_priority) {
     if (show_info)
-      status->Info("Set idle priority");
-    if (SetIdlePriority() < 0) {
-      Fatal("Failed to set idle priority");
+      status->Info("Set low priority");
+    if (SetLowPriority() < 0) {
+      Fatal("Failed to set priority");
     }
   }
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -1066,11 +1066,11 @@ int platformAwareUnlink(const char* filename) {
 	#endif
 }
 
-int SetIdlePriority() {
+int SetLowPriority() {
 #ifdef _WIN32
   HANDLE hProcess = GetCurrentProcess();
-  return !SetPriorityClass(hProcess, IDLE_PRIORITY_CLASS) ? -1 : 0;
+  return !SetPriorityClass(hProcess, BELOW_NORMAL_PRIORITY_CLASS) ? -1 : 0;
 #else
-  return setpriority(PRIO_PROCESS, 0, 19);
+  return setpriority(PRIO_PROCESS, 0, 10);
 #endif
 }

--- a/src/util.cc
+++ b/src/util.cc
@@ -36,6 +36,7 @@
 
 #ifndef _WIN32
 #include <unistd.h>
+#include <sys/resource.h>
 #include <sys/time.h>
 #endif
 
@@ -1063,4 +1064,13 @@ int platformAwareUnlink(const char* filename) {
 	#else
 		return unlink(filename);
 	#endif
+}
+
+int SetIdlePriority() {
+#ifdef _WIN32
+  HANDLE hProcess = GetCurrentProcess();
+  return !SetPriorityClass(hProcess, IDLE_PRIORITY_CLASS) ? -1 : 0;
+#else
+  return setpriority(PRIO_PROCESS, 0, 19);
+#endif
 }

--- a/src/util.h
+++ b/src/util.h
@@ -147,8 +147,8 @@ inline To FunctionCast(From from) {
 
 int platformAwareUnlink(const char* filename);
 
-/// Set the process priority to idle.
+/// Set the process priority to lower than normal.
 /// @return 0 on success, -1 on error.
-int SetIdlePriority();
+int SetLowPriority();
 
 #endif  // NINJA_UTIL_H_

--- a/src/util.h
+++ b/src/util.h
@@ -147,4 +147,8 @@ inline To FunctionCast(From from) {
 
 int platformAwareUnlink(const char* filename);
 
+/// Set the process priority to idle.
+/// @return 0 on success, -1 on error.
+int SetIdlePriority();
+
 #endif  // NINJA_UTIL_H_


### PR DESCRIPTION
Compiling on a desktop interfere with the interactive usage. For convenience, we add the option to lower the priority of the jobs.

On Windows, the priority is set to IDLE_PRIORITY_CLASS. On Unix, we lower the process priority with setpriority(). In both cases, the low priority is inherited by subprocess, such that setting the priority only once when ninja starts is sufficient.

Close #2176