### PR TITLE
Avoid string copies on lookup methods

### DIFF
--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -18,8 +18,8 @@
 
 using namespace std;
 
-string BindingEnv::LookupVariable(const string& var) {
-  map<string, string>::iterator i = bindings_.find(var);
+std::string BindingEnv::LookupVariable(StringPiece var) {
+  const auto i = bindings_.find(var);
   if (i != bindings_.end())
     return i->second;
   if (parent_)
@@ -27,8 +27,8 @@ string BindingEnv::LookupVariable(const string& var) {
   return "";
 }
 
-void BindingEnv::AddBinding(const string& key, const string& val) {
-  bindings_[key] = val;
+void BindingEnv::AddBinding(const std::string& key, StringPiece val) {
+  bindings_[key].assign(val.begin(), val.end());
 }
 
 void BindingEnv::AddRule(std::unique_ptr<const Rule> rule) {
@@ -36,14 +36,14 @@ void BindingEnv::AddRule(std::unique_ptr<const Rule> rule) {
   rules_[rule->name()] = std::move(rule);
 }
 
-const Rule* BindingEnv::LookupRuleCurrentScope(const string& rule_name) {
+const Rule* BindingEnv::LookupRuleCurrentScope(StringPiece rule_name) {
   auto i = rules_.find(rule_name);
   if (i == rules_.end())
     return NULL;
   return i->second.get();
 }
 
-const Rule* BindingEnv::LookupRule(const string& rule_name) {
+const Rule* BindingEnv::LookupRule(StringPiece rule_name) {
   auto i = rules_.find(rule_name);
   if (i != rules_.end())
     return i->second.get();
@@ -56,7 +56,7 @@ void Rule::AddBinding(const string& key, const EvalString& val) {
   bindings_[key] = val;
 }
 
-const EvalString* Rule::GetBinding(const string& key) const {
+const EvalString* Rule::GetBinding(StringPiece key) const {
   Bindings::const_iterator i = bindings_.find(key);
   if (i == bindings_.end())
     return NULL;
@@ -74,7 +74,7 @@ bool Rule::IsPhony() const {
 }
 
 // static
-bool Rule::IsReservedBinding(const string& var) {
+bool Rule::IsReservedBinding(StringPiece var) {
   return var == "command" ||
       var == "depfile" ||
       var == "dyndep" ||
@@ -88,14 +88,14 @@ bool Rule::IsReservedBinding(const string& var) {
       var == "msvc_deps_prefix";
 }
 
-const map<string, std::unique_ptr<const Rule>>& BindingEnv::GetRules() const {
+const map<string, std::unique_ptr<const Rule>, StringPieceLess>& BindingEnv::GetRules() const {
   return rules_;
 }
 
-string BindingEnv::LookupWithFallback(const string& var,
-                                      const EvalString* eval,
-                                      Env* env) {
-  map<string, string>::iterator i = bindings_.find(var);
+std::string BindingEnv::LookupWithFallback(StringPiece var,
+                                           const EvalString* eval,
+                                           Env* env) {
+  const auto i = bindings_.find(var);
   if (i != bindings_.end())
     return i->second;
 

--- a/src/graph.h
+++ b/src/graph.h
@@ -190,8 +190,8 @@ struct Edge {
   std::string EvaluateCommand(bool incl_rsp_file = false) const;
 
   /// Returns the shell-escaped value of |key|.
-  std::string GetBinding(const std::string& key) const;
-  bool GetBindingBool(const std::string& key) const;
+  std::string GetBinding(StringPiece key) const;
+  bool GetBindingBool(StringPiece key) const;
 
   /// Like GetBinding("depfile"), but without shell escaping.
   std::string GetUnescapedDepfile() const;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -685,12 +685,10 @@ int NinjaMain::ToolRules(const Options* options, int argc, char* argv[]) {
 
   // Print rules
 
-  typedef map<string, std::unique_ptr<const Rule>> Rules;
-  const Rules& rules = state_.bindings_.GetRules();
-  for (Rules::const_iterator i = rules.begin(); i != rules.end(); ++i) {
-    printf("%s", i->first.c_str());
+  for (const auto& r : state_.bindings_.GetRules()) {
+    printf("%s", r.first.c_str());
     if (print_description) {
-      const Rule* rule = i->second.get();
+      const Rule* rule = r.second.get();
       const EvalString* description = rule->GetBinding("description");
       if (description != NULL) {
         printf(": %s", description->Unparse().c_str());

--- a/src/string_piece_util.cc
+++ b/src/string_piece_util.cc
@@ -15,8 +15,10 @@
 #include "string_piece_util.h"
 
 #include <algorithm>
+#include <cstring>
 #include <string>
 #include <vector>
+
 using namespace std;
 
 vector<StringPiece> SplitStringPiece(StringPiece input, char sep) {
@@ -75,4 +77,16 @@ bool EqualsCaseInsensitiveASCII(StringPiece a, StringPiece b) {
   }
 
   return true;
+}
+
+bool StringPieceLess::operator()(StringPiece lhs,
+                                 StringPiece rhs) const {
+
+  const std::size_t min_length = std::min(lhs.size(), rhs.size());
+  const int cmp = std::memcmp(lhs.str_, rhs.str_, min_length);
+  if (cmp == 0) {
+    return lhs.size() < rhs.size();
+  } else {
+    return cmp < 0;
+  }
 }

--- a/src/string_piece_util.h
+++ b/src/string_piece_util.h
@@ -30,4 +30,16 @@ inline char ToLowerASCII(char c) {
 
 bool EqualsCaseInsensitiveASCII(StringPiece a, StringPiece b);
 
+/// A comparator for StringPiece that can be used in
+/// `std::map<std::string, V, StringPieceLess>` that will allow using a
+/// StringPiece as a key.  Note that this compares elements of the
+/// strings as `unsigned char`, which means that implementations that
+/// have a signed `char` may give an unexpected (yet valid) ordering
+/// when iterating through a `std::map` containing negative `char`s.
+struct StringPieceLess {
+  using is_transparent = void;
+
+  bool operator()(StringPiece lhs, StringPiece rhs) const;
+};
+
 #endif  // NINJA_STRINGPIECE_UTIL_H_

--- a/src/string_piece_util_test.cc
+++ b/src/string_piece_util_test.cc
@@ -129,3 +129,18 @@ TEST(StringPieceUtilTest, EqualsCaseInsensitiveASCII) {
   EXPECT_FALSE(EqualsCaseInsensitiveASCII("/", "\\"));
   EXPECT_FALSE(EqualsCaseInsensitiveASCII("1", "10"));
 }
+
+
+TEST(StringPieceUtilTest, StringPieceLess) {
+  const std::vector<StringPiece> strings = {
+    "", "A", "AbC", "a", "abc", "c", "ca",
+  };
+  const StringPieceLess less;
+
+  for (int l = 0; l < strings.size(); ++l) {
+    for (int r = 0; r < strings.size(); ++r) {
+      EXPECT_EQ(less(strings[l], strings[r]), l < r)
+          << strings[l].AsString() << " < " << strings[r].AsString();
+    }
+  }
+}


### PR DESCRIPTION
Create a transparent comparator `StringPieceLess` that can allow us to lookup up values in a `std::map<std::string, V>` using a `StringPiece` without needing to create a temporary `std::string`.

Similarly, there are other methods on classes in `graph.h` that take a `std::string` that can work just fine with a `StringPiece` and avoid more temporaries.