### PR TITLE
Add a small speed up to `PathDecanonicalized`

### DIFF
--- a/src/graph.h
+++ b/src/graph.h
@@ -81,11 +81,11 @@ struct Node {
 
   const std::string& path() const { return path_; }
   /// Get |path()| but use slash_bits to convert back to original slash styles.
-  std::string PathDecanonicalized() const {
-    return PathDecanonicalized(path_, slash_bits_);
+  void AppendPathDecanonicalized(std::string* output) const {
+    return AppendPathDecanonicalized(output, path_, slash_bits_);
   }
-  static std::string PathDecanonicalized(const std::string& path,
-                                         uint64_t slash_bits);
+  static void AppendPathDecanonicalized(std::string* output, StringPiece path,
+                                        uint64_t slash_bits);
   uint64_t slash_bits() const { return slash_bits_; }
 
   TimeStamp mtime() const { return mtime_; }
@@ -122,7 +122,7 @@ private:
   std::string path_;
 
   /// Set bits starting from lowest for backslashes that were normalized to
-  /// forward slashes by CanonicalizePath. See |PathDecanonicalized|.
+  /// forward slashes by CanonicalizePath. See |AppendPathDecanonicalized|.
   uint64_t slash_bits_ = 0;
 
   /// Possible values of mtime_:

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -619,10 +619,35 @@ TEST_F(GraphTest, Decanonicalize) {
   EXPECT_EQ(root_nodes[1]->path(), "out/out2/out3/out4");
   EXPECT_EQ(root_nodes[2]->path(), "out3");
   EXPECT_EQ(root_nodes[3]->path(), "out4/foo");
-  EXPECT_EQ(root_nodes[0]->PathDecanonicalized(), "out\\out1");
-  EXPECT_EQ(root_nodes[1]->PathDecanonicalized(), "out\\out2/out3\\out4");
-  EXPECT_EQ(root_nodes[2]->PathDecanonicalized(), "out3");
-  EXPECT_EQ(root_nodes[3]->PathDecanonicalized(), "out4\\foo");
+
+  std::string decanon;
+  root_nodes[0]->AppendPathDecanonicalized(&decanon);
+  EXPECT_EQ(decanon, "out\\out1");
+
+  // Check we are indeed appending to the end
+  decanon = "text at the start:";
+  root_nodes[0]->AppendPathDecanonicalized(&decanon);
+  EXPECT_EQ(decanon, "text at the start:out\\out1");
+
+  decanon.clear();
+  root_nodes[1]->AppendPathDecanonicalized(&decanon);
+  EXPECT_EQ(decanon, "out\\out2/out3\\out4");
+
+  decanon.clear();
+  root_nodes[2]->AppendPathDecanonicalized(&decanon);
+  EXPECT_EQ(decanon, "out3");
+
+  decanon.clear();
+  root_nodes[3]->AppendPathDecanonicalized(&decanon);
+  EXPECT_EQ(decanon, "out4\\foo");
+
+  // In build.cc there is one place we pass `~0u` as the slash_bits
+  // because we assume the output is only backslashes and the existing
+  // code doesn't bother to calculate it.  Ensure this doesn't cause
+  // a problem by indicating there are more backslashes then there are.
+  decanon = "/path/=";
+  Node::AppendPathDecanonicalized(&decanon, "a/b/c", ~0u);
+  EXPECT_EQ(decanon, "/path/=a\\b\\c");
 }
 #endif
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -351,8 +351,9 @@ Node* NinjaMain::CollectTarget(const char* cpath, string* err) {
     }
     return node;
   } else {
-    *err =
-        "unknown target '" + Node::PathDecanonicalized(path, slash_bits) + "'";
+    *err = "unknown target '";
+    Node::AppendPathDecanonicalized(err, path, slash_bits);
+    *err += "'";
     if (path == "clean") {
       *err += ", did you mean 'ninja -t clean'?";
     } else if (path == "help") {


### PR DESCRIPTION
Avoid a mandatory allocation in `PathDecanonicalized` by taking an output `std::string*` to append to. Improve its performance by swapping `strchr` with `std::string::find`, which can take advantage of knowing the length of the string.

We can also return as soon as we run out of forwardslashes that need to be turned into backslashes, instead of iterating through all forwardslashes.

If backslashes are the common path separator in ninja build files on Windows, it may be worthwhile canonicalizing paths into backslashes-only, which would now allow us to skip the loop entirely in `PathDecanonicalized` in the case of paths with no forwardslashes.

Rename this function to `AppendPathDecanonicalized` to reflect its new functionality.

Running `manifest_parser_perftest.exe` on Windows gives initial timings of:

    min 549ms  max 613ms  avg 573.1ms

and timings after this change of:

    min 534ms  max 597ms  avg 559.9ms

which is a 2-3% improvement.