### PR TITLE
Optimize `IncludesNormalize`

### DIFF
--- a/src/includes_normalize-win32.cc
+++ b/src/includes_normalize-win32.cc
@@ -19,32 +19,32 @@
 #include "util.h"
 
 #include <algorithm>
+#include <cassert>
 #include <iterator>
 #include <sstream>
 
 #include <windows.h>
 
-using namespace std;
-
 namespace {
 
-bool InternalGetFullPathName(const StringPiece& file_name, char* buffer,
-                             size_t buffer_length, string *err) {
-  DWORD result_size = GetFullPathNameA(file_name.AsString().c_str(),
-                                       buffer_length, buffer, NULL);
+bool InternalGetFullPathName(const char* file_name, char* buffer,
+                             std::size_t buffer_length, std::size_t* new_len,
+                             std::string* err) {
+  DWORD result_size = GetFullPathNameA(file_name, buffer_length, buffer, NULL);
   if (result_size == 0) {
-    *err = "GetFullPathNameA(" + file_name.AsString() + "): " +
-        GetLastErrorString();
+    *err = "GetFullPathNameA(";
+    *err += file_name;
+    *err += "): ";
+    *err += GetLastErrorString();
     return false;
   } else if (result_size > buffer_length) {
     *err = "path too long";
     return false;
   }
+  if (new_len) {
+    *new_len = result_size;
+  }
   return true;
-}
-
-bool IsPathSeparator(char c) {
-  return c == '/' ||  c == '\\';
 }
 
 // Return true if paths a and b are on the same windows drive.
@@ -67,25 +67,27 @@ bool SameDriveFast(StringPiece a, StringPiece b) {
     return false;
   }
 
-  return IsPathSeparator(a[2]) && IsPathSeparator(b[2]);
+  return a[2] == '/' && b[2] == '/';
 }
 
 // Return true if paths a and b are on the same Windows drive.
-bool SameDrive(StringPiece a, StringPiece b, string* err)  {
+bool SameDrive(const std::string& a, const std::string& b, std::string* err)  {
   if (SameDriveFast(a, b)) {
     return true;
   }
 
   char a_absolute[_MAX_PATH];
   char b_absolute[_MAX_PATH];
-  if (!InternalGetFullPathName(a, a_absolute, sizeof(a_absolute), err)) {
+  if (!InternalGetFullPathName(a.c_str(), a_absolute, sizeof(a_absolute),
+                               nullptr, err)) {
     return false;
   }
-  if (!InternalGetFullPathName(b, b_absolute, sizeof(b_absolute), err)) {
+  if (!InternalGetFullPathName(b.c_str(), b_absolute, sizeof(b_absolute),
+                               nullptr, err)) {
     return false;
   }
-  char a_drive[_MAX_DIR];
-  char b_drive[_MAX_DIR];
+  char a_drive[_MAX_DRIVE];
+  char b_drive[_MAX_DRIVE];
   _splitpath(a_absolute, a_drive, NULL, NULL, NULL);
   _splitpath(b_absolute, b_drive, NULL, NULL, NULL);
   return _stricmp(a_drive, b_drive) == 0;
@@ -95,116 +97,204 @@ bool SameDrive(StringPiece a, StringPiece b, string* err)  {
 // This ignores difference of path separator.
 // This is used not to call very slow GetFullPathName API.
 bool IsFullPathName(StringPiece s) {
-  if (s.size() < 3 ||
-      !islatinalpha(s[0]) ||
-      s[1] != ':' ||
-      !IsPathSeparator(s[2])) {
-    return false;
-  }
-
-  // Check "." or ".." is contained in path.
-  for (size_t i = 2; i < s.size(); ++i) {
-    if (!IsPathSeparator(s[i])) {
-      continue;
-    }
-
-    // Check ".".
-    if (i + 1 < s.size() && s[i+1] == '.' &&
-        (i + 2 >= s.size() || IsPathSeparator(s[i+2]))) {
-      return false;
-    }
-
-    // Check "..".
-    if (i + 2 < s.size() && s[i+1] == '.' && s[i+2] == '.' &&
-        (i + 3 >= s.size() || IsPathSeparator(s[i+3]))) {
-      return false;
-    }
-  }
-
-  return true;
+  return s.size() >= 3 && islatinalpha(s[0]) && s[1] == ':' && s[2] == '/';
 }
+
+#ifdef NDEBUG
+void AssertIsAbsoluteInDebug(StringPiece) {
+#else
+void AssertIsAbsoluteInDebug(StringPiece s) {
+  std::string err;
+  std::string copy = s.AsString();
+  IncludesNormalize::MakePathAbsolute(&copy, &err);
+  assert(StringPiece(copy) == s);
+#endif
+}
+
+#ifdef NDEBUG
+void AssertIsCanonicalInDebug(StringPiece) {
+#else
+void AssertIsCanonicalInDebug(StringPiece original) {
+  std::string actual = original.AsString();
+  std::uint64_t slash_bits;
+  CanonicalizePath(&actual, &slash_bits);
+  assert(StringPiece(actual) == original);
+#endif
+}
+
+struct StringPieceRange {
+  struct const_iterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type        = StringPiece;
+    using difference_type   = std::ptrdiff_t;
+    using pointer           = const StringPiece*;
+    using reference         = const StringPiece&;
+
+    const_iterator(StringPiece str, const char *end, char sep)
+        : str_(str), end_(end), sep_(sep) {}
+
+    const_iterator& operator++() {
+      if (str_.end() == end_) {
+        str_ = StringPiece();
+      } else {
+        const char* start = str_.end() + 1;
+        const char* slash =
+            static_cast<const char*>(memchr(start, '/', end_ - start));
+        const std::size_t len = slash ? slash - start : end_ - start;
+        str_ = StringPiece(start, len);
+      }
+      return *this;
+    }
+
+    reference operator*() const {
+      return str_;
+    }
+
+    pointer operator->() const { return &str_; }
+
+    friend bool operator==(
+        const const_iterator& lhs, const const_iterator& rhs) {
+      return lhs.str_.str_ == rhs.str_.str_;
+    }
+
+    friend bool operator!=(
+        const const_iterator& lhs, const const_iterator& rhs) {
+      return !(lhs == rhs);
+    }
+
+    StringPiece str_;
+    const char* end_;
+    char sep_;
+  };
+
+  StringPieceRange(StringPiece str, char sep)
+    : str_(str), sep_(sep) {}
+
+  const_iterator begin() const {
+    const char* slash =
+        static_cast<const char*>(memchr(str_.begin(), '/', str_.size()));
+    const std::size_t len = slash ? slash - str_.begin() : str_.size();
+    return const_iterator(StringPiece(str_.begin(), len), str_.end(), sep_);
+  }
+
+  const_iterator end() const {
+    return const_iterator(StringPiece(), str_.end(), sep_);
+  }
+
+  StringPiece str_;
+  char sep_;
+};
 
 }  // anonymous namespace
 
-IncludesNormalize::IncludesNormalize(const string& relative_to) {
-  string err;
-  relative_to_ = AbsPath(relative_to, &err);
-  if (!err.empty()) {
+IncludesNormalize::IncludesNormalize(StringPiece relative_to)
+ : relative_to_(relative_to.str_, relative_to.len_) {
+  std::uint64_t slash_bits;
+  CanonicalizePath(&relative_to_, &slash_bits);
+  std::string err;
+  if (!MakePathAbsolute(&relative_to_, &err)) {
     Fatal("Initializing IncludesNormalize(): %s", err.c_str());
   }
-  split_relative_to_ = SplitStringPiece(relative_to_, '/');
+  const StringPieceRange components(relative_to_, '/');
+  split_relative_to_.assign(components.begin(), components.end());
 }
 
-string IncludesNormalize::AbsPath(StringPiece s, string* err) {
-  if (IsFullPathName(s)) {
-    string result = s.AsString();
-    for (size_t i = 0; i < result.size(); ++i) {
-      if (result[i] == '\\') {
-        result[i] = '/';
-      }
-    }
-    return result;
+bool IncludesNormalize::MakePathAbsolute(std::string* s, std::string* err) {
+  AssertIsCanonicalInDebug(*s);
+  if (IsFullPathName(*s)) {
+    return true;
   }
 
+  std::size_t len;
   char result[_MAX_PATH];
-  if (!InternalGetFullPathName(s, result, sizeof(result), err)) {
-    return "";
+  if (!InternalGetFullPathName(s->c_str(), result, sizeof(result), &len, err)) {
+    s->clear();
+    return false;
   }
-  for (char* c = result; *c; ++c)
-    if (*c == '\\')
-      *c = '/';
-  return result;
+
+  // Fixup all backslashes with forward slashes introduced with `GetFullPathNameA`.
+  char* bs = result;
+  const char* end = result + len;
+  while ((bs = static_cast<char*>(memchr(bs, '\\', end - bs))) !=
+         nullptr) {
+    *bs++ = '/';
+  }
+  s->assign(result, len);
+  return true;
 }
 
-string IncludesNormalize::Relativize(
-    StringPiece path, const vector<StringPiece>& start_list, string* err) {
-  string abs_path = AbsPath(path, err);
-  if (!err->empty())
-    return "";
-  vector<StringPiece> path_list = SplitStringPiece(abs_path, '/');
-  int i;
-  for (i = 0; i < static_cast<int>(min(start_list.size(), path_list.size()));
-       ++i) {
-    if (!EqualsCaseInsensitiveASCII(start_list[i], path_list[i])) {
-      break;
+void IncludesNormalize::Relativize(std::string* abs_path,
+                                   const std::vector<StringPiece>& start_list) {
+  AssertIsAbsoluteInDebug(*abs_path);
+  AssertIsCanonicalInDebug(*abs_path);
+
+  const StringPieceRange path_list(*abs_path, '/');
+
+  // `Relativize` only callable when `abs_path` and `start_list` are on the
+  // same drive.  Skip comparing them each time and start from the 2nd
+  // component.
+  assert(EqualsCaseInsensitiveASCII(*path_list.begin(), *start_list.begin()));
+  const auto diff = std::mismatch(std::next(path_list.begin()), path_list.end(),
+                                  std::next(start_list.begin()),
+                                  start_list.end(), EqualsCaseInsensitiveASCII);
+
+  // The length of the common path prefix, in abs_path characters.
+  const std::size_t common_prefix_len =
+      (diff.first == path_list.end()) ? abs_path->size()
+                                      : diff.first->str_ - abs_path->data();
+
+  // The number of ../ to be inserted at the start of the result, corresponding
+  // to the number of path segments after the common prefix from start_list.
+  const std::size_t dotdot_count = start_list.end() - diff.second;
+
+  const std::size_t dotdot_len = 3 * dotdot_count;
+
+  // The following must remove the common prefix characters, then prepend
+  // a sequence of |dotdot_count| "../" segments into the result. The end result
+  // is [<dotdot_len>][<non_common_path>].
+
+  // First relocate the non common path to the right position, removing
+  // or inserting bytes if needed.
+  if (common_prefix_len > dotdot_len) {
+    abs_path->erase(0, common_prefix_len - dotdot_len);
+  } else if (common_prefix_len < dotdot_len) {
+    abs_path->insert(0, dotdot_len - common_prefix_len, '\0');
+  }
+
+  if (abs_path->empty()) {
+    *abs_path = '.';
+  } else {
+    // Now write the ../ sequence in place.
+    char* data = &*abs_path->begin();
+    for (std::size_t remaining = dotdot_count; remaining > 0; --remaining) {
+      memcpy(data, "../", 3);
+      data += 3;
     }
   }
-
-  vector<StringPiece> rel_list;
-  rel_list.reserve(start_list.size() - i + path_list.size() - i);
-  for (int j = 0; j < static_cast<int>(start_list.size() - i); ++j)
-    rel_list.push_back("..");
-  for (int j = i; j < static_cast<int>(path_list.size()); ++j)
-    rel_list.push_back(path_list[j]);
-  if (rel_list.size() == 0)
-    return ".";
-  return JoinStringPiece(rel_list, '/');
 }
 
-bool IncludesNormalize::Normalize(const string& input,
-                                  string* result, string* err) const {
+bool IncludesNormalize::Normalize(StringPiece input, std::string* result,
+                                  std::string* err) const {
   char copy[_MAX_PATH + 1];
-  size_t len = input.size();
+  std::size_t len = input.size();
   if (len > _MAX_PATH) {
     *err = "path too long";
     return false;
   }
-  strncpy(copy, input.c_str(), input.size() + 1);
-  uint64_t slash_bits;
+  strncpy(copy, input.str_, input.len_);
+  copy[len] = '\0';
+  std::uint64_t slash_bits;
   CanonicalizePath(copy, &len, &slash_bits);
-  StringPiece partially_fixed(copy, len);
-  string abs_input = AbsPath(partially_fixed, err);
-  if (!err->empty())
+  result->assign(copy, len);
+  if (!MakePathAbsolute(result, err))
     return false;
 
-  if (!SameDrive(abs_input, relative_to_, err)) {
+  if (!SameDrive(*result, relative_to_, err)) {
     if (!err->empty())
       return false;
-    *result = partially_fixed.AsString();
+    result->assign(copy, len);
     return true;
   }
-  *result = Relativize(abs_input, split_relative_to_, err);
-  if (!err->empty())
-    return false;
+  Relativize(result, split_relative_to_);
   return true;
 }

--- a/src/includes_normalize.h
+++ b/src/includes_normalize.h
@@ -21,20 +21,26 @@
 struct StringPiece;
 
 /// Utility functions for normalizing include paths on Windows.
-/// TODO: this likely duplicates functionality of CanonicalizePath; refactor.
 struct IncludesNormalize {
   /// Normalize path relative to |relative_to|.
-  IncludesNormalize(const std::string& relative_to);
+  IncludesNormalize(StringPiece relative_to);
 
   // Internal utilities made available for testing, maybe useful otherwise.
-  static std::string AbsPath(StringPiece s, std::string* err);
-  static std::string Relativize(StringPiece path,
-                                const std::vector<StringPiece>& start_list,
-                                std::string* err);
+  /// Make \a `path` absolute and return whether it was successful. On failure,
+  /// load an error message to \a `err`.
+  /// \pre `path` must be in the canonical form, see `CanonicalizePath`.
+  static bool MakePathAbsolute(std::string* path, std::string* err);
+
+  /// Make the \a `abs_path` variable relative to the path components in
+  /// \a `start_list`.
+  /// \pre `abs_path` and `start_list` must both be absolute paths on the same
+  /// drive, and in the canonical form, see `CanonicalizePath`.
+  static void Relativize(std::string* abs_path,
+                         const std::vector<StringPiece>& start_list);
 
   /// Normalize by fixing slashes style, fixing redundant .. and . and makes the
   /// path |input| relative to |this->relative_to_| and store to |result|.
-  bool Normalize(const std::string& input, std::string* result,
+  bool Normalize(StringPiece input, std::string* result,
                  std::string* err) const;
 
  private:

--- a/src/includes_normalize_test.cc
+++ b/src/includes_normalize_test.cc
@@ -33,7 +33,7 @@ string GetCurDir() {
   return parts[parts.size() - 1].AsString();
 }
 
-string NormalizeAndCheckNoError(const string& input) {
+string NormalizeAndCheckNoError(StringPiece input) {
   string result, err;
   IncludesNormalize normalizer(".");
   EXPECT_TRUE(normalizer.Normalize(input, &result, &err));
@@ -41,8 +41,8 @@ string NormalizeAndCheckNoError(const string& input) {
   return result;
 }
 
-string NormalizeRelativeAndCheckNoError(const string& input,
-                                        const string& relative_to) {
+string NormalizeRelativeAndCheckNoError(StringPiece input,
+                                        StringPiece relative_to) {
   string result, err;
   IncludesNormalize normalizer(relative_to);
   EXPECT_TRUE(normalizer.Normalize(input, &result, &err));
@@ -57,14 +57,17 @@ TEST(IncludesNormalize, Simple) {
   EXPECT_EQ("b", NormalizeAndCheckNoError("a\\../b"));
   EXPECT_EQ("a/b", NormalizeAndCheckNoError("a\\.\\b"));
   EXPECT_EQ("a/b", NormalizeAndCheckNoError("a\\./b"));
+  EXPECT_EQ("../b", NormalizeAndCheckNoError("a/../../b"));
 }
 
 TEST(IncludesNormalize, WithRelative) {
   string err;
   string currentdir = GetCurDir();
+
   EXPECT_EQ("c", NormalizeRelativeAndCheckNoError("a/b/c", "a/b"));
-  EXPECT_EQ("a",
-            NormalizeAndCheckNoError(IncludesNormalize::AbsPath("a", &err)));
+  string absA = "a";
+  IncludesNormalize::MakePathAbsolute(&absA, &err);
+  EXPECT_EQ("a", NormalizeAndCheckNoError(absA));
   EXPECT_EQ("", err);
   EXPECT_EQ(string("../") + currentdir + string("/a"),
             NormalizeRelativeAndCheckNoError("a", "../b"));
@@ -97,6 +100,9 @@ TEST(IncludesNormalize, DifferentDrive) {
   EXPECT_EQ("P:/wee/stuff.h",
             NormalizeRelativeAndCheckNoError("P:/vs08\\../wee\\stuff.h",
                                              "D:\\stuff/things"));
+  EXPECT_EQ(".", NormalizeAndCheckNoError("P:\\.."));
+  EXPECT_EQ("a", NormalizeAndCheckNoError("P:\\../a"));
+  EXPECT_EQ("P:/a", NormalizeAndCheckNoError("P:\\a//.//b/.."));
 }
 
 TEST(IncludesNormalize, LongInvalidPath) {

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -220,6 +220,10 @@ TEST(CanonicalizePath, PathSamplesWindows) {
   path = "\\";
   CanonicalizePath(&path);
   EXPECT_EQ("/", path);
+
+  path = "C:\\..\\./foo";
+  CanonicalizePath(&path);
+  EXPECT_EQ("foo", path);
 }
 
 TEST(CanonicalizePath, SlashTracking) {


### PR DESCRIPTION
Achieve a 2x speedup in `clparser_perftest.exe` by optimizing `IncludesNormalize`.

Before:

    Parse 16384 times in 2917ms avg 178.0us

After:

    Parse 32768 times in 2685ms avg 81.9us

In particular:

  * Take string as `StringPiece` if possible to avoid `std::string` copies.
  * Swap the `StringPiece` argument in `InternalGetFullPathName` to `const std::string&` as we need a `null`-terminated string and this avoids allocating a temporary within the function.
  * Use `_MAX_DRIVE` instead of `_MAX_DIR` (3 vs 256)
  * `IsPathSeparator` has been removed and we check only against `'/'` because all paths are canonical and do not contain `'\\'`
  * `IsFullPathName` is run only on canonical paths, so there is never going to be a "./" component, and the only "../" components will appear at the beginning of the string (unit tests added to confirm). Avoid iterating through the entire string and just look at the start.
  * `AbsPath` is only run against canonical paths so there's no need to replace backslashes unless we get a new path from `GetFullPathNameA` - and even in this case we can use `memchr` for performance.
  * `Relativize` has been rewritten to avoid almost all allocations and to lazily parse the path components until a mismatch has been found.