### PR TITLE
Allow UTF-8 emoji characters in NINJA_STATUS

### DIFF
--- a/src/elide_middle.cc
+++ b/src/elide_middle.cc
@@ -15,7 +15,161 @@
 #include "elide_middle.h"
 
 #include <assert.h>
+#include <stdint.h>
 #include <string.h>
+
+namespace {
+
+size_t Utf8CharSize(const char* ptr, const char* end) {
+  // Decode the leading byte using UTF-8 prefix masks:
+  // 0xxxxxxx (0x80)      -> 1 byte
+  // 110xxxxx (0xE0/0xC0) -> 2 bytes
+  // 1110xxxx (0xF0/0xE0) -> 3 bytes
+  // 11110xxx (0xF8/0xF0) -> 4 bytes
+  const unsigned char lead = static_cast<unsigned char>(*ptr);
+  if (lead < 0x80)
+    return 1;
+
+  size_t size = 0;
+  if ((lead & 0xE0) == 0xC0) {
+    size = 2;
+  } else if ((lead & 0xF0) == 0xE0) {
+    size = 3;
+  } else if ((lead & 0xF8) == 0xF0) {
+    size = 4;
+  } else {
+    // Invalid leading byte, fall back to single-byte consumption.
+    return 1;
+  }
+
+  if (ptr + size > end)
+    return 1;
+
+  // Validate UTF-8 continuation bytes (10xxxxxx).
+  for (size_t i = 1; i < size; ++i) {
+    const unsigned char ch = static_cast<unsigned char>(ptr[i]);
+    if ((ch & 0xC0) != 0x80)
+      return 1;
+  }
+
+  return size;
+}
+
+uint32_t Utf8Decode(const char* ptr, const char* end, size_t* size) {
+  // Determine sequence length and decode the codepoint from UTF-8 bytes.
+  *size = Utf8CharSize(ptr, end);
+  const unsigned char lead = static_cast<unsigned char>(*ptr);
+  if (*size == 1) {
+    // ASCII or invalid byte (map invalid to U+FFFD).
+    return lead < 0x80 ? lead : 0xFFFD;
+  }
+  if (*size == 2) {
+    // 110xxxxx 10xxxxxx
+    return ((lead & 0x1F) << 6) |
+           (static_cast<unsigned char>(ptr[1]) & 0x3F);
+  }
+  if (*size == 3) {
+    // 1110xxxx 10xxxxxx 10xxxxxx
+    return ((lead & 0x0F) << 12) |
+           ((static_cast<unsigned char>(ptr[1]) & 0x3F) << 6) |
+           (static_cast<unsigned char>(ptr[2]) & 0x3F);
+  }
+  // 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+  return ((lead & 0x07) << 18) |
+         ((static_cast<unsigned char>(ptr[1]) & 0x3F) << 12) |
+         ((static_cast<unsigned char>(ptr[2]) & 0x3F) << 6) |
+         (static_cast<unsigned char>(ptr[3]) & 0x3F);
+}
+
+// Returns terminal column width for a decoded Unicode codepoint.
+size_t Utf8CodepointWidth(uint32_t ucs) {
+  // NUL has no printable width.
+  if (ucs == 0)
+    return 0;
+  // Zero-width joiner and variation selectors render no columns.
+  if (ucs == 0x200D || (ucs >= 0xFE00 && ucs <= 0xFE0F))
+    return 0;
+  // C0/C1 control ranges are non-printing.
+  if (ucs < 32 || (ucs >= 0x7F && ucs < 0xA0))
+    return 0;
+  // Treat common emoji ranges as double-width.
+  if ((ucs >= 0x1F300 && ucs <= 0x1FAFF) ||
+      (ucs >= 0x2600 && ucs <= 0x27BF) ||
+      (ucs >= 0x2300 && ucs <= 0x23FF)) {
+    return 2;
+  }
+  // Default to single-column width.
+  return 1;
+}
+
+size_t Utf8VisibleWidth(const std::string& input) {
+  const char* ptr = input.data();
+  const char* end = ptr + input.size();
+  size_t width = 0;
+  while (ptr < end) {
+    size_t size = 0;
+    const uint32_t codepoint = Utf8Decode(ptr, end, &size);
+    ptr += size;
+    width += Utf8CodepointWidth(codepoint);
+  }
+  return width;
+}
+
+// Returns byte index for a given visible column boundary.
+// If |ceil| is false, the index stops before crossing the boundary.
+// If |ceil| is true, the index advances to the next visible boundary.
+size_t Utf8ByteIndexForVisiblePos(const std::string& input,
+                                  size_t visible_pos,
+                                  bool ceil) {
+  if (visible_pos == 0)
+    return 0;
+  const char* ptr = input.data();
+  const char* end = ptr + input.size();
+  size_t width = 0;
+  size_t index = 0;
+  while (ptr < end) {
+    size_t size = 0;
+    const uint32_t codepoint = Utf8Decode(ptr, end, &size);
+    const size_t char_width = Utf8CodepointWidth(codepoint);
+    // For floor, stop before crossing the requested visible column.
+    if (!ceil && char_width > 0 && width + char_width > visible_pos)
+      break;
+    // For ceil, always advance until the column is at or past the target.
+    ptr += size;
+    index += size;
+    width += char_width;
+    // Stop once we've reached the boundary on a visible character.
+    if (char_width > 0 && width >= visible_pos)
+      break;
+  }
+  // Include trailing zero-width codepoints (e.g. variation selectors)
+  // that immediately follow a visible character.
+  while (ptr < end) {
+    size_t size = 0;
+    const uint32_t codepoint = Utf8Decode(ptr, end, &size);
+    if (Utf8CodepointWidth(codepoint) != 0)
+      break;
+    ptr += size;
+    index += size;
+  }
+  return index;
+}
+
+// Byte index for the last codepoint fully before |visible_pos|, using
+// UTF-8 decoding to map visible column positions to byte offsets.
+size_t Utf8ByteIndexForVisiblePosFloor(const std::string& input,
+                                       size_t visible_pos) {
+  return Utf8ByteIndexForVisiblePos(input, visible_pos, false);
+}
+
+// Byte index for the first codepoint at or after |visible_pos|, using
+// UTF-8 decoding to map visible column positions to byte offsets.
+size_t Utf8ByteIndexForVisiblePosCeil(const std::string& input,
+                                      size_t visible_pos) {
+  return Utf8ByteIndexForVisiblePos(input, visible_pos, true);
+}
+
+}  // namespace
 
 // Convenience class used to iterate over the ANSI color sequences
 // of an input string. Note that this ignores non-color related
@@ -152,7 +306,12 @@ struct AnsiColorSequenceIterator {
 //
 struct VisibleInputCharsIterator {
   VisibleInputCharsIterator(const std::string& input)
-      : input_size_(input.size()), ansi_iter_(input) {}
+      : input_(input.data()),
+        input_end_(input_ + input.size()),
+        input_size_(input.size()),
+        ansi_iter_(input) {
+    UpdateCurrent();
+  }
 
   // Return true if there is a character in the sequence.
   bool HasChar() const { return input_index_ < input_size_; }
@@ -165,30 +324,68 @@ struct VisibleInputCharsIterator {
 
   // Return true if the current input character is visible
   // (i.e. not part of an ANSI color sequence).
-  bool IsVisible() const { return !ansi_iter_.SequenceContains(input_index_); }
+  bool IsVisible() const { return current_is_visible_; }
+
+  // Return terminal column width of the current visible character.
+  size_t VisibleWidth() const { return current_visible_width_; }
+
+  // Return size in bytes of current input character or ANSI sequence.
+  size_t InputSize() const { return current_size_; }
 
   // Find next character from the input.
   void NextChar() {
-    visible_pos_ += IsVisible();
-    if (++input_index_ == ansi_iter_.SequenceEnd()) {
-      ansi_iter_.NextSequence();
-    }
+    visible_pos_ += current_visible_width_;
+    input_index_ += current_size_;
+    UpdateCurrent();
   }
 
  private:
+  void UpdateCurrent() {
+    if (input_index_ >= input_size_) {
+      current_size_ = 0;
+      current_is_visible_ = false;
+      current_visible_width_ = 0;
+      return;
+    }
+
+    if (ansi_iter_.HasSequence() &&
+        input_index_ == ansi_iter_.SequenceStart()) {
+      // Skip entire ANSI color sequences as zero-width.
+      current_is_visible_ = false;
+      current_size_ = ansi_iter_.SequenceSize();
+      current_visible_width_ = 0;
+      ansi_iter_.NextSequence();
+      return;
+    }
+
+    // Consume a single UTF-8 codepoint and compute its display width.
+    current_is_visible_ = true;
+    size_t size = 0;
+    const uint32_t codepoint =
+        Utf8Decode(input_ + input_index_, input_end_, &size);
+    current_size_ = size;
+    current_visible_width_ = Utf8CodepointWidth(codepoint);
+  }
+
+  const char* input_;
+  const char* input_end_;
   size_t input_size_;
   size_t input_index_ = 0;
   size_t visible_pos_ = 0;
+  size_t current_size_ = 0;
+  size_t current_visible_width_ = 0;
+  bool current_is_visible_ = false;
   AnsiColorSequenceIterator ansi_iter_;
 };
 
 void ElideMiddleInPlace(std::string& str, size_t max_width) {
-  if (str.size() <= max_width) {
-    return;
-  }
   // Look for an ESC character. If there is none, use a fast path
   // that avoids any intermediate allocations.
   if (str.find('\x1b') == std::string::npos) {
+    const size_t visible_width = Utf8VisibleWidth(str);
+    if (visible_width <= max_width)
+      return;
+
     const int ellipsis_width = 3;  // Space for "...".
 
     // If max width is too small, do not keep anything from the input.
@@ -204,18 +401,18 @@ void ElideMiddleInPlace(std::string& str, size_t max_width) {
     const size_t right_span_size = remaining_size - left_span_size;
 
     // Replace the gap in the input between the spans with "..."
-    const size_t gap_start = left_span_size;
-    const size_t gap_end = str.size() - right_span_size;
+    const size_t gap_start =
+        Utf8ByteIndexForVisiblePosFloor(str, left_span_size);
+    const size_t gap_end =
+        Utf8ByteIndexForVisiblePosCeil(str, visible_width - right_span_size);
     str.replace(gap_start, gap_end - gap_start, "...");
     return;
   }
 
   // Compute visible width.
-  size_t visible_width = str.size();
-  for (AnsiColorSequenceIterator ansi(str); ansi.HasSequence();
-       ansi.NextSequence()) {
-    visible_width -= ansi.SequenceSize();
-  }
+  size_t visible_width = 0;
+  for (VisibleInputCharsIterator iter(str); iter.HasChar(); iter.NextChar())
+    visible_width += iter.VisibleWidth();
 
   if (visible_width <= max_width)
     return;
@@ -230,7 +427,29 @@ void ElideMiddleInPlace(std::string& str, size_t max_width) {
   // Compute the gap of visible characters that will be replaced by
   // the ellipsis in visible space.
   const size_t visible_gap_start = visible_left_span_size;
-  const size_t visible_gap_end = visible_width - visible_right_span_size;
+  size_t visible_gap_end = visible_width - visible_right_span_size;
+
+  // Round the right span start forward to the next character boundary to
+  // avoid splitting wide codepoints.
+  if (visible_gap_end > 0 && visible_gap_end < visible_width) {
+    size_t adjusted_gap_end = visible_gap_end;
+    for (VisibleInputCharsIterator gap_iter(str); gap_iter.HasChar();
+         gap_iter.NextChar()) {
+      const size_t pos = gap_iter.VisiblePosition();
+      const size_t width = gap_iter.VisibleWidth();
+      if (width == 0)
+        continue;
+      if (pos == visible_gap_end) {
+        adjusted_gap_end = visible_gap_end;
+        break;
+      }
+      if (pos + width >= visible_gap_end) {
+        adjusted_gap_end = pos + width;
+        break;
+      }
+    }
+    visible_gap_end = adjusted_gap_end;
+  }
 
   std::string result;
   result.reserve(str.size());
@@ -253,7 +472,11 @@ void ElideMiddleInPlace(std::string& str, size_t max_width) {
 
   // Step 1 - determine left span length in input chars.
   for (; iter.HasChar(); iter.NextChar()) {
-    if (iter.VisiblePosition() == visible_gap_start)
+    const size_t pos = iter.VisiblePosition();
+    const size_t width = iter.VisibleWidth();
+    if (!iter.IsVisible() && pos == visible_gap_start)
+      break;
+    if (width > 0 && pos + width > visible_gap_start)
       break;
   }
   result.append(str.begin(), str.begin() + iter.InputIndex());
@@ -263,10 +486,14 @@ void ElideMiddleInPlace(std::string& str, size_t max_width) {
 
   // Step 3 - Append elided ANSI sequences to the result.
   for (; iter.HasChar(); iter.NextChar()) {
-    if (iter.VisiblePosition() == visible_gap_end)
+    const size_t pos = iter.VisiblePosition();
+    const size_t width = iter.VisibleWidth();
+    if (!iter.IsVisible() && pos == visible_gap_end)
+      break;
+    if (width > 0 && pos + width > visible_gap_end)
       break;
     if (!iter.IsVisible())
-      result.push_back(str[iter.InputIndex()]);
+      result.append(str.data() + iter.InputIndex(), iter.InputSize());
   }
 
   // Step 4 - Append anything else.

--- a/src/elide_middle_test.cc
+++ b/src/elide_middle_test.cc
@@ -48,6 +48,20 @@ TEST(ElideMiddle, ElideInTheMiddle) {
   EXPECT_EQ("01234567890123456789", ElideMiddle(input, 20));
 }
 
+TEST(ElideMiddle, Utf8EmojiWidth) {
+  const char* kThread = "\xF0\x9F\xA7\xB5";  // 🧵
+  const char* kStopwatch = "\xE2\x8F\xB1\xEF\xB8\x8F";  // ⏱️ (with VS16)
+  std::string input = std::string("A") + kThread + "B";
+  EXPECT_EQ(input, ElideMiddle(input, 4));
+  EXPECT_EQ("...", ElideMiddle(input, 3));
+
+  input = std::string("A") + kStopwatch + "B";
+  EXPECT_EQ(input, ElideMiddle(input, 4));
+
+  input = std::string("0") + kThread + "1234567";
+  EXPECT_EQ(std::string("0") + kThread + "...567", ElideMiddle(input, 9));
+}
+
 // A few ANSI escape sequences. These macros make the following
 // test easier to read and understand.
 #define MAGENTA "\x1B[0;35m"
@@ -93,6 +107,12 @@ TEST(ElideMiddle, ElideAnsiEscapeCodes) {
   EXPECT_EQ("ab..." RED RESET "BC", ElideMiddle(input, 7));
   EXPECT_EQ("ab..." RED "A" RESET "BC", ElideMiddle(input, 8));
   EXPECT_EQ("abcdef" RED "A" RESET "BC", ElideMiddle(input, 9));
+}
+
+TEST(ElideMiddle, Utf8EmojiWithAnsi) {
+  const char* kThread = "\xF0\x9F\xA7\xB5";  // 🧵
+  std::string input = std::string("A") + RED + kThread + RESET + "B";
+  EXPECT_EQ(input, ElideMiddle(input, 4));
 }
 
 #undef RESET


### PR DESCRIPTION
Add UTF-8 parsing code to allow UTF-8 encoded emojis in NINJA_STATUS. In #2428, support was added for parsing ANSI colors, so that the correct terminal width was observed. This patch is similar in nature, and allows UTF-8 emojis to be used whilst still using the full width of the terminal window.

I've had to add quite a bit of UTF-8 parsing code, so we don't misparse UTF-8 glyphs. `ElideMiddle` now decodes UTF-8 codepoints and assigns terminal column widths with a small emoji-width heuristic, while treating ZWJ and variation selectors as zero-width.

This code assumes common emoji and pictograph ranges render as double-width and everything else is single-width unless it is a control character. I would use `wcwidth()`, but AFAIK, this isn't available on Windows.

I've added some new tests for this functionality, and all the existing tests continue to pass.

Fixes #2728