### PR TITLE
"ninja -t restat" doesn't work with "builddir"

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -397,6 +397,9 @@ _Available since Ninja 1.11._
 
 `restat`:: updates all recorded file modification timestamps in the `.ninja_log`
 file. _Available since Ninja 1.10._
++
+The build manifest won't be parsed when running this tool. If you're using a
+`builddir` you must pass it via `--builddir=DIR`. _Available since Ninja 1.14._
 
 `rules`:: output the list of all rules. It can be used to know which rule name
 to pass to +ninja -t targets rule _name_+ or +ninja -t compdb+. Adding the `-d`

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1114,19 +1114,24 @@ int NinjaMain::ToolRestat(const Options* options, int argc, char* argv[]) {
 
   optind = 1;
   int opt;
-  while ((opt = getopt(argc, argv, const_cast<char*>("h"))) != -1) {
+  const option kLongOptions[] = { { "builddir", required_argument, nullptr,
+                                    'b' },
+                                  { "help", no_argument, nullptr, 'h' },
+                                  { nullptr, 0, nullptr, 0 } };
+  while ((opt = getopt_long(argc, argv, const_cast<char*>("h"), kLongOptions,
+                            nullptr)) != -1) {
     switch (opt) {
+    case 'b':
+      build_dir_ = optarg;
+      break;
     case 'h':
     default:
-      printf("usage: ninja -t restat [outputs]\n");
+      printf("usage: ninja -t restat [--builddir=DIR] [outputs]\n");
       return 1;
     }
   }
   argv += optind;
   argc -= optind;
-
-  if (!EnsureBuildDirExists())
-    return 1;
 
   string log_path = ".ninja_log";
   if (!build_dir_.empty())

--- a/tests/restat/test_restat_builddir.py
+++ b/tests/restat/test_restat_builddir.py
@@ -90,7 +90,9 @@ build output.txt: touch
 
         # Run ninja -t restat
         result = subprocess.run(
-            [NINJA_PATH, "-t", "restat"], capture_output=True, text=True
+            [NINJA_PATH, "-t", "restat", "--builddir=build"],
+            capture_output=True,
+            text=True,
         )
         self.assertEqual(
             result.returncode, 0, f"ninja -t restat failed: {result.stderr}"


### PR DESCRIPTION
When specifying "builddir = foo" in the manifest ninja -t restat doesn't work because the tool skips parsing the manifest for performance reasons. Maybe we should parse it but stop as soon as we have the builddir which is often at the beginning of the file.