### PR TITLE
fix: replace 2 bare except clauses with except Exception

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -383,7 +383,7 @@ else:
             stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
         if proc.wait() == 0:
             cflags += ['-fdiagnostics-color']
-    except:
+    except Exception:
         pass
     if platform.is_mingw():
         cflags += ['-D_WIN32_WINNT=0x0601', '-D__USE_MINGW_ANSI_STDIO=1']

--- a/misc/ci.py
+++ b/misc/ci.py
@@ -19,7 +19,7 @@ def error(path: str, msg: str) -> None:
 try:
 	import git
 	repo = git.Repo('.')
-except:
+except Exception:
 	repo = None
 
 for root, directory, filenames in os.walk('.'):


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance. Bare except catches SystemExit, KeyboardInterrupt, and GeneratorExit which is rarely intended.