### PR TITLE
Update MSVC C++ standard to C++17, see PR #2734.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -332,6 +332,7 @@ if platform.is_msvc():
     cflags = ['/showIncludes',
               '/nologo',  # Don't print startup banner.
               '/utf-8',
+              '/std:c++17',
               '/Zi',  # Create pdb with debug info.
               '/W4',  # Highest warning level.
               '/WX',  # Warnings as errors.


### PR DESCRIPTION
Only use `/std:c++17` to keep sync with `-std=c++17` for GCC and Clang.