### PR TITLE
set EditorConfig to use indent size of 4 for Python files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ end_of_line = lf
 
 [CMakeLists.txt]
 indent_style = tab
+
+[*.py]
+indent_size = 4


### PR DESCRIPTION
The Python files in this repository use an indentation size of 4 spaces.

In Visual Studio Code with the [EditorConfig extension](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig), the Python indentation is set to 2, but I think it should be set to 4 to ease editing.