### PR TITLE
Fix segfault on manifest include cycles

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -36,8 +36,31 @@ ManifestParser::ManifestParser(State* state, FileReader* file_reader,
   env_ = &state->bindings_;
 }
 
+struct ScopedActiveInclude {
+  std::set<std::string>* active_includes_;
+  std::string canon_;
+  ScopedActiveInclude(std::set<std::string>* active_includes, const std::string& canon)
+      : active_includes_(active_includes), canon_(canon) {
+    active_includes_->insert(canon_);
+  }
+  ~ScopedActiveInclude() {
+    active_includes_->erase(canon_);
+  }
+};
+
 bool ManifestParser::Parse(const string& filename, const string& input,
                            string* err) {
+  // The root parser lazily creates the set on first use; subparsers receive
+  // a pointer to the root's set via ParseFileInclude().
+  if (!active_includes_) {
+    owned_active_includes_.reset(new set<string>());
+    active_includes_ = owned_active_includes_.get();
+  }
+  string canon = filename;
+  uint64_t slash_bits;
+  CanonicalizePath(&canon, &slash_bits);
+  ScopedActiveInclude scoped_include(active_includes_, canon);
+
   lexer_.Start(filename, input);
 
   for (;;) {
@@ -426,9 +449,16 @@ bool ManifestParser::ParseFileInclude(bool new_scope, string* err) {
     return false;
   string path = eval.Evaluate(env_);
 
+  string canon_path = path;
+  uint64_t unused_bits;
+  CanonicalizePath(&canon_path, &unused_bits);
+  if (active_includes_->count(canon_path))
+    return lexer_.Error("include cycle: '" + path + "'", err);
+
   if (subparser_ == nullptr) {
     subparser_.reset(new ManifestParser(state_, file_reader_, options_));
   }
+  subparser_->active_includes_ = active_includes_;
   if (new_scope) {
     subparser_->env_ = new BindingEnv(env_);
   } else {

--- a/src/manifest_parser.h
+++ b/src/manifest_parser.h
@@ -18,6 +18,8 @@
 #include "parser.h"
 
 #include <memory>
+#include <set>
+#include <string>
 #include <vector>
 
 struct BindingEnv;
@@ -72,6 +74,12 @@ private:
   // subparser_ is reused solely to get better reuse out ins_/outs_/validation_.
   std::unique_ptr<ManifestParser> subparser_;
   std::vector<EvalString> ins_, outs_, validations_;
+
+  // Tracks files currently being parsed to detect include cycles.
+  // The root parser owns the set; subparsers receive a pointer via
+  // ParseFileInclude().
+  std::unique_ptr<std::set<std::string>> owned_active_includes_;
+  std::set<std::string>* active_includes_ = nullptr;
 };
 
 #endif  // NINJA_MANIFEST_PARSER_H_

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -930,6 +930,64 @@ TEST_F(ParserTest, BrokenInclude) {
             , err);
 }
 
+TEST_F(ParserTest, IncludeCycle) {
+  fs_.Create("a.ninja", "include b.ninja\n");
+  fs_.Create("b.ninja", "include a.ninja\n");
+  ManifestParser parser(&state, &fs_);
+  string err;
+  EXPECT_FALSE(parser.ParseTest("include a.ninja\n", &err));
+  EXPECT_EQ("b.ninja:1: include cycle: 'a.ninja'\n"
+            "include a.ninja\n"
+            "               ^ near here"
+            , err);
+}
+
+TEST_F(ParserTest, IncludeCycleSelf) {
+  fs_.Create("self.ninja", "include self.ninja\n");
+  ManifestParser parser(&state, &fs_);
+  string err;
+  EXPECT_FALSE(parser.ParseTest("include self.ninja\n", &err));
+  EXPECT_EQ("self.ninja:1: include cycle: 'self.ninja'\n"
+            "include self.ninja\n"
+            "                  ^ near here"
+            , err);
+}
+
+TEST_F(ParserTest, SubninjaCycle) {
+  fs_.Create("a.ninja", "subninja b.ninja\n");
+  fs_.Create("b.ninja", "subninja a.ninja\n");
+  ManifestParser parser(&state, &fs_);
+  string err;
+  EXPECT_FALSE(parser.ParseTest("subninja a.ninja\n", &err));
+  EXPECT_EQ("b.ninja:1: include cycle: 'a.ninja'\n"
+            "subninja a.ninja\n"
+            "                ^ near here"
+            , err);
+}
+
+TEST_F(ParserTest, SubninjaCycleSelf) {
+  fs_.Create("self.ninja", "subninja self.ninja\n");
+  ManifestParser parser(&state, &fs_);
+  string err;
+  EXPECT_FALSE(parser.ParseTest("subninja self.ninja\n", &err));
+  EXPECT_EQ("self.ninja:1: include cycle: 'self.ninja'\n"
+            "subninja self.ninja\n"
+            "                   ^ near here"
+            , err);
+}
+
+TEST_F(ParserTest, IncludeSubninjaMixedCycle) {
+  fs_.Create("a.ninja", "include b.ninja\n");
+  fs_.Create("b.ninja", "subninja a.ninja\n");
+  ManifestParser parser(&state, &fs_);
+  string err;
+  EXPECT_FALSE(parser.ParseTest("subninja a.ninja\n", &err));
+  EXPECT_EQ("b.ninja:1: include cycle: 'a.ninja'\n"
+            "subninja a.ninja\n"
+            "                ^ near here"
+            , err);
+}
+
 TEST_F(ParserTest, Implicit) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(
 "rule cat\n"


### PR DESCRIPTION
Circular include/subninja directives (e.g. a.ninja includes b.ninja which includes a.ninja) caused unbounded recursion and a stack overflow. Track which files are currently being parsed and report an error when a cycle is detected.