### PR TITLE
fix: use == instead of = in newline escape version check

### DIFF
--- a/src/lexer.cc
+++ b/src/lexer.cc
@@ -760,7 +760,7 @@ yy81:
       if (!newline_version_checked_)
       {
         if ((manifest_version_major < kMinNewlineEscapeVersionMajor) ||
-            (manifest_version_major = kMinNewlineEscapeVersionMajor &&
+            (manifest_version_major == kMinNewlineEscapeVersionMajor &&
              manifest_version_minor < kMinNewlineEscapeVersionMinor))
         {
           return Error("using $^ escape requires specifying 'ninja_required_version' with version greater or equal 1.14", err);

--- a/src/lexer.in.cc
+++ b/src/lexer.in.cc
@@ -267,7 +267,7 @@ bool Lexer::ReadEvalString(EvalString* eval, bool path, string* err) {
       if (!newline_version_checked_)
       {
         if ((manifest_version_major < kMinNewlineEscapeVersionMajor) ||
-            (manifest_version_major = kMinNewlineEscapeVersionMajor &&
+            (manifest_version_major == kMinNewlineEscapeVersionMajor &&
              manifest_version_minor < kMinNewlineEscapeVersionMinor))
         {
           return Error("using $^ escape requires specifying 'ninja_required_version' with version greater or equal 1.14", err);


### PR DESCRIPTION
The condition used assignment (=) instead of comparison (==), which would always evaluate to true and break the version check logic.