### PR TITLE
Visit all of an edge's inputs before checking if any is ready

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -168,14 +168,18 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
   validation_nodes->insert(validation_nodes->end(),
       edge->validations_.begin(), edge->validations_.end());
 
-  // Visit all inputs; we're dirty if any of the inputs are dirty.
+  // Visit all inputs before checking if any of them is ready.
+  // Newly encountered edges may load dyndep files and gain
+  // outputs that correspond to some of our inputs.
+  for (Node* i : edge->inputs_) {
+    if (!RecomputeNodeDirty(i, stack, validation_nodes, err))
+      return false;
+  }
+
+  // We're dirty if any of the inputs is dirty.
   Node* most_recent_input = NULL;
   for (vector<Node*>::iterator i = edge->inputs_.begin();
        i != edge->inputs_.end(); ++i) {
-    // Visit this input.
-    if (!RecomputeNodeDirty(*i, stack, validation_nodes, err))
-      return false;
-
     // If an input is not ready, neither are our outputs.
     if (Edge* in_edge = (*i)->in_edge()) {
       if (!in_edge->outputs_ready_)

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -895,6 +895,72 @@ TEST_F(GraphTest, DyndepImplicitInputNewer) {
   EXPECT_TRUE(GetNode("out")->dirty());
 }
 
+TEST_F(GraphTest, DyndepOutputIsDependentInput) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule r\n"
+"  command = unused\n"
+"build tmp: r in || dd\n"
+"  dyndep = dd\n"
+"build out: r | tmp.imp || tmp\n"
+));
+  fs_.Create("tmp", "");
+  fs_.Create("tmp.imp", "");
+  fs_.Create("out", "");
+  fs_.Create("dd",
+"ninja_dyndep_version = 1\n"
+"build tmp | tmp.imp: dyndep\n"
+);
+  fs_.Tick();
+  fs_.Create("in", "");
+
+  string err;
+  EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
+  ASSERT_EQ("", err);
+
+  EXPECT_FALSE(GetNode("in")->dirty());
+  EXPECT_FALSE(GetNode("dd")->dirty());
+
+  EXPECT_TRUE(GetNode("tmp")->dirty());
+  EXPECT_TRUE(GetNode("tmp.imp")->dirty());
+
+  // "out" is dirty due to implicit dependency on dyndep-specified output
+  EXPECT_TRUE(GetNode("out")->dirty());
+}
+
+TEST_F(GraphTest, DyndepOutputIsDependentInputFromDepfile) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule r\n"
+"  command = unused\n"
+"build tmp: r in || dd\n"
+"  dyndep = dd\n"
+"build out: r || tmp\n"
+"  depfile = out.d\n"
+));
+  fs_.Create("tmp", "");
+  fs_.Create("tmp.imp", "");
+  fs_.Create("out", "");
+  fs_.Create("out.d", "out: tmp.imp\n");
+  fs_.Create("dd",
+"ninja_dyndep_version = 1\n"
+"build tmp | tmp.imp: dyndep\n"
+);
+  fs_.Tick();
+  fs_.Create("in", "");
+
+  string err;
+  EXPECT_TRUE(scan_.RecomputeDirty(GetNode("out"), NULL, &err));
+  ASSERT_EQ("", err);
+
+  EXPECT_FALSE(GetNode("in")->dirty());
+  EXPECT_FALSE(GetNode("dd")->dirty());
+
+  EXPECT_TRUE(GetNode("tmp")->dirty());
+  EXPECT_TRUE(GetNode("tmp.imp")->dirty());
+
+  // "out" is dirty due to depfile dependency on dyndep-specified output
+  EXPECT_TRUE(GetNode("out")->dirty());
+}
+
 TEST_F(GraphTest, DyndepFileReady) {
   AssertParse(&state_,
 "rule r\n"


### PR DESCRIPTION
Newly encountered edges may load dyndep files and gain outputs that correspond to some of our inputs.  In that case those inputs' readiness is determined by their edges instead of just mtimes.

Fixes: #2641