### PR TITLE
Fix/browse url encode

### DIFF
--- a/src/browse.py
+++ b/src/browse.py
@@ -37,9 +37,9 @@ if sys.version_info >= (3, 2):
 else:
     from cgi import escape
 try:
-    from urllib.request import unquote  # type: ignore # Module "urllib.request" has no attribute "unquote"
+    from urllib.parse import quote, unquote
 except ImportError:
-    from urllib2 import unquote
+    from urllib import quote, unquote
 from collections import namedtuple
 from typing import Tuple, Any
 
@@ -144,7 +144,7 @@ def generate_html(node: Node) -> str:
                 if type:
                     extra = ' (%s)' % html_escape(type)
                 document.append('<tt><a href="?%s">%s</a>%s</tt><br>' %
-                                (html_escape(input), html_escape(input), extra))
+                                (quote(input), html_escape(input), extra))
             document.append('</div>')
 
     if node.outputs:
@@ -152,7 +152,7 @@ def generate_html(node: Node) -> str:
         document.append('<div class=filelist>')
         for output in sorted(node.outputs):
             document.append('<tt><a href="?%s">%s</a></tt><br>' %
-                            (html_escape(output), html_escape(output)))
+                            (quote(output), html_escape(output)))
         document.append('</div>')
 
     return '\n'.join(document)

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -4405,3 +4405,18 @@ TEST_F(BuildTest, ValidationWithCircularDependency) {
   EXPECT_FALSE(builder_.AddTarget("out", &err));
   EXPECT_EQ("dependency cycle: validate -> validate_in -> validate", err);
 }
+
+TEST_F(StateTestWithBuiltinRules, ComplexTargetPreserved) {
+  // Ensure targets containing spaces, percent-encoded sequences,
+  // and URL-reserved characters are preserved exactly during parsing.
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+    "rule copy\n"
+    "  command = cp $in $out\n"
+    "name = foo %2F bar?baz&x=1\n"
+    "build $name: copy foo\n"));
+
+  Node* node = state_.LookupNode("foo %2F bar?baz&x=1");
+  ASSERT_NE(node, nullptr);
+
+  EXPECT_EQ(node->path(), "foo %2F bar?baz&x=1");
+}


### PR DESCRIPTION
Fixes: #2652 

### Root Cause Analysis (RCA)

The -t browse tool generates links to targets using their raw names.
For targets containing % (e.g., foo%2Fbar), the link was generated without URL encoding:

```
/?foo%2Fbar
```

When this URL is handled by the server, it is decoded using unquote(), which interprets %2F as /:

```
foo%2Fbar -> foo/bar
```

As a result, Ninja attempts to query a different target (foo/bar instead of foo%2Fbar), leading to lookup failures and broken navigation in the browse UI.

### Fix

The fix ensures that target names are properly URL-encoded when generating links by using quote():

```
quote(output)
```

This encodes % as %25, so:

```
foo%2Fbar -> foo%252Fbar
```

Now when the server decodes the URL once:

```
foo%252Fbar -> foo%2Fbar
```
The original target string is preserved, and Ninja can correctly resolve the target.

#### Test Added

Added a unit test:

```
TEST_F(StateTestWithBuiltinRules, ComplexTargetPreserved)
```

This test verifies that targets containing:
- spaces
- percent-encoded sequences (%2F)
- URL-reserved characters (?, &, =)

are preserved exactly during parsing and lookup.