### PR TITLE
Fix -t clean to remove all outputs of multi-output edges

### DIFF
--- a/src/clean.cc
+++ b/src/clean.cc
@@ -151,7 +151,12 @@ void Cleaner::DoCleanTarget(Node* target) {
   if (Edge* e = target->in_edge()) {
     // Do not try to remove phony targets
     if (!e->is_phony()) {
-      Remove(target->path());
+      // Remove all outputs of this edge, not just the named target.
+      // A multi-output edge produces all its outputs from a single command,
+      // so they must be cleaned together.
+      for (Node* output : e->outputs_) {
+        Remove(output->path());
+      }
       RemoveEdgeFiles(e);
     }
     for (vector<Node*>::iterator n = e->inputs_.begin(); n != e->inputs_.end();

--- a/src/clean_test.cc
+++ b/src/clean_test.cc
@@ -130,6 +130,26 @@ TEST_F(CleanTest, CleanTarget) {
   EXPECT_EQ(0u, fs_.files_removed_.size());
 }
 
+TEST_F(CleanTest, CleanTargetMultiOutput) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"build out1 out2: cat src1\n"
+"build out3: cat src2\n"));
+  fs_.Create("out1", "");
+  fs_.Create("out2", "");
+  fs_.Create("out3", "");
+
+  Cleaner cleaner(&state_, config_, &fs_);
+
+  // Cleaning out1 should also clean out2 (same edge), but not out3.
+  ASSERT_EQ(0, cleaner.CleanTarget("out1"));
+  EXPECT_EQ(2, cleaner.cleaned_files_count());
+
+  string err;
+  EXPECT_EQ(0, fs_.Stat("out1", &err));
+  EXPECT_EQ(0, fs_.Stat("out2", &err));
+  EXPECT_LT(0, fs_.Stat("out3", &err));
+}
+
 TEST_F(CleanTest, CleanTargetDryRun) {
   ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
 "build in1: cat src1\n"


### PR DESCRIPTION
When cleaning a specific target with `ninja -t clean <target>`, DoCleanTarget only removed the named target file. For multi-output edges (e.g. `build a.txt | b.txt: gen in.txt`), the other outputs were left behind even though they are produced by the same command and cannot be rebuilt independently. The docs say "additional arguments are targets, which removes the given targets and **recursively all files built for them**", so I think this is a bug. 

Fix by iterating over all edge outputs in DoCleanTarget, consistent with how CleanAll already handles multi-output edges.