### PR TITLE
Document more precisely how a dyndep file may affect the build graph

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -1259,6 +1259,16 @@ implicit inputs and/or outputs.  Ninja will update the build graph
 accordingly and the build will proceed as if the information was known
 originally.
 
+A dyndep file may only affect dependent portions of the build graph,
+i.e., the set of build statements that specify the file as a `dyndep`
+binding, or build statements known by the _original_ build manifest
+to depend directly or indirectly on at least one member of that set.
+In particular, dynamically discovered outputs of a build statement
+may not correspond to inputs of build statements that were originally
+independent of the dyndep file.  In other words, a dyndep file may
+not change the build graph in a way that causes up-to-date build
+statements to become out-of-date.
+
 Dyndep file reference
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Only the part of the graph that depends on the edges with a dyndep binding may be affected by content loaded from the dyndep file. Otherwise the dyndep file could change the build graph in a way that causes already up-to-date build statements to become out-of-date.
