### PR TITLE
Improve readability of dyndep, depfile, and validation node logic

### DIFF
--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -343,10 +343,10 @@ TEST_F(StatTest, TwoStep) {
   scan_.RecomputeDirty(out, NULL, NULL);
   ASSERT_EQ(3u, stats_.size());
   ASSERT_EQ("out", stats_[0]);
+  ASSERT_EQ("in",  stats_[1]);
+  ASSERT_EQ("mid", stats_[2]);
   ASSERT_TRUE(GetNode("out")->dirty());
-  ASSERT_EQ("mid",  stats_[1]);
   ASSERT_TRUE(GetNode("mid")->dirty());
-  ASSERT_EQ("in",  stats_[2]);
 }
 
 TEST_F(StatTest, Tree) {
@@ -362,9 +362,10 @@ TEST_F(StatTest, Tree) {
   ASSERT_EQ(1u, stats_.size());
   scan_.RecomputeDirty(out, NULL, NULL);
   ASSERT_EQ(1u + 6u, stats_.size());
-  ASSERT_EQ("mid1", stats_[1]);
+  ASSERT_EQ("in11", stats_[1]);
+  ASSERT_EQ("in12", stats_[2]);
+  ASSERT_EQ("mid1", stats_[3]);
   ASSERT_TRUE(GetNode("mid1")->dirty());
-  ASSERT_EQ("in11", stats_[2]);
 }
 
 TEST_F(StatTest, Middle) {

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -105,6 +105,14 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
   if (!VerifyDAG(node, stack, err))
     return false;
 
+  // Store any validation nodes from the edge for adding to the initial
+  // nodes.  Don't recurse into them, that would trigger the dependency
+  // cycle detector if the validation node depends on this node.
+  // RecomputeDirty will add the validation nodes to the initial nodes
+  // and recurse into them.
+  validation_nodes->insert(validation_nodes->end(),
+      edge->validations_.begin(), edge->validations_.end());
+
   // Mark the edge temporarily while in the call stack.
   edge->mark_ = Edge::VisitInStack;
   stack->push_back(node);
@@ -159,14 +167,6 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
       dirty = edge->deps_missing_ = true;
     }
   }
-
-  // Store any validation nodes from the edge for adding to the initial
-  // nodes.  Don't recurse into them, that would trigger the dependency
-  // cycle detector if the validation node depends on this node.
-  // RecomputeDirty will add the validation nodes to the initial nodes
-  // and recurse into them.
-  validation_nodes->insert(validation_nodes->end(),
-      edge->validations_.begin(), edge->validations_.end());
 
   // Visit all inputs before checking if any of them is ready.
   // Newly encountered edges may load dyndep files and gain

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -748,6 +748,11 @@ bool ImplicitDepLoader::LoadDepsFromLog(Edge* edge, string* err) {
     return false;
   }
 
+  // Load the output's mtime if we haven't already.
+  if (!output->StatIfNecessary(disk_interface_, err)) {
+    return false;
+  }
+
   // Deps are invalid if the output is newer than the deps.
   if (output->mtime() > deps->mtime) {
     explanations_.Record(output,

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -123,6 +123,8 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
 
   if (!edge->deps_loaded_) {
     // This is our first encounter with this edge.
+    edge->deps_loaded_ = true;
+
     // If there is a pending dyndep file, visit it now:
     // * If the dyndep file is ready then load it now to get any
     //   additional inputs and outputs for this and other edges.
@@ -144,21 +146,8 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
           return false;
       }
     }
-  }
 
-  // Load output mtimes so we can compare them to the most recent input below.
-  for (vector<Node*>::iterator o = edge->outputs_.begin();
-       o != edge->outputs_.end(); ++o) {
-    if (err) {
-      *err = "";
-    }
-    if (!(*o)->StatIfNecessary(disk_interface_, err))
-      return false;
-  }
-
-  if (!edge->deps_loaded_) {
-    // This is our first encounter with this edge.  Load discovered deps.
-    edge->deps_loaded_ = true;
+    // Load discovered deps.
     if (!dep_loader_.LoadDeps(edge, err)) {
       if (!err->empty())
         return false;
@@ -174,6 +163,16 @@ bool DependencyScan::RecomputeNodeDirty(Node* node, std::vector<Node*>* stack,
   for (Node* i : edge->inputs_) {
     if (!RecomputeNodeDirty(i, stack, validation_nodes, err))
       return false;
+  }
+
+  // Load output mtimes so we can compare them to the most recent input below.
+  for (Node* o : edge->outputs_) {
+    if (err) {
+      *err = "";
+    }
+    if (!o->StatIfNecessary(disk_interface_, err)) {
+      return false;
+    }
   }
 
   // We're dirty if any of the inputs is dirty.


### PR DESCRIPTION
This changes no functionality, but makes RecomputeNodeDirty easier to follow:

* Queue an edge's validation nodes before *all* inputs

  Previously a dyndep binding could cause one input to be traversed
  before queuing the validation nodes of the current edge.  This does
  not affect correctness, but it makes the code easier to follow.

* Explicitly load a node's mtime before comparing it to the deps log

  Previously we were relying on RecomputeNodeDirty to do
  this before LoadDeps.  Avoid this non-local assumption.

* Simplify logic that updates an edge from dyndep and depfile bindings

  RecomputeNodeDirty checks both dyndep and depfile bindings when an edge
  is first encountered.  Consolidate them into a single conditional block.
  This simplification was missed in
  #1521.
