### PR TITLE
%q to show time spent per edge

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -243,6 +243,7 @@ specified by `-j` or its default)
 `%W`:: Remaining time (ETA) in [h:]mm:ss format. _(Available since Ninja 1.12.)_
 `%P`:: The percentage (in ppp% format) of time elapsed out of predicted total runtime. _(Available since Ninja 1.12.)_
 `%%`:: A plain `%` character.
+`%q`:: Time spent on current edge in seconds.
 
 The default progress status is `"[%f/%t] "` (note the trailing space
 to separate from the build rule). Another example of possible progress status

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -2298,30 +2298,30 @@ TEST_F(BuildTest, DepsGccWithEmptyDepfileErrorsOut) {
 TEST_F(BuildTest, StatusFormatElapsed_e) {
   status_.BuildStarted();
   // Before any task is done, the elapsed time must be zero.
-  EXPECT_EQ("[%/e0.000]", status_.FormatProgressStatus("[%%/e%e]", 0));
+  EXPECT_EQ("[%/e0.000]", status_.FormatProgressStatus("[%%/e%e]", 0, 0));
 }
 
 TEST_F(BuildTest, StatusFormatElapsed_w) {
   status_.BuildStarted();
   // Before any task is done, the elapsed time must be zero.
-  EXPECT_EQ("[%/e00:00]", status_.FormatProgressStatus("[%%/e%w]", 0));
+  EXPECT_EQ("[%/e00:00]", status_.FormatProgressStatus("[%%/e%w]", 0, 0));
 }
 
 TEST_F(BuildTest, StatusFormatETA) {
   status_.BuildStarted();
   // Before any task is done, the ETA time must be unknown.
-  EXPECT_EQ("[%/E?]", status_.FormatProgressStatus("[%%/E%E]", 0));
+  EXPECT_EQ("[%/E?]", status_.FormatProgressStatus("[%%/E%E]", 0, 0));
 }
 
 TEST_F(BuildTest, StatusFormatTimeProgress) {
   status_.BuildStarted();
   // Before any task is done, the percentage of elapsed time must be zero.
-  EXPECT_EQ("[%/p  0%]", status_.FormatProgressStatus("[%%/p%p]", 0));
+  EXPECT_EQ("[%/p  0%]", status_.FormatProgressStatus("[%%/p%p]", 0, 0));
 }
 
 TEST_F(BuildTest, StatusFormatReplacePlaceholder) {
   EXPECT_EQ("[%/s0/t0/r0/u0/f0]",
-            status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]", 0));
+            status_.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]", 0, 0));
 }
 
 TEST_F(BuildTest, FailedDepsParse) {

--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -262,7 +262,8 @@ void StatusPrinter::BuildFinished() {
 }
 
 string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
-                                           int64_t time_millis, int64_t time_millis_q) const {
+                                           int64_t time_millis,
+                                           int64_t time_millis_q) const {
   string out;
   char buf[32];
   for (const char* s = progress_status_format; *s != '\0'; ++s) {

--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -89,7 +89,7 @@ void StatusPrinter::BuildEdgeStarted(const Edge* edge,
   time_millis_ = start_time_millis;
 
   if (edge->use_console() || printer_.is_smart_terminal())
-    PrintStatus(edge, start_time_millis);
+    PrintStatus(edge, start_time_millis, 0);
 
   if (edge->use_console())
     printer_.SetConsoleLocked(true);
@@ -198,7 +198,7 @@ void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
     return;
 
   if (!edge->use_console())
-    PrintStatus(edge, end_time_millis);
+    PrintStatus(edge, end_time_millis, (end_time_millis - start_time_millis));
 
   --running_edges_;
 
@@ -262,7 +262,7 @@ void StatusPrinter::BuildFinished() {
 }
 
 string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
-                                           int64_t time_millis) const {
+                                           int64_t time_millis, int64_t time_millis_q) const {
   string out;
   char buf[32];
   for (const char* s = progress_status_format; *s != '\0'; ++s) {
@@ -326,6 +326,14 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
         out += buf;
         break;
       }
+
+        // Time spent (in seconds) on this edge specifically.
+      case 'q':
+        if (time_millis_q != 0) {
+            std::snprintf(buf, sizeof(buf), "%.3f", (time_millis_q / 1e3));
+            out += buf;
+        }
+        break;
 
 #define FORMAT_TIME_HMMSS(t)                                                \
   "%" PRId64 ":%02" PRId64 ":%02" PRId64 "", (t) / 3600, ((t) % 3600) / 60, \
@@ -405,7 +413,7 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
   return out;
 }
 
-void StatusPrinter::PrintStatus(const Edge* edge, int64_t time_millis) {
+void StatusPrinter::PrintStatus(const Edge* edge, int64_t time_millis, int64_t time_millis_q) {
   if (explanations_) {
     explanations_->ExplainEdge(edge);
   }
@@ -422,7 +430,7 @@ void StatusPrinter::PrintStatus(const Edge* edge, int64_t time_millis) {
   if (to_print.empty() || force_full_command)
     to_print = edge->GetBinding("command");
 
-  to_print = FormatProgressStatus(progress_status_format_, time_millis)
+  to_print = FormatProgressStatus(progress_status_format_, time_millis, time_millis_q)
       + to_print;
 
   printer_.Print(to_print,

--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -329,10 +329,8 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
 
         // Time spent (in seconds) on this edge specifically.
       case 'q':
-        if (time_millis_q != 0) {
-            std::snprintf(buf, sizeof(buf), "%.3f", (time_millis_q / 1e3));
-            out += buf;
-        }
+        std::snprintf(buf, sizeof(buf), "%.3f", (time_millis_q / 1e3));
+        out += buf;
         break;
 
 #define FORMAT_TIME_HMMSS(t)                                                \

--- a/src/status_printer.h
+++ b/src/status_printer.h
@@ -49,7 +49,8 @@ struct StatusPrinter : Status {
   /// @param time_millis The time elapsed overall.
   /// @param time_millis_q The time elapsed for this edge.
   std::string FormatProgressStatus(const char* progress_status_format,
-                                   int64_t time_millis, int64_t time_millis_q) const;
+                                   int64_t time_millis,
+                                   int64_t time_millis_q) const;
 
   /// Set the |explanations_| pointer. Used to implement `-d explain`.
   void SetExplanations(Explanations* explanations) override {

--- a/src/status_printer.h
+++ b/src/status_printer.h
@@ -46,9 +46,10 @@ struct StatusPrinter : Status {
   /// See the user manual for more information about the available
   /// placeholders.
   /// @param progress_status_format The format of the progress status.
-  /// @param status The status of the edge.
+  /// @param time_millis The time elapsed overall.
+  /// @param time_millis_q The time elapsed for this edge.
   std::string FormatProgressStatus(const char* progress_status_format,
-                                   int64_t time_millis) const;
+                                   int64_t time_millis, int64_t time_millis_q) const;
 
   /// Set the |explanations_| pointer. Used to implement `-d explain`.
   void SetExplanations(Explanations* explanations) override {
@@ -56,7 +57,7 @@ struct StatusPrinter : Status {
   }
 
  private:
-  void PrintStatus(const Edge* edge, int64_t time_millis);
+  void PrintStatus(const Edge* edge, int64_t time_millis, int64_t time_millis_q);
 
   const BuildConfig& config_;
 

--- a/src/status_test.cc
+++ b/src/status_test.cc
@@ -22,9 +22,9 @@ TEST(StatusTest, StatusFormatElapsed) {
 
   status.BuildStarted();
   // Before any task is done, the elapsed time must be zero.
-  EXPECT_EQ("[%/e0.000]", status.FormatProgressStatus("[%%/e%e]", 0));
+  EXPECT_EQ("[%/e0.000]", status.FormatProgressStatus("[%%/e%e]", 0, 0));
   // Before any task is done, the elapsed time must be zero.
-  EXPECT_EQ("[%/e00:00]", status.FormatProgressStatus("[%%/e%w]", 0));
+  EXPECT_EQ("[%/e00:00]", status.FormatProgressStatus("[%%/e%w]", 0, 0));
 }
 
 TEST(StatusTest, StatusFormatReplacePlaceholder) {
@@ -32,5 +32,5 @@ TEST(StatusTest, StatusFormatReplacePlaceholder) {
   StatusPrinter status(config);
 
   EXPECT_EQ("[%/s0/t0/r0/u0/f0]",
-            status.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]", 0));
+            status.FormatProgressStatus("[%%/s%s/t%t/r%r/u%u/f%f]", 0, 0));
 }


### PR DESCRIPTION
This should be able to close #2044. When %q is included in NINJA_STATUS, the time spent on an edge is printed. I still need to fix the formatting, which I will do sometime soon.