### PR TITLE
misc: Add new fuzzers to be consumed by OSS-Fuzz

### DIFF
--- a/misc/build_log_fuzzer.cc
+++ b/misc/build_log_fuzzer.cc
@@ -1,0 +1,35 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <string>
+#include <stdio.h>
+#include <unistd.h>
+#include "build_log.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  char temp_path[] = "/tmp/ninja_build_log_fuzzer.XXXXXX";
+  int fd = mkstemp(temp_path);
+  if (fd < 0) return 0;
+  
+  write(fd, data, size);
+  close(fd);
+  
+  BuildLog build_log;
+  std::string err;
+  build_log.Load(temp_path, &err);
+  
+  unlink(temp_path);
+  return 0;
+}

--- a/misc/depfile_fuzzer.cc
+++ b/misc/depfile_fuzzer.cc
@@ -1,0 +1,28 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <string>
+#include "depfile_parser.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  std::string input(reinterpret_cast<const char*>(data), size);
+  // DepfileParser::Parse may mutate the content in-place.
+  
+  DepfileParserOptions options;
+  DepfileParser parser(options);
+  std::string err;
+  parser.Parse(&input, &err);
+  return 0;
+}

--- a/misc/deps_log_fuzzer.cc
+++ b/misc/deps_log_fuzzer.cc
@@ -1,0 +1,37 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <string>
+#include <stdio.h>
+#include <unistd.h>
+#include "deps_log.h"
+#include "state.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  char temp_path[] = "/tmp/ninja_deps_log_fuzzer.XXXXXX";
+  int fd = mkstemp(temp_path);
+  if (fd < 0) return 0;
+  
+  write(fd, data, size);
+  close(fd);
+  
+  State state;
+  DepsLog deps_log;
+  std::string err;
+  deps_log.Load(temp_path, &state, &err);
+  
+  unlink(temp_path);
+  return 0;
+}

--- a/misc/graph_fuzzer.cc
+++ b/misc/graph_fuzzer.cc
@@ -1,0 +1,103 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include <map>
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include "disk_interface.h"
+#include "state.h"
+#include "manifest_parser.h"
+#include "graph.h"
+#include "depfile_parser.h"
+#include "explanations.h"
+
+struct FuzzFileSystem : public DiskInterface {
+  TimeStamp Stat(const std::string& path, std::string* err) const override {
+    auto it = mtimes_.find(path);
+    if (it != mtimes_.end()) return it->second;
+    return 1;
+  }
+  bool WriteFile(const std::string& path, const std::string& contents, bool) override { return true; }
+  bool MakeDir(const std::string& path) override { return true; }
+  Status ReadFile(const std::string& path, std::string* contents, std::string* err) override {
+    auto it = files_.find(path);
+    if (it != files_.end()) {
+      *contents = it->second;
+      return Okay;
+    }
+    return NotFound;
+  }
+  int RemoveFile(const std::string& path) override { return 0; }
+
+  std::map<std::string, TimeStamp> mtimes_;
+  std::map<std::string, std::string> files_;
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  FuzzedDataProvider fdp(data, size);
+
+  // Split data into manifest and file system state
+  std::string manifest = fdp.ConsumeRandomLengthString(size / 2);
+  
+  FuzzFileSystem fs;
+  // Populate some random files/mtimes
+  int num_files = fdp.ConsumeIntegralInRange<int>(0, 10);
+  for (int i = 0; i < num_files; ++i) {
+    std::string path = fdp.ConsumeRandomLengthString(20);
+    if (path.empty()) continue;
+    fs.mtimes_[path] = fdp.ConsumeIntegralInRange<TimeStamp>(0, 100);
+    if (fdp.ConsumeBool()) {
+      fs.files_[path] = fdp.ConsumeRandomLengthString(100);
+    }
+  }
+
+  State state;
+  ManifestParser parser(&state, &fs);
+  std::string err;
+  if (!parser.ParseTest(manifest, &err)) {
+    return 0;
+  }
+
+  // Assign random mtimes to nodes mentioned in the manifest
+  for (auto it = state.paths_.begin(); it != state.paths_.end(); ++it) {
+    if (fdp.ConsumeBool()) {
+        fs.mtimes_[it->first.AsString()] = fdp.ConsumeIntegralInRange<TimeStamp>(0, 100);
+    }
+  }
+
+  DepfileParserOptions depfile_opts;
+  Explanations explanations;
+  DependencyScan scan(&state, nullptr, nullptr, &fs, &depfile_opts, &explanations);
+
+  std::string err2;
+  std::vector<Node*> roots = state.RootNodes(&err2);
+  if (!err2.empty()) return 0;
+
+  for (Node* root : roots) {
+    std::string err3;
+    std::vector<Node*> validation_nodes;
+    scan.RecomputeDirty(root, &validation_nodes, &err3);
+  }
+
+  for (Edge* edge : state.edges_) {
+    if (fdp.ConsumeBool()) {
+      explanations.ExplainEdge(edge);
+    }
+  }
+
+  return 0;
+}

--- a/misc/oss-fuzz/build.sh
+++ b/misc/oss-fuzz/build.sh
@@ -20,10 +20,17 @@ cmake --build build-cmake
 
 cd $SRC/ninja/misc
 
+# Compile each fuzzer
+for fuzzer in depfile_fuzzer build_log_fuzzer deps_log_fuzzer util_fuzzer graph_fuzzer; do
+    $CXX $CXXFLAGS -fdiagnostics-color -I/src/ninja/src -o ${fuzzer}.o -c ${fuzzer}.cc
+done
 $CXX $CXXFLAGS -fdiagnostics-color -I/src/ninja/src -o fuzzer.o -c manifest_fuzzer.cc
 
 find .. -name "*.o" -exec ar rcs fuzz_lib.a {} \;
 
+for fuzzer in depfile_fuzzer build_log_fuzzer deps_log_fuzzer util_fuzzer graph_fuzzer; do
+    $CXX $CXXFLAGS $LIB_FUZZING_ENGINE ${fuzzer}.o -o $OUT/${fuzzer} fuzz_lib.a
+done
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE fuzzer.o -o $OUT/fuzzer fuzz_lib.a
 
 zip $OUT/fuzzer_seed_corpus.zip $SRC/sample_ninja_build

--- a/misc/util_fuzzer.cc
+++ b/misc/util_fuzzer.cc
@@ -1,0 +1,91 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include "util.h"
+#include "edit_distance.h"
+#include "json.h"
+#include "string_piece_util.h"
+#include "clparser.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  FuzzedDataProvider fdp(data, size);
+
+  // Fuzz CLParser
+  {
+    std::string deps_prefix = fdp.ConsumeRandomLengthString(32);
+    std::string output = fdp.ConsumeRandomLengthString(256);
+    CLParser parser;
+    std::string filtered_output, err;
+    parser.Parse(output, deps_prefix, &filtered_output, &err);
+  }
+
+  // Fuzz EditDistance
+  std::string s1 = fdp.ConsumeRandomLengthString(100);
+  std::string s2 = fdp.ConsumeRandomLengthString(100);
+  bool allow_replacements = fdp.ConsumeBool();
+  int max_edit_distance = fdp.ConsumeIntegralInRange<int>(0, 10);
+  EditDistance(s1, s2, allow_replacements, max_edit_distance);
+
+  // Fuzz CanonicalizePath
+  std::string path = fdp.ConsumeRandomLengthString(256);
+  uint64_t slash_bits = 0;
+  CanonicalizePath(&path, &slash_bits);
+
+  // Fuzz Shell Escaping
+  std::string unescaped = fdp.ConsumeRandomLengthString(256);
+  std::string escaped;
+  GetShellEscapedString(unescaped, &escaped);
+  escaped.clear();
+  GetWin32EscapedString(unescaped, &escaped);
+
+  // Fuzz StripAnsiEscapeCodes
+  std::string ansi_in = fdp.ConsumeRandomLengthString(256);
+  StripAnsiEscapeCodes(ansi_in);
+
+  // Fuzz SpellcheckStringV
+  {
+    std::string text = fdp.ConsumeRandomLengthString(20);
+    int num_words = fdp.ConsumeIntegralInRange<int>(0, 10);
+    std::vector<std::string> words_s;
+    for (int i = 0; i < num_words; ++i) {
+      words_s.push_back(fdp.ConsumeRandomLengthString(20));
+    }
+    std::vector<const char*> words_c;
+    for (int i = 0; i < num_words; ++i) {
+      words_c.push_back(words_s[i].c_str());
+    }
+    SpellcheckStringV(text, words_c);
+  }
+
+  // Fuzz EncodeJSONString
+  std::string json_in = fdp.ConsumeRandomLengthString(256);
+  EncodeJSONString(json_in);
+
+  // Fuzz StringPieceUtil
+  std::string sp_in = fdp.ConsumeRandomLengthString(256);
+  char sep = fdp.ConsumeIntegral<char>();
+  std::vector<StringPiece> pieces = SplitStringPiece(sp_in, sep);
+  JoinStringPiece(pieces, sep);
+
+  std::string sp_a = fdp.ConsumeRandomLengthString(100);
+  std::string sp_b = fdp.ConsumeRandomLengthString(100);
+  EqualsCaseInsensitiveASCII(sp_a, sp_b);
+
+  return 0;
+}


### PR DESCRIPTION
Adds additional fuzzing harnesses to be consumed by OSS-Fuzz. The goal is to increase code coverage, for which a recent coverage report is: https://storage.googleapis.com/oss-fuzz-coverage/ninja/reports/20260503/linux/report.html