### PR TITLE
Support OSC 9;4 progress bars in NINJA_STATUS

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -242,6 +242,8 @@ specified by `-j` or its default)
 `%w`:: Elapsed time in [h:]mm:ss format. _(Available since Ninja 1.12.)_
 `%W`:: Remaining time (ETA) in [h:]mm:ss format. _(Available since Ninja 1.12.)_
 `%P`:: The percentage (in ppp% format) of time elapsed out of predicted total runtime. _(Available since Ninja 1.12.)_
+`%b`:: OSC 9;4 progress bar for percentage of finished edges. _(Available since Ninja 1.14.)_
+`%B`:: OSC 9;4 progress bar for percentage of time elapsed out of predicted total runtime. _(Available since Ninja 1.14.)_
 `%%`:: A plain `%` character.
 
 The default progress status is `"[%f/%t] "` (note the trailing space

--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -327,6 +327,18 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
         break;
       }
 
+      // OSC 9;4 progress bar for percentage of edges
+      case 'b': {
+        int percent = 0;
+        if (finished_edges_ != 0 && total_edges_ != 0)
+          percent = (100 * finished_edges_) / total_edges_;
+        int state = finished_edges_ == total_edges_ ? 0 : 1;
+
+        snprintf(buf, sizeof(buf), "\x1b]9;4;%i;%i\x7", state, percent);
+        out += buf;
+        break;
+      }
+
 #define FORMAT_TIME_HMMSS(t)                                                \
   "%" PRId64 ":%02" PRId64 ":%02" PRId64 "", (t) / 3600, ((t) % 3600) / 60, \
       (t) % 60
@@ -389,6 +401,16 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
       case 'P': {
         snprintf(buf, sizeof(buf), "%3i%%",
                  (int)(100. * time_predicted_percentage_));
+        out += buf;
+        break;
+      }
+
+      // OSC 9;4 progress bar for predicted time
+      case 'B': {
+        int percent = (int)(100. * time_predicted_percentage_);
+        int state = finished_edges_ == total_edges_ ? 0 : 1;
+
+        snprintf(buf, sizeof(buf), "\x1b]9;4;%i;%i\x7", state, percent);
         out += buf;
         break;
       }


### PR DESCRIPTION
This adds `%b` and `%B` placeholders for `NINJA_STATUS` that will generate progress bars using `OSC 9;4` sequences for percentage of finished edges and time elapsed, respectively.

The `OSC 9;4` sequences are originally from ConEmu, but are supported by various terminals on linux and mac as well at this point.

Fixes #2555