### PR TITLE
remove noop CMake policy - always new already

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ check_ipo_supported(RESULT lto_supported OUTPUT error)
 
 if(lto_supported)
 	message(STATUS "IPO / LTO enabled")
-	set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
 	set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
 else()
 	message(STATUS "IPO / LTO not supported: <${error}>")


### PR DESCRIPTION
cmake_minimum_required(VERSION 3.9) and higher already set this policy. Further, the canonical way for projects to set individual policies is as done for CMP0135 in this project.