### PR TITLE
Fix dyndep loading for multi-output dyndep generators

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -223,9 +223,8 @@ bool Plan::EdgeFinished(Edge* edge, EdgeResult result, string* err) {
   edge->outputs_ready_ = true;
 
   // Check off any nodes we were waiting for with this edge.
-  for (vector<Node*>::iterator o = edge->outputs_.begin();
-       o != edge->outputs_.end(); ++o) {
-    if (!NodeFinished(*o, err))
+  for (auto o : edge->outputs_) {
+    if (!NodeFinished(o, err))
       return false;
   }
   return true;
@@ -241,9 +240,8 @@ bool Plan::NodeFinished(Node* node, string* err) {
   }
 
   // See if we we want any edges from this node.
-  for (vector<Edge*>::const_iterator oe = node->out_edges().begin();
-       oe != node->out_edges().end(); ++oe) {
-    map<Edge*, Want>::iterator want_e = want_.find(*oe);
+  for (auto oe : node->out_edges()) {
+    map<Edge*, Want>::iterator want_e = want_.find(oe);
     if (want_e == want_.end())
       continue;
 

--- a/src/build.cc
+++ b/src/build.cc
@@ -222,6 +222,10 @@ bool Plan::EdgeFinished(Edge* edge, EdgeResult result, string* err) {
   want_.erase(e);
   edge->outputs_ready_ = true;
 
+  // If this edge provides dyndep info, load it now.
+  if (builder_ && !builder_->LoadDyndeps(edge->outputs_, err))
+    return false;
+
   // Check off any nodes we were waiting for with this edge.
   for (auto o : edge->outputs_) {
     if (!NodeFinished(o, err))
@@ -231,14 +235,6 @@ bool Plan::EdgeFinished(Edge* edge, EdgeResult result, string* err) {
 }
 
 bool Plan::NodeFinished(Node* node, string* err) {
-  // If this node provides dyndep info, load it now.
-  if (node->dyndep_pending()) {
-    assert(builder_ && "dyndep requires Plan to have a Builder");
-    // Load the now-clean dyndep file.  This will also update the
-    // build plan and schedule any new work that is ready.
-    return builder_->LoadDyndeps(node, err);
-  }
-
   // See if we we want any edges from this node.
   for (auto oe : node->out_edges()) {
     map<Edge*, Want>::iterator want_e = want_.find(oe);
@@ -1062,16 +1058,27 @@ bool Builder::ExtractDeps(BuildResult::CommandCompleted& result,
   return true;
 }
 
-bool Builder::LoadDyndeps(Node* node, string* err) {
-  // Load the dyndep information provided by this node.
-  DyndepFile ddf;
-  if (!scan_.LoadDyndeps(node, &ddf, err))
-    return false;
+bool Builder::LoadDyndeps(const std::vector<Node*>& nodes, std::string* err) {
+  using dyndepPair = std::pair<const Node*, const DyndepFile>;
+  std::vector<dyndepPair> dyndeps;
 
-  // Update the build plan to account for dyndep modifications to the graph.
-  if (!plan_.DyndepsLoaded(&scan_, node, ddf, err))
-    return false;
+  // first update scan_ for all loaded dyndep files
+  for (Node* node : nodes) {
+    if (!node->dyndep_pending())
+      continue;
 
+    DyndepFile ddf;
+    if (!scan_.LoadDyndeps(node, &ddf, err))
+      return false;
+
+    dyndeps.emplace_back(node, std::move(ddf));
+  }
+
+  // update the plan
+  for (const auto& dyndep : dyndeps) {
+    if (!plan_.DyndepsLoaded(&scan_, dyndep.first, dyndep.second, err))
+      return false;
+  }
   return true;
 }
 

--- a/src/build.h
+++ b/src/build.h
@@ -239,8 +239,8 @@ struct Builder {
     scan_.set_build_log(log);
   }
 
-  /// Load the dyndep information provided by the given node.
-  bool LoadDyndeps(Node* node, std::string* err);
+  /// Load the dyndep information provided by the given nodes.
+  bool LoadDyndeps(const std::vector<Node*>& nodes, std::string* err);
 
   State* state_;
   const BuildConfig& config_;

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -4421,3 +4421,87 @@ TEST_F(StateTestWithBuiltinRules, ComplexTargetPreserved) {
 
   EXPECT_EQ(node->path(), "foo %2F bar?baz&x=1");
 }
+
+// These tests primarily exercise Plan, but dyndep loading requires filesystem
+// interactions managed by Builder. Therefore BuildTest is used instead of
+// PlanTest.
+// https://github.com/ninja-build/ninja/issues/2782
+TEST_F(BuildTest, DyndepOneEdgeTwoDyndepfilesRaceCondition) {
+  // Verify that loading multiple dyndep files does not introduce a race
+  // condition.
+
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_, R"ninja(
+rule make_dyndep
+  command = printf "ninja_dyndep_version = 1\nbuild a.pcm: dyndep | b.pcm\n" > a.dd; printf "ninja_dyndep_version = 1\nbuild b.pcm: dyndep | c.pcm\n" > b.dd
+build a.dd b.dd: make_dyndep
+
+rule touch
+  command = touch $out
+build a.pcm: touch a | a.dd
+  dyndep = a.dd
+
+rule touch_slow
+  command = touch $out
+build c.pcm: touch_slow c
+
+rule check_exists
+  command = [ -f c.pcm ] && touch $out
+build b.pcm: check_exists b | b.dd
+  dyndep = b.dd
+)ninja"));
+
+  fs_.Create("a", "");
+  fs_.Create("b", "");
+  fs_.Create("c", "");
+  fs_.Create("a.dd",
+             "ninja_dyndep_version = 1\n"
+             "build a.pcm: dyndep | b.pcm\n");
+  fs_.Create("b.dd",
+             "ninja_dyndep_version = 1\n"
+             "build b.pcm: dyndep | c.pcm\n");
+
+  state_.GetNode("a.dd", 0)->MarkDirty();
+  state_.GetNode("b.dd", 0)->MarkDirty();
+  state_.GetNode("a.pcm", 0)->MarkDirty();
+  state_.GetNode("b.pcm", 0)->MarkDirty();
+  state_.GetNode("c.pcm", 0)->MarkDirty();
+
+  auto& plan_ = builder_.plan_;
+
+  // Simulate `ninja` adding all default targets in their original order.
+  string err;
+  EXPECT_TRUE(plan_.AddTarget(GetNode("a.pcm"), &err));
+  ASSERT_EQ("", err);
+  EXPECT_TRUE(plan_.AddTarget(GetNode("c.pcm"), &err));
+  ASSERT_EQ("", err);
+  EXPECT_TRUE(plan_.AddTarget(GetNode("b.pcm"), &err));
+  ASSERT_EQ("", err);
+
+  plan_.PrepareQueue();
+  EXPECT_TRUE(plan_.more_to_do());
+  EXPECT_TRUE(plan_.work_ready());
+
+  // Start running the first two processes.
+  Edge* edge1 = plan_.FindWork();
+  ASSERT_TRUE(edge1);
+  EXPECT_EQ(edge1->rule().name(), "make_dyndep");
+  EXPECT_TRUE(plan_.work_ready());
+
+  Edge* edge2 = plan_.FindWork();
+  ASSERT_TRUE(edge2);
+  EXPECT_EQ(edge2->rule().name(), "touch_slow");
+  EXPECT_FALSE(plan_.work_ready());
+
+  // 'make_dyndep' finishes first and loads the dyndep files, but additional
+  // work is still blocked because 'touch_slow' is still building 'c.pcm'.
+  plan_.EdgeFinished(edge1, Plan::kEdgeSucceeded, &err);
+  ASSERT_EQ("", err);
+  EXPECT_FALSE(plan_.work_ready());
+
+  // 'touch_slow' finishes second; the dependent edge can now start.
+  plan_.EdgeFinished(edge2, Plan::kEdgeSucceeded, &err);
+  ASSERT_EQ("", err);
+
+  // The next edge should now be ready to run.
+  EXPECT_TRUE(plan_.work_ready());
+}


### PR DESCRIPTION
## Issue
Fixes: #2782

## Problem Analysis
When an edge produces a dyndep file, Ninja performs two steps:
 - update the dependency graph with the newly discovered dependencies
 - update the build plan and schedule additional work

For edges that generate multiple dyndep files, Ninja previously processed them one at a time by immediately updating the plan after each individual dyndep file was loaded.

This meant the scheduler could observe a partially updated dependency graph while later dyndep files from the same edge had not yet been processed. As a result, newly discovered dependencies could be missed during scheduling, leading to incorrect build ordering in parallel builds.

## Proposed Change 
This PR changes the behavior to first load and apply all generated dyndep files to the graph. Only after the graph is fully updated, the build plan is refreshed.