### PR TITLE
Update lockfile mtime by writing a byte to it

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -865,7 +865,12 @@ bool Builder::StartEdge(Edge* edge, string* err) {
     if (!disk_interface_->MakeDirs((*o)->path()))
       return false;
     if (build_start == -1) {
-      disk_interface_->WriteFile(lock_file_path_, "", false);
+      disk_interface_->WriteFile(lock_file_path_, ".", false);
+      // It's necessary to write at least one byte to the lock file because
+      // otherwise, certain filesystems (e.g. tmpfs on macOS; AWS FSx mounted
+      // via NFS) expose a bug in their fopen() implementations where they
+      // fail to update the lock file's mtime. (POSIX requires that fopen()
+      // update the file's mtime when the mode is "wb".)
       build_start = disk_interface_->Stat(lock_file_path_, err);
       if (build_start == -1)
         build_start = 0;


### PR DESCRIPTION
\[This PR was produced by the use of artisanal methods only.]

On a tmpfs on macOS 26.5 (25F71), the use of

  DiskInterface::WriteFile(".ninja_lock", "", false)

...has no effect in all evaluations after the first, and this is because of a bug in Darwin's implementation of fopen(). In particular, in the event where a file foo already exists, and is stored on a tmpfs filesystem, the call fopen("foo", "wb") fails to update the mtime of the file foo. (According to POSIX, this call to fopen() should update the mtime.)

In this change, we work around that bug by writing a single byte to the lock file.

Fixes: #2784