### PR TITLE
dyndep: fix handling of multiple dyndep file outputs on one edge

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -222,6 +222,11 @@ bool Plan::EdgeFinished(Edge* edge, EdgeResult result, string* err) {
   want_.erase(e);
   edge->outputs_ready_ = true;
 
+  // Load dyndep info provided by this edge's outputs.
+  if (builder_ && !builder_->LoadDyndeps(edge, err)) {
+    return false;
+  }
+
   // Check off any nodes we were waiting for with this edge.
   for (vector<Node*>::iterator o = edge->outputs_.begin();
        o != edge->outputs_.end(); ++o) {
@@ -232,14 +237,6 @@ bool Plan::EdgeFinished(Edge* edge, EdgeResult result, string* err) {
 }
 
 bool Plan::NodeFinished(Node* node, string* err) {
-  // If this node provides dyndep info, load it now.
-  if (node->dyndep_pending()) {
-    assert(builder_ && "dyndep requires Plan to have a Builder");
-    // Load the now-clean dyndep file.  This will also update the
-    // build plan and schedule any new work that is ready.
-    return builder_->LoadDyndeps(node, err);
-  }
-
   // See if we we want any edges from this node.
   for (vector<Edge*>::const_iterator oe = node->out_edges().begin();
        oe != node->out_edges().end(); ++oe) {
@@ -324,21 +321,25 @@ bool Plan::CleanNode(DependencyScan* scan, Node* node, string* err) {
   return true;
 }
 
-bool Plan::DyndepsLoaded(DependencyScan* scan, const Node* node,
-                         const DyndepFile& ddf, string* err) {
+bool Plan::DyndepsLoaded(DependencyScan* scan,
+                         const std::vector<Node*>& dyndep_nodes,
+                         const std::unordered_map<Edge*, Dyndeps>& dyndep_edges,
+                         std::string* err) {
   // Recompute the dirty state of all our direct and indirect dependents now
   // that our dyndep information has been loaded.
-  if (!RefreshDyndepDependents(scan, node, err))
+  if (!RefreshDyndepDependents(scan, dyndep_nodes, err))
     return false;
 
-  // We loaded dyndep information for those out_edges of the dyndep node that
-  // specify the node in a dyndep binding, but they may not be in the plan.
+  // We loaded dyndep information for those out_edges of the dyndep nodes that
+  // specify one of them in a dyndep binding, but they may not be in the plan.
   // Starting with those already in the plan, walk newly-reachable portion
   // of the graph through the dyndep-discovered dependencies.
 
   // Find edges in the the build plan for which we have new dyndep info.
-  std::vector<DyndepFile::const_iterator> dyndep_roots;
-  for (DyndepFile::const_iterator oe = ddf.begin(); oe != ddf.end(); ++oe) {
+  std::vector<std::unordered_map<Edge*, Dyndeps>::const_iterator> dyndep_roots;
+  for (std::unordered_map<Edge*, Dyndeps>::const_iterator oe =
+           dyndep_edges.begin();
+       oe != dyndep_edges.end(); ++oe) {
     Edge* edge = oe->first;
 
     // If the edge outputs are ready we do not need to consider it here.
@@ -358,9 +359,10 @@ bool Plan::DyndepsLoaded(DependencyScan* scan, const Node* node,
 
   // Walk dyndep-discovered portion of the graph to add it to the build plan.
   std::set<Edge*> dyndep_walk;
-  for (std::vector<DyndepFile::const_iterator>::iterator
-       oei = dyndep_roots.begin(); oei != dyndep_roots.end(); ++oei) {
-    DyndepFile::const_iterator oe = *oei;
+  for (std::vector<std::unordered_map<Edge*, Dyndeps>::const_iterator>::iterator
+           oei = dyndep_roots.begin();
+       oei != dyndep_roots.end(); ++oei) {
+    std::unordered_map<Edge*, Dyndeps>::const_iterator oe = *oei;
     for (vector<Node*>::const_iterator i = oe->second.implicit_inputs_.begin();
          i != oe->second.implicit_inputs_.end(); ++i) {
       if (!AddSubTarget(*i, oe->first->outputs_[0], err, &dyndep_walk) &&
@@ -369,14 +371,16 @@ bool Plan::DyndepsLoaded(DependencyScan* scan, const Node* node,
     }
   }
 
-  // Add out edges from this node that are in the plan (just as
+  // Add dyndep node out edges that are in the plan (just as
   // Plan::NodeFinished would have without taking the dyndep code path).
-  for (vector<Edge*>::const_iterator oe = node->out_edges().begin();
-       oe != node->out_edges().end(); ++oe) {
-    map<Edge*, Want>::iterator want_e = want_.find(*oe);
-    if (want_e == want_.end())
-      continue;
-    dyndep_walk.insert(want_e->first);
+  for (Node* node : dyndep_nodes) {
+    for (vector<Edge*>::const_iterator oe = node->out_edges().begin();
+         oe != node->out_edges().end(); ++oe) {
+      map<Edge*, Want>::iterator want_e = want_.find(*oe);
+      if (want_e == want_.end())
+        continue;
+      dyndep_walk.insert(want_e->first);
+    }
   }
 
   // See if any encountered edges are now ready.
@@ -392,12 +396,15 @@ bool Plan::DyndepsLoaded(DependencyScan* scan, const Node* node,
   return true;
 }
 
-bool Plan::RefreshDyndepDependents(DependencyScan* scan, const Node* node,
+bool Plan::RefreshDyndepDependents(DependencyScan* scan,
+                                   const std::vector<Node*>& dyndep_nodes,
                                    string* err) {
   // Collect the transitive closure of dependents and mark their edges
   // as not yet visited by RecomputeDirty.
   set<Node*> dependents;
-  UnmarkDependents(node, &dependents);
+  for (Node* node : dyndep_nodes) {
+    UnmarkDependents(node, &dependents);
+  }
 
   // Update the dirty state of all dependents and check if their edges
   // have become wanted.
@@ -1064,17 +1071,25 @@ bool Builder::ExtractDeps(BuildResult::CommandCompleted& result,
   return true;
 }
 
-bool Builder::LoadDyndeps(Node* node, string* err) {
-  // Load the dyndep information provided by this node.
-  DyndepFile ddf;
-  if (!scan_.LoadDyndeps(node, &ddf, err))
-    return false;
+bool Builder::LoadDyndeps(Edge* edge, string* err) {
+  // Load the dyndep information provided by this edge's outputs.
+  std::vector<Node*> dyndep_nodes;
+  std::unordered_map<Edge*, Dyndeps> dyndep_edges;
+  for (Node* node : edge->outputs_) {
+    if (node->dyndep_pending()) {
+      // Load the dyndep information provided by this now-clean node.
+      DyndepFile ddf;
+      if (!scan_.LoadDyndeps(node, &ddf, err)) {
+        return false;
+      }
+      dyndep_nodes.emplace_back(node);
+      dyndep_edges.insert(std::make_move_iterator(ddf.begin()),
+                          std::make_move_iterator(ddf.end()));
+    }
+  }
 
   // Update the build plan to account for dyndep modifications to the graph.
-  if (!plan_.DyndepsLoaded(&scan_, node, ddf, err))
-    return false;
-
-  return true;
+  return plan_.DyndepsLoaded(&scan_, dyndep_nodes, dyndep_edges, err);
 }
 
 void Builder::SetFailureCode(ExitStatus code) {

--- a/src/build.h
+++ b/src/build.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "build_result.h"
@@ -85,9 +86,11 @@ struct Plan {
   void PrepareQueue();
 
   /// Update the build plan to account for modifications made to the graph
-  /// by information loaded from a dyndep file.
-  bool DyndepsLoaded(DependencyScan* scan, const Node* node,
-                     const DyndepFile& ddf, std::string* err);
+  /// by information loaded from a set of dyndep files.
+  bool DyndepsLoaded(DependencyScan* scan,
+                     const std::vector<Node*>& dyndep_nodes,
+                     const std::unordered_map<Edge*, Dyndeps>& dyndep_edges,
+                     std::string* err);
 
   /// Enumerate possible steps we want for an edge.
   enum Want
@@ -104,7 +107,9 @@ struct Plan {
 
  private:
   void ComputeCriticalPath();
-  bool RefreshDyndepDependents(DependencyScan* scan, const Node* node, std::string* err);
+  bool RefreshDyndepDependents(DependencyScan* scan,
+                               const std::vector<Node*>& dyndep_nodes,
+                               std::string* err);
   void UnmarkDependents(const Node* node, std::set<Node*>* dependents);
   bool AddSubTarget(const Node* node, const Node* dependent, std::string* err,
                     std::set<Edge*>* dyndep_walk);
@@ -239,8 +244,8 @@ struct Builder {
     scan_.set_build_log(log);
   }
 
-  /// Load the dyndep information provided by the given node.
-  bool LoadDyndeps(Node* node, std::string* err);
+  /// Load the dyndep information provided by the given edge's outputs.
+  bool LoadDyndeps(Edge* edge, std::string* err);
 
   State* state_;
   const BuildConfig& config_;

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -653,6 +653,7 @@ bool FakeCommandRunner::StartCommand(Edge* edge) {
       edge->rule().name() == "cc" ||
       edge->rule().name() == "cp_multi_msvc" ||
       edge->rule().name() == "cp_multi_gcc" ||
+      edge->rule().name() == "cp_other" ||
       edge->rule().name() == "touch" ||
       edge->rule().name() == "touch-interrupt" ||
       edge->rule().name() == "touch-fail-tick2") {
@@ -673,6 +674,17 @@ bool FakeCommandRunner::StartCommand(Edge* edge) {
     if (fs_->ReadFile(edge->inputs_[0]->path(), &content, &err) ==
         DiskInterface::Okay)
       fs_->WriteFile(edge->outputs_[0]->path(), content, false);
+  } else if (edge->rule().name() == "cp_inputs_to_outputs") {
+    assert(!edge->inputs_.empty());
+    assert(edge->outputs_.size() == edge->inputs_.size());
+    string content;
+    string err;
+    for (size_t i = 0; i < edge->inputs_.size(); ++i) {
+      if (fs_->ReadFile(edge->inputs_[i]->path(), &content, &err) ==
+          DiskInterface::Okay) {
+        fs_->WriteFile(edge->outputs_[i]->path(), content, false);
+      }
+    }
   } else if (edge->rule().name() == "touch-implicit-dep-out") {
     string dep = edge->GetBinding("test_dependency");
     fs_->Tick();
@@ -4161,6 +4173,47 @@ TEST_F(BuildTest, DyndepTwoLevelDiscoveredDirty) {
   EXPECT_EQ("touch in", command_runner_.commands_ran_[2]);
   EXPECT_EQ("touch tmp", command_runner_.commands_ran_[3]);
   EXPECT_EQ("touch out", command_runner_.commands_ran_[4]);
+}
+
+TEST_F(BuildTest, DyndepBuildMultiple) {
+  // Verify that multiple dyndep files can be produced by one edge
+  // and loaded in the opposite order than their dependents will run.
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+"rule touch\n"
+"  command = touch $out\n"
+"rule cp_inputs_to_outputs\n"
+"  command = cp dd3-in dd3 ; cp dd2-in dd2\n"
+"rule cp_other\n"
+"  command = cp out1 $out\n"
+"build dd3 dd2: cp_inputs_to_outputs dd3-in dd2-in\n"
+"build out3: touch in || dd3\n"
+"  dyndep = dd3\n"
+"build out2: cp_other || dd2\n"
+"  dyndep = dd2\n"
+"build out1: touch in\n"
+  ));
+  fs_.Create("in", "");
+  fs_.Create("dd3-in",
+"ninja_dyndep_version = 1\n"
+"build out3: dyndep | out2\n"
+);
+  fs_.Create("dd2-in",
+"ninja_dyndep_version = 1\n"
+"build out2: dyndep | out1\n"
+);
+
+  string err;
+  EXPECT_TRUE(builder_.AddTarget("out2", &err));
+  EXPECT_TRUE(builder_.AddTarget("out3", &err));
+  EXPECT_EQ("", err);
+
+  EXPECT_EQ(builder_.Build(&err), ExitSuccess);
+  EXPECT_EQ("", err);
+  ASSERT_EQ(4u, command_runner_.commands_ran_.size());
+  EXPECT_EQ("cp dd3-in dd3 ; cp dd2-in dd2", command_runner_.commands_ran_[0]);
+  EXPECT_EQ("touch out1", command_runner_.commands_ran_[1]);
+  EXPECT_EQ("cp out1 out2", command_runner_.commands_ran_[2]);
+  EXPECT_EQ("touch out3", command_runner_.commands_ran_[3]);
 }
 
 TEST_F(BuildTest, Validation) {


### PR DESCRIPTION
Normally an edge with a dyndep binding cannot be scheduled until its dyndep file is loaded because we require the dyndep file to be an input. However, in the case that one edge produces multiple dyndep files as outputs, none of their dependent edges is blocked on its dyndep input because all the dyndep files are ready.  Load all of the dyndep files before recomputing graph readiness to avoid mistakenly scheduling an edge that appears to be ready only because its dyndep information has not been loaded yet.

Fixes: #2782