### PR TITLE
Update status on edge finished

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -182,11 +182,11 @@ build b: echo
 build c: echo
   delay = 1
 ''', '-j3'),
-'''[1/3] echo c\x1b[K
+'''[1*3/3] echo c\x1b[K
 c
-[2/3] echo b\x1b[K
+[2*2/3] echo b\x1b[K
 b
-[3/3] echo a\x1b[K
+[3*1/3] echo a\x1b[K
 a
 ''')
 
@@ -199,7 +199,7 @@ build a: echo
 '''
         # Only strip color when ninja's output is piped.
         self.assertEqual(run(print_red),
-'''[1/1] echo a\x1b[K
+'''[1*1/1] echo a\x1b[K
 \x1b[31mred\x1b[0m
 ''')
         self.assertEqual(run(print_red, pipe=True),
@@ -233,7 +233,7 @@ red
 
 build a: cat
 ''', '-j3'),
-'''[1/1] cat cat.rsp cat.rsp > a\x1b[K
+'''[1*1/1] cat cat.rsp cat.rsp > a\x1b[K
 ''')
 
     def test_issue_2499(self) -> None:
@@ -251,12 +251,12 @@ build zoo: touch bar
 ''', flags='-j1 zoo', raw_output=True).split('\r'),
             [
                 '',
-                '[0/3] touch foo\x1b[K',
-                '[1/3] touch foo\x1b[K',
-                '[1/3] touch bar\x1b[K',
-                '[2/3] touch bar\x1b[K',
-                '[2/3] touch zoo\x1b[K',
-                '[3/3] touch zoo\x1b[K',
+                '[0*1/3] touch foo\x1b[K',
+                '[1*1/3] touch foo\x1b[K',
+                '[1*1/3] touch bar\x1b[K',
+                '[2*1/3] touch bar\x1b[K',
+                '[2*1/3] touch zoo\x1b[K',
+                '[3*1/3] touch zoo\x1b[K',
                 '\n',
             ])
 
@@ -379,7 +379,7 @@ ninja: build stopped: subcommand failed.
 
     def test_ninja_status_default(self) -> None:
         'Do we show the default status by default?'
-        self.assertEqual(run(Output.BUILD_SIMPLE_ECHO), '[1/1] echo a\x1b[K\ndo thing\n')
+        self.assertEqual(run(Output.BUILD_SIMPLE_ECHO), '[1*1/1] echo a\x1b[K\ndo thing\n')
 
     def test_ninja_status_quiet(self) -> None:
         'Do we suppress the status information when --quiet is specified?'

--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -76,8 +76,12 @@ StatusPrinter::StatusPrinter(const BuildConfig& config)
     progress_status_format_ = NULL;
   } else {
     progress_status_format_ = getenv("NINJA_STATUS");
-    if (!progress_status_format_)
-      progress_status_format_ = "[%f/%t] ";
+    if (!progress_status_format_) {
+      if (printer_.is_smart_terminal())
+        progress_status_format_ = "[%f*%r/%t] ";
+      else
+        progress_status_format_ = "[%f/%t] ";
+    }
   }
 }
 
@@ -114,6 +118,8 @@ void StatusPrinter::BuildEdgeStarted(const Edge* edge,
   ++started_edges_;
   ++running_edges_;
   time_millis_ = start_time_millis;
+  if (printer_.is_smart_terminal())
+    edges_.push_back(edge);
 
   if (edge->use_console() || printer_.is_smart_terminal())
     PrintStatus(edge, start_time_millis);
@@ -218,6 +224,12 @@ void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
   } else
     --eta_unpredictable_edges_remaining_;
 
+  if (printer_.is_smart_terminal()) {
+    *std::find(edges_.begin(), edges_.end(), edge) = nullptr;
+    while (!edges_.empty() && edges_.front() == nullptr)
+      edges_.pop_front();
+  }
+
   if (edge->use_console())
     printer_.SetConsoleLocked(false);
 
@@ -275,6 +287,9 @@ void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
     _setmode(_fileno(stdout), _O_TEXT);  // End Windows extra CR fix
 #endif
   }
+
+  if (printer_.is_smart_terminal() && !edges_.empty())
+    PrintStatus(edges_.front(), end_time_millis);
 }
 
 void StatusPrinter::BuildStarted() {

--- a/src/status_printer.h
+++ b/src/status_printer.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <queue>
 
@@ -106,6 +107,8 @@ struct StatusPrinter : Status {
   /// Parsed `--status` format, evaluated against status variables on each
   /// update. Null when `--status` was not supplied.
   std::unique_ptr<EvalString> status_eval_;
+
+  std::deque<const Edge*> edges_;
 
   template <size_t S>
   void SnprintfRate(double rate, char (&buf)[S], const char* format) const {


### PR DESCRIPTION
In the terminal, when an edge finishes update the status to display the first started (longest running) action.

Usually this will be immediately overwritten with the next started action but if there is a bottleneck in the build or if it is reaching the end, this ensures that the console displays status of a build that is actually running and not one that has completed.

This ensures that the user attributes any delay to the (or an) action that is actually causing the slowdown and not unfairly to an action that has already finished just because it happened to be the last started.

To make this clear, also change the default NINJA_STATUS to include current actual parallelism level - this will reduce from number of cores to 1 as the bottleneck or end of build approaches.

Implementation stores currently running nodes in a deque, with null for interior completed nodes. This should be fairly efficient and allows future extension to e.g. display multiple parallel action names, as in

Partially resolves #111 (should be enough for most purposes).