### PR TITLE
Fix bootstrap with unit tests

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -662,7 +662,6 @@ if gtest_src_dir:
         'manifest_parser_test',
         'ninja_test',
         'state_test',
-        'string_piece_util',
         'string_piece_util_test',
         'subprocess_test',
         'test',


### PR DESCRIPTION
```
bootstrap complete.  rebuilding...
ninja: error: build.ninja:220: multiple rules generate build/string_piece_util.o

Traceback (most recent call last):
  File "/home/orgads/Projects/ninja/./configure.py", line 813, in <module>
    subprocess.check_call(rebuild_args)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/subprocess.py", line 419, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['./ninja']' returned non-zero exit status 1.
```

Amends commit 0d3b9f16b376b1e31c94e60180dacb1f336ebe31.
