### PR TITLE
Add opt-in multi-line real-time build status display

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -392,6 +392,57 @@ ninja: build stopped: subcommand failed.
                      flags="--status '<${finished}/${total}> '")
         self.assertEqual(output, '<1/1> echo a\x1b[K\ndo thing\n')
 
+    def test_multiline_flag(self) -> None:
+        long_title = 'component/subdir/very/long/job/title/that/should/keep/the/right_side/of/the_name'
+        output = run(
+            f'''rule echo
+  command = printf "done"
+  description = {long_title}
+
+build a: echo
+''',
+            flags='-m',
+            raw_output=True)
+        status_line = '[1/1] ...le/that/should/keep/the/right_side/of/the_name 0.0s\x1b[K'
+        self.assertEqual(len(status_line.replace('\x1b[K', '')), 60)
+        self.assertEqual(
+            output,
+            f'{status_line}\r\n'
+            f'\x1b[J\x1b[1A{status_line}\r\n'
+            '\x1b[Jdone\r\n')
+
+    def test_multiline_single_hidden_edge(self) -> None:
+        output = run(
+'''rule echo
+  command = sleep 1 && echo $out
+  description = echo $out
+
+build a: echo
+build b: echo
+build c: echo
+build d: echo
+build e: echo
+build f: echo
+build g: echo
+build h: echo
+build i: echo
+''',
+            flags='-j9 -m',
+            raw_output=True)
+        self.assertRegex(
+            output,
+            r'(?s)^'
+            r'\[1/9\] echo a\.+ 0\.\ds\x1b\[K\r\n'
+            r'\[2/9\] echo b\.+ 0\.\ds\x1b\[K\r\n'
+            r'\[3/9\] echo c\.+ 0\.\ds\x1b\[K\r\n'
+            r'\[4/9\] echo d\.+ 0\.\ds\x1b\[K\r\n'
+            r'\[5/9\] echo e\.+ 0\.\ds\x1b\[K\r\n'
+            r'\[6/9\] echo f\.+ 0\.\ds\x1b\[K\r\n'
+            r'\[7/9\] echo g\.+ 0\.\ds\x1b\[K\r\n'
+            r'\[8/9\] echo h\.+ 0\.\ds\x1b\[K\r\n'
+            r'\[9/9\] echo i\.+ 0\.\ds\x1b\[K\r\n')
+        self.assertNotIn('... and 1 more', output)
+
     def test_status_flag_unknown_variable(self) -> None:
         'Does --status fail clearly on an unknown variable?'
         self._test_expected_error(

--- a/src/build.cc
+++ b/src/build.cc
@@ -615,6 +615,7 @@ Builder::Builder(State* state, const BuildConfig& config, BuildLog* build_log,
       explanations_(g_explaining ? new Explanations(status) : nullptr),
       scan_(state, build_log, deps_log, disk_interface,
             &config_.depfile_parser_options, explanations_.get()) {
+  status->SetStartTimeMillis(start_time_millis);
   lock_file_path_ = ".ninja_lock";
   string build_dir = state_->bindings_.LookupVariable("builddir");
   if (!build_dir.empty())
@@ -715,7 +716,7 @@ ExitStatus Builder::Build(string* err) {
     if (config_.dry_run)
       command_runner_.reset(new DryRunCommandRunner);
     else
-      command_runner_.reset(CommandRunner::factory(config_, jobserver_.get()));
+      command_runner_.reset(CommandRunner::factory(config_, status_, jobserver_.get()));
     ;
   }
 
@@ -842,6 +843,7 @@ ExitStatus Builder::Build(string* err) {
   }
 
   status_->BuildFinished();
+  status_->Report();
   return ExitSuccess;
 }
 
@@ -851,6 +853,7 @@ bool Builder::StartEdge(Edge* edge, string* err) {
     return true;
 
   int64_t start_time_millis = GetTimeMillis() - start_time_millis_;
+  edge->start_time_ = start_time_millis;
   running_edges_.insert(make_pair(edge, start_time_millis));
 
   status_->BuildEdgeStarted(edge, start_time_millis);

--- a/src/build.h
+++ b/src/build.h
@@ -178,6 +178,7 @@ struct CommandRunner {
   /// Creates the RealCommandRunner. \arg jobserver can be nullptr if there
   /// is no jobserver pool to use.
   static CommandRunner* factory(const BuildConfig& config,
+                                Status* status,
                                 Jobserver::Client* jobserver);
 };
 
@@ -192,6 +193,7 @@ struct BuildConfig {
     VERBOSE
   };
   Verbosity verbosity = NORMAL;
+  bool multiline_console = false;
   bool dry_run = false;
   int parallelism = 1;
   bool disable_jobserver_client = false;

--- a/src/graph.h
+++ b/src/graph.h
@@ -220,6 +220,8 @@ struct Edge {
   BindingEnv* env_ = nullptr;
   size_t id_ = 0;
   int64_t critical_path_weight_ = -1;
+  int64_t start_time_ = 0;
+  int sequence_ = 0;
 
   /// A Jobserver slot instance. Invalid by default.
   Jobserver::Slot job_slot_;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -233,6 +233,7 @@ void Usage(const BuildConfig& config) {
 "options:\n"
 "  --version      print ninja version (\"%s\")\n"
 "  -v, --verbose  show all command lines while building\n"
+"  -m             enable multiline status display when supported\n"
 "  --quiet        don't show progress status, just command output\n"
 "  --status FMT   progress status format using Ninja-style $vars\n"
 "                 (e.g. --status '[$finished/$total] ')\n"
@@ -1743,7 +1744,7 @@ int ReadFlags(int* argc, char*** argv,
 
   int opt;
   while (!options->tool &&
-         (opt = getopt_long(*argc, *argv, "d:f:j:k:l:nt:vw:C:h", kLongOptions,
+      (opt = getopt_long(*argc, *argv, "d:f:j:k:l:mnt:vw:C:h", kLongOptions,
                             NULL)) != -1) {
     switch (opt) {
       case 'd':
@@ -1788,6 +1789,9 @@ int ReadFlags(int* argc, char*** argv,
         config->max_load_average = value;
         break;
       }
+      case 'm':
+        config->multiline_console = true;
+        break;
       case 'n':
         config->dry_run = true;
         config->disable_jobserver_client = true;

--- a/src/real_command_runner.cc
+++ b/src/real_command_runner.cc
@@ -16,12 +16,15 @@
 #include "exit_status.h"
 #include "jobserver.h"
 #include "limits.h"
+#include "metrics.h"
+#include "status.h"
 #include "subprocess.h"
 
 struct RealCommandRunner : public CommandRunner {
   explicit RealCommandRunner(const BuildConfig& config,
+                             Status *status,
                              Jobserver::Client* jobserver)
-      : config_(config), jobserver_(jobserver) {}
+      : config_(config), status_(status),  jobserver_(jobserver) {}
   size_t CanRunMore() const override;
   bool StartCommand(Edge* edge) override;
   BuildResult WaitForCommand() override;
@@ -38,9 +41,11 @@ struct RealCommandRunner : public CommandRunner {
   }
 
   const BuildConfig& config_;
+  Status* status_;
   SubprocessSet subprocs_;
   Jobserver::Client* jobserver_ = nullptr;
   std::map<const Subprocess*, Edge*> subproc_to_edge_;
+  int64_t timer_ = 0;
 };
 
 std::vector<Edge*> RealCommandRunner::GetActiveEdges() {
@@ -119,6 +124,11 @@ BuildResult RealCommandRunner::WaitForCommandOrJobserverToken(
   // Wait for DoWork() to report activity
   while (work_result == SubprocessSet::WorkResult::NoWork) {
     work_result = subprocs_.DoWork();
+    const int64_t now = GetTimeMillis();
+    if (now - timer_ > 100) {
+      timer_ = now;
+      status_->Report();
+    }
   }
 
   // Address interrupts first, then subprocesses finishing, then finally
@@ -155,6 +165,7 @@ BuildResult RealCommandRunner::WaitForCommandOrJobserverToken(
 }
 
 CommandRunner* CommandRunner::factory(const BuildConfig& config,
+                                      Status* status,
                                       Jobserver::Client* jobserver) {
-  return new RealCommandRunner(config, jobserver);
+  return new RealCommandRunner(config, status, jobserver);
 }

--- a/src/status.h
+++ b/src/status.h
@@ -25,15 +25,17 @@ struct Explanations;
 /// Abstract interface to object that tracks the status of a build:
 /// completion fraction, printing updates.
 struct Status {
+  virtual void SetStartTimeMillis(int64_t start_time_millis) = 0;
   virtual void EdgeAddedToPlan(const Edge* edge) = 0;
   virtual void EdgeRemovedFromPlan(const Edge* edge) = 0;
-  virtual void BuildEdgeStarted(const Edge* edge,
+  virtual void BuildEdgeStarted(Edge* edge,
                                 int64_t start_time_millis) = 0;
   virtual void BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
                                  int64_t end_time_millis, ExitStatus exit_code,
                                  const std::string& output) = 0;
   virtual void BuildStarted() = 0;
   virtual void BuildFinished() = 0;
+  virtual void Report() = 0;
 
   /// Set the Explanations instance to use to report explanations,
   /// argument can be nullptr if no explanations need to be printed

--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -29,12 +29,17 @@
 #ifdef _WIN32
 #include <fcntl.h>
 #include <io.h>
+#include <windows.h>
+#else
+#include <sys/ioctl.h>
+#include <unistd.h>
 #endif
 
 #include "build.h"
 #include "debug_flags.h"
 #include "exit_status.h"
 #include "lexer.h"
+#include "metrics.h"
 #include "util.h"
 
 using namespace std;
@@ -57,11 +62,37 @@ Status* Status::factory(const BuildConfig& config) {
 
 StatusPrinter::StatusPrinter(const BuildConfig& config)
     : config_(config), started_edges_(0), finished_edges_(0), total_edges_(0),
-      running_edges_(0), progress_status_format_(NULL),
+      progress_status_format_(NULL),
       current_rate_(config.parallelism) {
   // Don't do anything fancy in verbose mode.
   if (config_.verbosity != BuildConfig::NORMAL)
     printer_.set_smart_terminal(false);
+
+  // If explicitly enabled and the terminal supports ANSI codes, use
+  // multi-line real-time status.
+  if (config_.multiline_console && printer_.supports_color()) {
+    multi_line_status_ = true;
+    printer_.set_smart_terminal(false);
+
+    // Limit status lines to terminal height - 1 (for the cursor line),
+    // capped at 8.
+    int term_lines = 0;
+#ifdef _WIN32
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi)) {
+      term_lines = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+      term_cols_ = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+    }
+#else
+    struct winsize ws = {};
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0 && ws.ws_row > 0)
+      term_lines = ws.ws_row;
+    if (ws.ws_col > 0)
+      term_cols_ = ws.ws_col;
+#endif
+    if (term_lines > 1 && term_lines - 1 < max_status_lines_)
+      max_status_lines_ = term_lines - 1;
+  }
 
   if (config.progress_status_format) {
     // --status uses Ninja-style variable expansion ($var / ${var}).
@@ -109,13 +140,14 @@ void StatusPrinter::EdgeRemovedFromPlan(const Edge* edge) {
     --eta_unpredictable_edges_remaining_;
 }
 
-void StatusPrinter::BuildEdgeStarted(const Edge* edge,
+void StatusPrinter::BuildEdgeStarted(Edge* edge,
                                      int64_t start_time_millis) {
+  edges_.push_back(edge);
   ++started_edges_;
-  ++running_edges_;
+  edge->sequence_ = started_edges_;
   time_millis_ = start_time_millis;
 
-  if (edge->use_console() || printer_.is_smart_terminal())
+  if (!multi_line_status_ && (edge->use_console() || printer_.is_smart_terminal()))
     PrintStatus(edge, start_time_millis);
 
   if (edge->use_console())
@@ -224,10 +256,30 @@ void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
   if (config_.verbosity == BuildConfig::QUIET)
     return;
 
-  if (!edge->use_console())
+  if (!multi_line_status_ && !edge->use_console())
     PrintStatus(edge, end_time_millis);
 
-  --running_edges_;
+  // In multi-line mode, overwrite the display block in place to avoid flicker.
+  if (multi_line_status_) {
+    // Move cursor to the top of the entire display block.
+    int total_up = last_reported_ + (has_kept_line_ ? 1 : 0);
+    if (total_up > 0)
+      printf("\x1B[%dA", total_up);
+    // Print the finished edge as the new kept line.
+    PrintStatus(edge, end_time_millis);
+    has_kept_line_ = true;
+    last_reported_ = 0;
+  }
+
+  edges_.remove(edge);
+
+  // If there's error/output, clear the old status lines below the kept line
+  // and let the next Report() redraw them after the output.
+  if (multi_line_status_ && (exit_code != ExitSuccess || !output.empty())) {
+    printf("\x1B[J");
+    fflush(stdout);
+    has_kept_line_ = false;
+  }
 
   // Print the command that is spewing before printing its output.
   if (exit_code != ExitSuccess) {
@@ -275,17 +327,73 @@ void StatusPrinter::BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
     _setmode(_fileno(stdout), _O_TEXT);  // End Windows extra CR fix
 #endif
   }
+
+  // Immediately redraw status area to avoid flicker.
+  if (multi_line_status_ && has_kept_line_)
+    Report();
 }
 
 void StatusPrinter::BuildStarted() {
   started_edges_ = 0;
   finished_edges_ = 0;
-  running_edges_ = 0;
+  edges_.clear();
+  last_reported_ = 0;
 }
 
 void StatusPrinter::BuildFinished() {
+  ClearReport();
   printer_.SetConsoleLocked(false);
   printer_.PrintOnNewLine("");
+}
+
+void StatusPrinter::Report() {
+  if (!multi_line_status_ || edges_.empty()) {
+    if (last_reported_ > 0)
+      ClearReport();
+    return;
+  }
+
+  if (config_.verbosity == BuildConfig::QUIET
+      || config_.verbosity == BuildConfig::NO_STATUS_UPDATE)
+    return;
+
+  const int64_t now = GetTimeMillis() - start_time_millis_;
+
+  if (last_reported_ > 0)
+    printf("\x1B[%dA", last_reported_);
+
+  int lines = 0;
+  list<const Edge*>::const_iterator edge = edges_.begin();
+  for (; edge != edges_.end(); ++edge) {
+    if (lines >= max_status_lines_)
+      break;
+    PrintStatus(*edge, now);
+    ++lines;
+  }
+  const int hidden_edges = int(edges_.size()) - max_status_lines_;
+  if (hidden_edges == 1 && edge != edges_.end()) {
+    PrintStatus(*edge, now);
+    ++lines;
+  } else if (hidden_edges > 0) {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "  ... and %d more", hidden_edges);
+    printf("%s\x1B[K\n", buf);
+    ++lines;
+  }
+
+  // Clear any remaining lines from previous report or overwritten block.
+  printf("\x1B[J");
+
+  last_reported_ = lines;
+  fflush(stdout);
+}
+
+void StatusPrinter::ClearReport() {
+  if (last_reported_ > 0) {
+    printf("\x1B[%dA\x1B[J", last_reported_);
+    fflush(stdout);
+    last_reported_ = 0;
+  }
 }
 
 string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
@@ -314,7 +422,7 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
 
         // Running edges.
       case 'r': {
-        snprintf(buf, sizeof(buf), "%d", running_edges_);
+        snprintf(buf, sizeof(buf), "%d", int(edges_.size()));
         out += buf;
         break;
       }
@@ -444,7 +552,7 @@ string StatusPrinter::FormatStatusVariable(const string& name) const {
     return buf;
   }
   if (name == "running") {
-    snprintf(buf, sizeof(buf), "%d", running_edges_);
+    snprintf(buf, sizeof(buf), "%d", int(edges_.size()));
     return buf;
   }
   if (name == "remaining") {
@@ -525,9 +633,61 @@ void StatusPrinter::PrintStatus(const Edge* edge, int64_t time_millis) {
   if (status_eval_) {
     StatusFormatEnv env(this);
     to_print = status_eval_->Evaluate(&env) + to_print;
+  } else if (multi_line_status_) {
+    // In multi-line mode, show each edge's own start order number.
+    char prefix[32];
+    snprintf(prefix, sizeof(prefix), "[%d/%d] ", edge->sequence_,
+             total_edges_);
+    to_print = string(prefix) + to_print;
   } else {
     to_print = FormatProgressStatus(progress_status_format_, time_millis)
         + to_print;
+  }
+
+  if (multi_line_status_) {
+    // Add dot-padding and elapsed time for multi-line display.
+    const int ds = static_cast<int>(time_millis - edge->start_time_) / 100;
+    char tbuf[32];
+    snprintf(tbuf, sizeof(tbuf), " %d.%ds", ds / 10, ds % 10);
+    const int time_len = static_cast<int>(strlen(tbuf));
+
+    // Clamp visible width to 60 to keep the multiline block compact.
+    int width = term_cols_ > 0 ? min(term_cols_, 60) : 60;
+    int text_width = width - time_len;
+    if (text_width < 0)
+      text_width = 0;
+
+    size_t prefix_len = 0;
+    if (!status_eval_) {
+      char prefix[32];
+      snprintf(prefix, sizeof(prefix), "[%d/%d] ", edge->sequence_, total_edges_);
+      prefix_len = strlen(prefix);
+    }
+
+    if (int(to_print.size()) > text_width) {
+      if (text_width > static_cast<int>(prefix_len) + 3) {
+        string prefix = to_print.substr(0, prefix_len);
+        int title_width = text_width - static_cast<int>(prefix_len);
+        string title = to_print.substr(prefix_len);
+        if (int(title.size()) > title_width) {
+          title = "..." + title.substr(title.size() - (title_width - 3));
+        }
+        to_print = prefix + title;
+      } else if (text_width > 3) {
+        to_print = "..." + to_print.substr(to_print.size() - (text_width - 3));
+      } else {
+        to_print = to_print.substr(to_print.size() - text_width);
+      }
+    }
+
+    if (int(to_print.size()) < text_width) {
+      to_print += '.';
+      int pad = text_width - int(to_print.size());
+      if (pad > 0)
+        to_print += string(pad, '.');
+    }
+    to_print += tbuf;
+    to_print += "\x1B[K";
   }
 
   printer_.Print(to_print,

--- a/src/status_printer.h
+++ b/src/status_printer.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <cstdint>
+#include <list>
 #include <memory>
 #include <queue>
 
@@ -27,17 +28,22 @@
 /// human-readable strings to stdout
 struct StatusPrinter : Status {
   explicit StatusPrinter(const BuildConfig& config);
+  void SetStartTimeMillis(int64_t start_time_millis) override
+  {
+    start_time_millis_ = start_time_millis;
+  }
 
   /// Callbacks for the Plan to notify us about adding/removing Edge's.
   void EdgeAddedToPlan(const Edge* edge) override;
   void EdgeRemovedFromPlan(const Edge* edge) override;
 
-  void BuildEdgeStarted(const Edge* edge, int64_t start_time_millis) override;
+  void BuildEdgeStarted(Edge* edge, int64_t start_time_millis) override;
   void BuildEdgeFinished(Edge* edge, int64_t start_time_millis,
                                  int64_t end_time_millis, ExitStatus exit_code,
                                  const std::string& output) override;
   void BuildStarted() override;
   void BuildFinished() override;
+  void Report() override;
 
   void NewLine() override;
   void Info(const char* msg, ...) override;
@@ -64,10 +70,18 @@ struct StatusPrinter : Status {
 
  private:
   void PrintStatus(const Edge* edge, int64_t time_millis);
+  void ClearReport();
 
   const BuildConfig& config_;
 
-  int started_edges_, finished_edges_, total_edges_, running_edges_;
+  int started_edges_, finished_edges_, total_edges_;
+  bool multi_line_status_ = false;
+  int max_status_lines_ = 8;
+  int term_cols_ = 0;
+  int last_reported_ = 0;
+  bool has_kept_line_ = false;
+  int64_t start_time_millis_ = 0;
+  std::list<const Edge*> edges_;
 
   /// How much wall clock elapsed so far?
   int64_t time_millis_ = 0;

--- a/src/subprocess-posix.cc
+++ b/src/subprocess-posix.cc
@@ -352,7 +352,8 @@ SubprocessSet::WorkResult SubprocessSet::DoWork() {
 
   interrupted_ = 0;
   s_sigchld_received = 0;
-  int ret = ppoll(&fds.front(), nfds, NULL, &old_mask_);
+  struct timespec timeout = { 0, 100 * 1000 * 1000 };  // 100ms
+  int ret = ppoll(&fds.front(), nfds, &timeout, &old_mask_);
   // Note: This can remove console processes from the running set, but that is
   // not a problem for the pollfd set, as console processes are not part of the
   // pollfd set (they don't have a fd).
@@ -430,7 +431,8 @@ SubprocessSet::WorkResult SubprocessSet::DoWork() {
 
   interrupted_ = 0;
   s_sigchld_received = 0;
-  int ret = pselect(nfds, (nfds > 0 ? &set : nullptr), 0, 0, 0, &old_mask_);
+  struct timespec timeout = { 0, 100 * 1000 * 1000 };  // 100ms
+  int ret = pselect(nfds, (nfds > 0 ? &set : nullptr), 0, 0, &timeout, &old_mask_);
   CheckConsoleProcessTerminated(&work_result);
   if (ret == -1) {
     if (errno != EINTR) {

--- a/src/subprocess-win32.cc
+++ b/src/subprocess-win32.cc
@@ -258,8 +258,11 @@ SubprocessSet::WorkResult SubprocessSet::DoWork() {
   WorkResult work_result = WorkResult::NoWork;
 
   if (!GetQueuedCompletionStatus(ioport_, &bytes_read, (PULONG_PTR)&subproc,
-                                 &overlapped, INFINITE)) {
-    if (GetLastError() != ERROR_BROKEN_PIPE)
+                                 &overlapped, 100)) {
+    DWORD err = GetLastError();
+    if (err == WAIT_TIMEOUT)
+      return WorkResult::NoWork;
+    if (err != ERROR_BROKEN_PIPE)
       Win32Fatal("GetQueuedCompletionStatus");
   }
 


### PR DESCRIPTION
Add an opt-in `-m` status mode that shows currently running edges in a multi-line real-time status area on ANSI-capable terminals, while preserving the existing single-line output when the flag is not used.

Each status line shows the edge sequence number, description, and elapsed time. The multiline display is capped to the terminal height and 8 rows, and its width is clamped to 60 columns. Long job titles are trimmed from the left so the right side remains visible.

The last finished edge is kept as a temporary line above the active status block, overwritten by the next completion. Error output and command output are printed cleanly after clearing the status area.

Key changes:
- Add `-m` to enable multiline status explicitly.
- Keep default output unchanged when `-m` is not given.
- Add 100ms timeout to ppoll/pselect/IOCP so DoWork() returns periodically and refreshes status via Report().
- Detect terminal dimensions to cap status lines at min(rows - 1, 8).
- Clamp multiline width to 60 columns and trim long titles from the left.
- Track each edge's start order via Edge::sequence_ for per-line numbering.
- Overwrite the display block in place to reduce flicker.
- Show `... and N more` when running edges exceed the display limit.

Fixes #111.