### PR TITLE
jobserver: accept socket descriptors in addition to fifo/char-device

### DIFF
--- a/src/jobserver-posix.cc
+++ b/src/jobserver-posix.cc
@@ -26,12 +26,13 @@
 
 namespace {
 
-// Return true if |fd| is a fifo or character device.
+// Return true if |fd| is a fifo, character device, or socket.
 bool IsJobserverDescriptor(int fd) {
   struct stat info;
   int ret = ::fstat(fd, &info);
   return (ret == 0) && (((info.st_mode & S_IFMT) == S_IFIFO) ||
-                        ((info.st_mode & S_IFMT) == S_IFCHR));
+                        ((info.st_mode & S_IFMT) == S_IFCHR) ||
+                        ((info.st_mode & S_IFMT) == S_IFSOCK));
 }
 
 // Implementation of Jobserver::Client for Posix systems


### PR DESCRIPTION
A jobserver pool may be implemented over a Unix domain socket pair rather than a named pipe. The token semantics are identical (one byte read = acquire a slot, one byte written = release a slot), and read/write/poll behave the same on a socket as on a pipe, so the descriptor-type sanity check should accept S_IFSOCK as well.

This follows the precedent of accepting S_IFCHR for CUSE/FUSE-emulated FIFOs; Many other clients, including make itself, performs no such descriptor type check at all.