### PR TITLE
Fix signature mismatch in `StatusFormatEnv`

### DIFF
--- a/src/status_printer.cc
+++ b/src/status_printer.cc
@@ -48,7 +48,7 @@ struct StatusFormatEnv : public Env {
   const string& description;
   StatusFormatEnv(const StatusPrinter* p, const string& d)
       : printer(p), description(d) {}
-  string LookupVariable(const string& var) override {
+  string LookupVariable(StringPiece var) override {
     if (var == "description")
       return description;
     return printer->FormatStatusVariable(var);
@@ -437,7 +437,7 @@ string StatusPrinter::FormatProgressStatus(const char* progress_status_format,
   return out;
 }
 
-string StatusPrinter::FormatStatusVariable(const string& name) const {
+string StatusPrinter::FormatStatusVariable(StringPiece name) const {
   char buf[32];
 
   if (name == "started") {
@@ -506,7 +506,7 @@ string StatusPrinter::FormatStatusVariable(const string& name) const {
     return buf;
   }
 
-  Fatal("unknown variable '%s' in --status format", name.c_str());
+  Fatal("unknown variable '%s' in --status format", name.AsString().c_str());
   return "";
 }
 

--- a/src/status_printer.h
+++ b/src/status_printer.h
@@ -22,6 +22,7 @@
 #include "explanations.h"
 #include "line_printer.h"
 #include "status.h"
+#include "string_piece.h"
 
 /// Implementation of the Status interface that prints the status as
 /// human-readable strings to stdout
@@ -55,7 +56,7 @@ struct StatusPrinter : Status {
   /// Look up the value of a named status variable (used by `--status`,
   /// which evaluates a Ninja-style format string). Calls Fatal on an
   /// unknown name.
-  std::string FormatStatusVariable(const std::string& name) const;
+  std::string FormatStatusVariable(StringPiece name) const;
 
   /// Set the |explanations_| pointer. Used to implement `-d explain`.
   void SetExplanations(Explanations* explanations) override {


### PR DESCRIPTION
`StatusFormatEnv` was added as an implementation of `Env`, but at the same time the signature of `LookupVariable` was changed.  This caused a compilation failure when both were merged.