### PR TITLE
Unittest DyndepBuildDiscoverOutputAndDepfileInput

### DIFF
--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -3805,13 +3805,11 @@ TEST_F(BuildTest, DyndepBuildDiscoverOutputAndDepfileInput) {
   EXPECT_TRUE(builder_.AddTarget("out", &err));
   ASSERT_EQ("", err);
 
-  // Loading the depfile did not give tmp.imp a phony input edge.
-  ASSERT_FALSE(GetNode("tmp.imp")->in_edge());
-
   EXPECT_EQ(builder_.Build(&err), ExitSuccess);
   EXPECT_EQ("", err);
 
   // Loading the dyndep file gave tmp.imp a real input edge.
+  ASSERT_TRUE(GetNode("tmp.imp")->in_edge());
   ASSERT_FALSE(GetNode("tmp.imp")->in_edge()->is_phony());
 
   ASSERT_EQ(3u, command_runner_.commands_ran_.size());


### PR DESCRIPTION
PR #2680 changed how depfiles are loaded, which requires updating the DyndepBuildDiscoverOutputAndDepfileInput unittest.

The call to 
`GetNode("tmp.imp")`
no longer returns an existing node but instead creates a new one. Since PR #2680, no depfile is loaded at this point anymore. Previously, the node `tmp.imp` had already been added to the graph when the depfile was loaded.

As a result, the corresponding ASSERT(...) has been removed.