### PR TITLE
Preserve tool arguments before -t selection

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -20,6 +20,7 @@ import typing as T
 default_env = dict(os.environ)
 default_env.pop('NINJA_STATUS', None)
 default_env.pop('CLICOLOR_FORCE', None)
+default_env.pop('POSIXLY_CORRECT', None)
 default_env['TERM'] = ''
 NINJA_PATH = os.path.abspath('./ninja')
 
@@ -131,6 +132,20 @@ class BuildDir:
             return output.decode('utf-8')
         return remove_non_visible_lines(output)
 
+    def run_args(
+        self,
+        args: T.Sequence[str],
+        env: T.Dict[str, str] = default_env,
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [NINJA_PATH, *args],
+            cwd=self.d.name,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
 def run(
     build_ninja: str,
     flags: T.Optional[str] = None,
@@ -143,6 +158,234 @@ def run(
     """
     with BuildDir(build_ninja) as b:
         return b.run(flags, pipe, raw_output, env, print_err_output)
+
+class CommandLine(unittest.TestCase):
+    COMMANDS_PLAN = '''\
+rule echo
+  command = echo $out
+
+build foo.o: echo
+build bar.o: echo
+build baz.o: echo
+'''
+
+    COMMANDS_WITH_DEPS_PLAN = '''\
+rule echo
+  command = echo $out
+
+build foo.dep: echo
+build foo.o: echo foo.dep
+build bar.dep: echo
+build bar.o: echo bar.dep
+'''
+
+    INPUTS_PLAN = '''\
+rule cat
+  command = cat $in $out
+build out1: cat in1
+build out2: cat in2 out1
+build out3: cat out2 out1 | implicit || order_only
+'''
+
+    def test_tool_arguments_before_selection(self) -> None:
+        with BuildDir(self.COMMANDS_WITH_DEPS_PLAN) as b:
+            result = b.run_args([
+                '-f', 'build.ninja', '--status', 'unused', '--quiet',
+                '-s', 'foo.o',
+                '-t', 'commands', 'bar.o',
+            ])
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, 'echo foo.o\necho bar.o\n')
+
+            result = b.run_args(['-t', 'commands', '-s', 'foo.o'])
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, 'echo foo.o\n')
+
+        with BuildDir(self.INPUTS_PLAN) as b:
+            result = b.run_args([
+                '--dependency-order', 'out3', '-t', 'inputs',
+            ])
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, '''\
+in2
+in1
+out1
+out2
+implicit
+order_only
+''')
+
+        with BuildDir('''\
+rule generator
+  command = echo $out
+  generator = 1
+build generated: generator
+''') as b:
+            generated = os.path.join(b.path, 'generated')
+            with open(generated, 'w'):
+                pass
+            result = b.run_args(['-g', '-t', 'clean'])
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(os.path.exists(generated))
+
+    def test_global_options_before_tool_selection(self) -> None:
+        prefixes = (
+            ['-n'],
+            ['-v'],
+            ['-nv'],
+            ['-j1'],
+            ['-j', '1'],
+            ['-k0'],
+            ['-l0'],
+            ['-d', 'explain'],
+            ['-w', 'phonycycle=warn'],
+            ['-fbuild.ninja'],
+            ['-f', 'build.ninja'],
+            ['-C.'],
+            ['-C', '.'],
+            ['--verbose'],
+            ['--quiet'],
+            ['--status=unused'],
+            ['--status', 'unused'],
+        )
+        expected = 'echo foo.o\necho bar.o\n'
+        with BuildDir(self.COMMANDS_WITH_DEPS_PLAN) as b:
+            for prefix in prefixes:
+                args = [*prefix, '-s', 'foo.o', '-t', 'commands', 'bar.o']
+                with self.subTest(prefix=prefix):
+                    result = b.run_args(args)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout, expected)
+
+        with BuildDir(self.COMMANDS_PLAN) as b:
+            result = b.run_args([
+                'foo.o', '-v', '--quiet', '-t', 'commands', 'bar.o',
+            ])
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, 'echo foo.o\necho bar.o\n')
+
+            result = b.run_args([
+                '--verb', 'foo.o', '-t', 'commands', 'bar.o',
+            ])
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, 'echo foo.o\necho bar.o\n')
+
+            version = b.run_args(['--version'])
+            abbreviated_version = b.run_args(['--vers', '-t', 'commands'])
+            self.assertEqual(abbreviated_version.returncode, version.returncode)
+            self.assertEqual(abbreviated_version.stdout, version.stdout)
+            self.assertEqual(abbreviated_version.stderr, version.stderr)
+
+    def test_tool_selection_boundaries(self) -> None:
+        with BuildDir(self.COMMANDS_PLAN) as b:
+            cases = (
+                (['-t', 'commands', 'foo.o'], 'echo foo.o\n'),
+                (['foo.o', '-tcommands', 'bar.o'],
+                 'echo foo.o\necho bar.o\n'),
+                (['foo.o', '-vtcommands', 'bar.o'],
+                 'echo foo.o\necho bar.o\n'),
+                (['foo.o', '-v', '-t', 'commands'], 'echo foo.o\n'),
+                (['-t', 'commands', '--', 'foo.o'], 'echo foo.o\n'),
+            )
+            for args, expected in cases:
+                with self.subTest(args=args):
+                    result = b.run_args(args)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout, expected)
+
+            result = b.run_args([
+                '--not-a-command-option', '-t', 'commands',
+            ])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('usage: ninja -t commands', result.stdout)
+
+            result = b.run_args(['-:', '-t', 'commands'])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('usage: ninja -t commands', result.stdout)
+
+        with BuildDir('') as b:
+            result = b.run_args(['--', '-t', 'commands'])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unknown target '-t'", result.stderr)
+
+            result = b.run_args(['--not-a-ninja-option'])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('usage: ninja [options]', result.stderr)
+
+            result = b.run_args(['--ver', '-t', 'commands'])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('ambiguous', result.stderr)
+            self.assertIn('usage: ninja [options]', result.stderr)
+
+            result = b.run_args(['-f', '-t', 'commands'])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("loading '-t'", result.stderr)
+
+            result = b.run_args(['-f', '--', '-t', 'commands'])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("loading '--'", result.stderr)
+
+            result = b.run_args(['-:'])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('usage: ninja [options]', result.stderr)
+
+            result = b.run_args(['-t'])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn('usage: ninja [options]', result.stderr)
+
+            result = b.run_args(['-t', 'not-a-tool'])
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unknown tool 'not-a-tool'", result.stderr)
+
+    def test_posixly_correct(self) -> None:
+        env = default_env.copy()
+        env['POSIXLY_CORRECT'] = '1'
+
+        with BuildDir(self.COMMANDS_WITH_DEPS_PLAN) as b:
+            result = b.run_args(
+                ['-s', 'foo.o', '-t', 'commands', 'bar.o'], env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, 'echo foo.o\necho bar.o\n')
+
+            result = b.run_args(
+                ['-v', 'foo.o', '-t', 'commands', 'bar.o'], env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout,
+                'echo foo.dep\necho foo.o\necho bar.dep\necho bar.o\n',
+            )
+
+            result = b.run_args(
+                ['foo.o', '-v', '-t', 'commands'], env=env)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unknown target '-v'", result.stderr)
+
+        with BuildDir(self.INPUTS_PLAN) as b:
+            result = b.run_args(
+                ['--dependency-order', 'out3', '-t', 'inputs'], env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, '''\
+in2
+in1
+out1
+out2
+implicit
+order_only
+''')
+
+        with BuildDir('''\
+rule generator
+  command = echo $out
+  generator = 1
+build generated: generator
+''') as b:
+            generated = os.path.join(b.path, 'generated')
+            with open(generated, 'w'):
+                pass
+            result = b.run_args(['-g', '-t', 'clean'], env=env)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(os.path.exists(generated))
+
 
 @unittest.skipIf(platform.system() == 'Windows', 'These test methods do not work on Windows')
 class Output(unittest.TestCase):

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1723,10 +1723,128 @@ class DeferGuessParallelism {
   ~DeferGuessParallelism() { Refresh(); }
 };
 
+const option* FindLongOption(const char* arg, const option* long_options,
+                             bool* ambiguous) {
+  const char* name = arg + 2;
+  const char* equals = strchr(name, '=');
+  const size_t name_length = equals ? equals - name : strlen(name);
+  const option* match = NULL;
+  *ambiguous = false;
+
+  for (const option* candidate = long_options; candidate->name; ++candidate) {
+    if (strncmp(name, candidate->name, name_length) != 0)
+      continue;
+    if (strlen(candidate->name) == name_length) {
+      *ambiguous = false;
+      return candidate;
+    }
+    *ambiguous = match != NULL;
+    match = candidate;
+  }
+  return *ambiguous ? NULL : match;
+}
+
+bool SplitToolCommandLine(int argc, char** argv, const char* short_options,
+                          const option* long_options,
+                          std::vector<char*>* ninja_args,
+                          std::vector<char*>* tool_args, char** tool_name) {
+  ninja_args->push_back(argv[0]);
+  *tool_name = NULL;
+  bool parse_ninja_options = true;
+  const bool require_order = getenv("POSIXLY_CORRECT") != NULL;
+
+  for (int index = 1; index < argc; ++index) {
+    char* arg = argv[index];
+    if (strcmp(arg, "--") == 0)
+      return false;
+
+    if (arg[0] != '-' || arg[1] == '\0') {
+      tool_args->push_back(arg);
+      if (require_order)
+        parse_ninja_options = false;
+      continue;
+    }
+
+    // Even in POSIX require-order mode, -t remains the structural boundary
+    // between deferred tool arguments and the tool name.
+    if (!parse_ninja_options) {
+      if (arg[1] != 't') {
+        tool_args->push_back(arg);
+        continue;
+      }
+
+      ninja_args->push_back(arg);
+      if (arg[2]) {
+        *tool_name = arg + 2;
+      } else if (index + 1 < argc) {
+        *tool_name = argv[++index];
+        ninja_args->push_back(*tool_name);
+      }
+      for (++index; index < argc; ++index)
+        tool_args->push_back(argv[index]);
+      return true;
+    }
+
+    if (arg[1] == '-') {
+      bool ambiguous = false;
+      const option* long_option = FindLongOption(arg, long_options, &ambiguous);
+      if (!long_option && !ambiguous) {
+        tool_args->push_back(arg);
+        continue;
+      }
+
+      ninja_args->push_back(arg);
+      if (long_option && !strchr(arg + 2, '=') &&
+          long_option->has_arg == required_argument && index + 1 < argc) {
+        ninja_args->push_back(argv[++index]);
+      }
+      continue;
+    }
+
+    bool recognized = true;
+    bool takes_next_argument = false;
+    for (char* short_option = arg + 1; *short_option; ++short_option) {
+      const char* definition = strchr(short_options, *short_option);
+      if (*short_option == ':' || !definition) {
+        recognized = false;
+        break;
+      }
+
+      if (*short_option == 't') {
+        ninja_args->push_back(arg);
+        if (short_option[1]) {
+          *tool_name = short_option + 1;
+        } else if (index + 1 < argc) {
+          *tool_name = argv[++index];
+          ninja_args->push_back(*tool_name);
+        }
+        for (++index; index < argc; ++index)
+          tool_args->push_back(argv[index]);
+        return true;
+      }
+
+      if (definition[1] == ':') {
+        takes_next_argument = short_option[1] == '\0';
+        break;
+      }
+    }
+
+    if (!recognized) {
+      tool_args->push_back(arg);
+      continue;
+    }
+
+    ninja_args->push_back(arg);
+    if (takes_next_argument && index + 1 < argc)
+      ninja_args->push_back(argv[++index]);
+  }
+  return false;
+}
+
 /// Parse argv for command-line options.
 /// Returns an exit code, or -1 if Ninja should continue.
-int ReadFlags(int* argc, char*** argv,
-              Options* options, BuildConfig* config) {
+int ReadFlags(int* argc, char*** argv, Options* options, BuildConfig* config,
+              std::vector<char*>* tool_argv) {
   DeferGuessParallelism deferGuessParallelism(config);
 
   enum { OPT_VERSION = 1, OPT_QUIET = 2, OPT_STATUS = 3 };
@@ -1738,10 +1856,25 @@ int ReadFlags(int* argc, char*** argv,
     { "status", required_argument, NULL, OPT_STATUS },
     { NULL, 0, NULL, 0 }
   };
+  const char kShortOptions[] = "d:f:j:k:l:nt:vw:C:h";
+
+  std::vector<char*> ninja_args;
+  std::vector<char*> tool_args;
+  char* tool_name = NULL;
+  const bool has_tool =
+      SplitToolCommandLine(*argc, *argv, kShortOptions, kLongOptions,
+                           &ninja_args, &tool_args, &tool_name);
+  int flags_argc = *argc;
+  char** flags_argv = *argv;
+  if (has_tool) {
+    ninja_args.push_back(NULL);
+    flags_argc = static_cast<int>(ninja_args.size()) - 1;
+    flags_argv = ninja_args.data();
+  }
 
   int opt;
   while (!options->tool &&
-         (opt = getopt_long(*argc, *argv, "d:f:j:k:l:nt:vw:C:h", kLongOptions,
+         (opt = getopt_long(flags_argc, flags_argv, kShortOptions, kLongOptions,
                             NULL)) != -1) {
     switch (opt) {
       case 'd':
@@ -1791,6 +1924,7 @@ int ReadFlags(int* argc, char*** argv,
         config->disable_jobserver_client = true;
         break;
       case 't':
+        tool_name = optarg;
         options->tool = ChooseTool(optarg);
         if (!options->tool)
           return 0;
@@ -1821,8 +1955,17 @@ int ReadFlags(int* argc, char*** argv,
         return 1;
     }
   }
-  *argv += optind;
-  *argc -= optind;
+  if (!has_tool) {
+    *argv += optind;
+    *argc -= optind;
+    return -1;
+  }
+
+  tool_argv->push_back(tool_name);
+  tool_argv->insert(tool_argv->end(), tool_args.begin(), tool_args.end());
+  tool_argv->push_back(NULL);
+  *argv = tool_argv->data() + 1;
+  *argc = static_cast<int>(tool_args.size());
 
   return -1;
 }
@@ -1833,11 +1976,12 @@ NORETURN void real_main(int argc, char** argv) {
   BuildConfig config;
   Options options = {};
   options.input_file = "build.ninja";
+  std::vector<char*> tool_argv;
 
   setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
   const char* ninja_command = argv[0];
 
-  int exit_code = ReadFlags(&argc, &argv, &options, &config);
+  int exit_code = ReadFlags(&argc, &argv, &options, &config, &tool_argv);
   if (exit_code >= 0)
     exit(exit_code);
 


### PR DESCRIPTION
## Summary

Fix command-line parsing so targets and tool-specific arguments placed before `-t` are preserved consistently across platforms.

Closes #2689.

## Implementation

- Pre-scan the command line to identify the `-t` tool-selection boundary before invoking `getopt_long`.
- Keep recognized global Ninja options in a dedicated global argv while collecting deferred targets and tool-specific options into the tool argv, preserving their original order around `-t`.
- Preserve the existing getopt boundaries for short-option clusters, abbreviated and argument-taking long options, `--`, and `POSIXLY_CORRECT` require-order behavior.
- Avoid depending on whether the platform getopt implementation eagerly permutes argv. This makes glibc getopt and Ninja bundled getopt behave consistently.

## Validation

- RED verification: all 24 new command-line assertions failed against the baseline before the implementation.
- Release build with warnings treated as errors: passed.
- CTest: 1 passed.
- Full pytest suite: 68 passed, 1 skipped, 1 deselected.
- Command-line matrix with both glibc getopt and Ninja bundled getopt: passed.
- `misc/ci.py`: passed.
- `clang-format` check: passed.

A native Windows run was not available. The complete local `misc/output_test.py` run still has only the pre-existing `issue_1214` PTY-environment failure; the new command-line tests pass.