### PR TITLE
Deduplicate consecutive build explanations

### DIFF
--- a/misc/output_test.py
+++ b/misc/output_test.py
@@ -636,12 +636,10 @@ out3<TAB>in3
               dyndep = dd
             default out
             ''')
-        # FIXME(#2759): "output out doesn't exist" is printed twice
         output1 = dedent('''\
             ninja explain: output dd doesn't exist
             [1/2] printf 'ninja_dyndep_version = 1\\nbuild out | out.imp: dyndep\\n' > dd
             ninja explain: loading dyndep file 'dd'
-            ninja explain: output out doesn't exist
             ninja explain: output out doesn't exist
             [2/2] touch out out.imp
             ''')

--- a/src/explanations.cc
+++ b/src/explanations.cc
@@ -51,7 +51,10 @@ void Explanations::Record(const void* item, const char* fmt, ...) {
 void Explanations::RecordArgs(const void* item, const char* fmt, va_list args) {
   char buffer[1024];
   vsnprintf(buffer, sizeof(buffer), fmt, args);
-  map_[item].emplace_back(buffer);
+  auto& explanations = map_[item];
+  if (explanations.empty() || explanations.back() != buffer) {
+    explanations.emplace_back(buffer);
+  }
 }
 
 void Explanations::ExplainEdge(const Edge* edge) {

--- a/src/explanations_test.cc
+++ b/src/explanations_test.cc
@@ -28,6 +28,7 @@ TEST(Explanations, Explanations) {
   Explanations exp;
 
   exp.Record(MakeItem(1), "first explanation");
+  exp.Record(MakeItem(1), "first explanation");
   exp.Record(MakeItem(1), "second explanation");
   exp.Record(MakeItem(2), "third explanation");
   exp.Record(MakeItem(2), "fourth %s", "explanation");


### PR DESCRIPTION
Dyndep loading can recompute a node's dirty state and record the same explanation twice. Suppress only consecutive duplicates for the same item, while preserving distinct and non-consecutive reasons.

Fixes #2759.

Testing:
- `./build-cmake/ninja_test --gtest_brief=1` (425 passed)
- Python test suite (64 passed, 1 skipped; the terminal-color test fails identically on an unmodified master build in this environment)
- GCC 12 and Clang 14 Release builds with warnings treated as errors
- full CMake build and project text checks