### PR TITLE
Fix DepsLog crash on a deps record with a bogus out_id

### DIFF
--- a/src/deps_log.cc
+++ b/src/deps_log.cc
@@ -211,6 +211,13 @@ LoadStatus DepsLog::Load(const string& path, State* state, string* err) {
       }
       int* deps_data = reinterpret_cast<int*>(buf);
       int out_id = deps_data[0];
+      // A truncated or concurrent write can leave a deps record whose
+      // out_id was never assigned a path. Truncate here; storing it
+      // made Recompact index nodes_ out of bounds.
+      if (out_id < 0 || out_id >= (int)nodes_.size() || !nodes_[out_id]) {
+        read_failed = true;
+        break;
+      }
       TimeStamp mtime;
       mtime = (TimeStamp)(((uint64_t)(unsigned int)deps_data[2] << 32) |
                           (uint64_t)(unsigned int)deps_data[1]);
@@ -315,6 +322,8 @@ Node* DepsLog::GetFirstReverseDepsNode(Node* node) {
     Deps* deps = deps_[id];
     if (!deps)
       continue;
+    if (id >= nodes_.size() || !nodes_[id])
+      continue;
     for (int i = 0; i < deps->node_count; ++i) {
       if (deps->nodes[i] == node)
         return nodes_[id];
@@ -346,6 +355,8 @@ bool DepsLog::Recompact(const string& path, string* err) {
   for (int old_id = 0; old_id < (int)deps_.size(); ++old_id) {
     Deps* deps = deps_[old_id];
     if (!deps) continue;  // If nodes_[old_id] is a leaf, it has no deps.
+    if (old_id >= (int)nodes_.size() || !nodes_[old_id])
+      continue;
 
     if (!IsDepsEntryLiveFor(nodes_[old_id]))
       continue;

--- a/src/deps_log_test.cc
+++ b/src/deps_log_test.cc
@@ -786,4 +786,59 @@ TEST_F(DepsLogTest, DuplicatePathRecovery) {
   }
 }
 
+// A deps record with an out_id past the path table used to be accepted by
+// Load(), after which Recompact() indexed nodes_ out of bounds.
+TEST_F(DepsLogTest, RecompactBogusOutId) {
+  {
+    State state;
+    DepsLog log;
+    string err;
+    EXPECT_TRUE(log.OpenForWrite(kTestFilename, &err));
+    ASSERT_EQ("", err);
+
+    vector<Node*> deps;
+    deps.push_back(state.GetNode("foo.h", 0));
+    log.RecordDeps(state.GetNode("out.o", 0), 1, deps);
+    log.Close();
+  }
+
+  {
+    RealDiskInterface disk;
+    string contents, err;
+    ASSERT_EQ(FileReader::Okay, disk.ReadFile(kTestFilename, &contents, &err));
+
+    // clang-format off
+    static const uint8_t kBogusDeps[] = {
+      // size = 12, high bit set (deps record)
+      0x0c, 0x00, 0x00, 0x80,
+      // out_id = 99, past the path records written above
+      0x63, 0x00, 0x00, 0x00,
+      // mtime
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+    };
+    // clang-format on
+
+    contents.append(reinterpret_cast<const char*>(kBogusDeps),
+                    sizeof(kBogusDeps));
+    ASSERT_TRUE(disk.WriteFile(kTestFilename, contents, false));
+  }
+
+  {
+    State state;
+    DepsLog log;
+    string err;
+    ASSERT_EQ(LOAD_SUCCESS, log.Load(kTestFilename, &state, &err));
+    ASSERT_EQ("premature end of file; recovering", err);
+
+    DepsLog::Deps* deps = log.GetDeps(state.GetNode("out.o", 0));
+    ASSERT_TRUE(deps);
+    ASSERT_EQ(1, deps->node_count);
+
+    err.clear();
+    ASSERT_TRUE(log.Recompact(kTestFilename, &err));
+    ASSERT_EQ("", err);
+  }
+}
+
 }  // anonymous namespace


### PR DESCRIPTION
A deps record with an out_id past the path table used to be stored by Load(). Recompact() then indexed nodes_ with that id and crashed (0xC0000005 on Windows).

Load() now treats that record the same way it treats a truncated file. Recompact() and GetFirstReverseDepsNode() skip ids that are out of range so a log that already made it into memory does not blow up.

Fixes #2787
