### PR TITLE
fix(windows): preserve UNC prefix after CanonicalizePath (#2800)

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -305,8 +305,9 @@ void CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits) {
 
   // UNC paths enter as "\\server\share\...". After the loop they look like
   // "//server/share/...". FindFirstFileExA treats that form as a network path
-  // and fails; keep the Win32 UNC prefix as backslashes (#2800).
-  if (*len >= 2 && start[0] == '/' && start[1] == '/') {
+  // and fails; restore the Win32 UNC prefix only when those separators were
+  // originally backslashes (#2800). Leave an already-forward "//..." alone.
+  if (*len >= 2 && start[0] == '/' && start[1] == '/' && (bits & 0x3) == 0x3) {
     start[0] = '\\';
     start[1] = '\\';
   }

--- a/src/util.cc
+++ b/src/util.cc
@@ -303,6 +303,14 @@ void CanonicalizePath(char* path, size_t* len, uint64_t* slash_bits) {
     }
   }
 
+  // UNC paths enter as "\\server\share\...". After the loop they look like
+  // "//server/share/...". FindFirstFileExA treats that form as a network path
+  // and fails; keep the Win32 UNC prefix as backslashes (#2800).
+  if (*len >= 2 && start[0] == '/' && start[1] == '/') {
+    start[0] = '\\';
+    start[1] = '\\';
+  }
+
   *slash_bits = bits;
 #else
   *slash_bits = 0;

--- a/src/util_test.cc
+++ b/src/util_test.cc
@@ -213,9 +213,14 @@ TEST(CanonicalizePath, PathSamplesWindows) {
   CanonicalizePath(&path);
   EXPECT_EQ("/foo", path);
 
+  // UNC prefix must stay as backslashes for Win32 file APIs (#2800).
   path = "\\\\foo";
   CanonicalizePath(&path);
-  EXPECT_EQ("//foo", path);
+  EXPECT_EQ("\\\\foo", path);
+
+  path = "\\\\foo\\bar\\baz\\patchlevel.h";
+  CanonicalizePath(&path);
+  EXPECT_EQ("\\\\foo/bar/baz/patchlevel.h", path);
 
   path = "\\";
   CanonicalizePath(&path);


### PR DESCRIPTION
﻿## Summary
Keeps Windows UNC prefixes as `\\` after path canonicalization so Win32 file APIs can open them (#2800).

`CanonicalizePath` rewrites every `\` to `/`. A UNC path such as `\\foo\bar\baz` therefore became `//foo/bar/baz`. On a later ninja run (e.g. after reading `.ninja_deps`), `FindFirstFileExA` treats that form as a network path and fails with "The network path was not found".

Rooted paths without a drive letter (`\foo` → `/foo`) are unchanged.

## Change
After slash normalization on Windows, if the result still starts with `//`, restore the first two characters to `\\`.

## Test
Updates `CanonicalizePath.PathSamplesWindows` for UNC inputs, including the `\\foo\bar\baz\patchlevel.h` case from the issue.

Closes #2800
