### PR TITLE
Fix phonycycle=warn input handling

### DIFF
--- a/src/graph.cc
+++ b/src/graph.cc
@@ -797,7 +797,7 @@ bool Edge::maybe_phonycycle_diagnostic() const {
   // of the form "build a: phony ... a ...".   Restrict our
   // "phonycycle" diagnostic option to the form it used.
   return is_phony() && outputs_.size() == 1 && implicit_outs_ == 0 &&
-      implicit_deps_ == 0;
+      implicit_deps_ == 0 && order_only_deps_ == 0;
 }
 
 // static

--- a/src/graph.h
+++ b/src/graph.h
@@ -116,6 +116,10 @@ struct Node {
   const std::vector<Edge*>& out_edges() const { return out_edges_; }
   const std::vector<Edge*>& validation_out_edges() const { return validation_out_edges_; }
   void AddOutEdge(Edge* edge) { out_edges_.push_back(edge); }
+  void RemoveOutEdge(Edge* edge) {
+    out_edges_.erase(std::remove(out_edges_.begin(), out_edges_.end(), edge),
+                     out_edges_.end());
+  }
   void AddValidationOutEdge(Edge* edge) { validation_out_edges_.push_back(edge); }
 
   void Dump(const char* prefix="") const;

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -391,6 +391,7 @@ bool ManifestParser::ParseEdge(string* err) {
     vector<Node*>::iterator new_end =
         remove(edge->inputs_.begin(), edge->inputs_.end(), out);
     if (new_end != edge->inputs_.end()) {
+      out->RemoveOutEdge(edge);
       edge->inputs_.erase(new_end, edge->inputs_.end());
       if (!quiet_) {
         Warning("phony target '%s' names itself as an input; "

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -366,6 +366,32 @@ TEST_F(ParserTest, PhonySelfReferenceIgnored) {
   Node* node = state.LookupNode("a");
   Edge* edge = node->in_edge();
   ASSERT_TRUE(edge->inputs_.empty());
+  ASSERT_TRUE(node->out_edges().empty());
+}
+
+TEST_F(ParserTest, PhonySelfReferenceWithOrderOnlyInputKept) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(
+"build a: phony b c || a\n"
+));
+
+  Node* node = state.LookupNode("a");
+  Edge* edge = node->in_edge();
+  ASSERT_EQ(size_t(3), edge->inputs_.size());
+  EXPECT_EQ("b", edge->inputs_[0]->path());
+  EXPECT_EQ("c", edge->inputs_[1]->path());
+  EXPECT_EQ(node, edge->inputs_[2]);
+  EXPECT_EQ(1, edge->order_only_deps_);
+}
+
+TEST_F(ParserTest, PhonySelfReferenceKeepsOtherOutEdge) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(
+"build a: phony a\n"
+"build b: phony a\n"
+));
+
+  Node* node = state.LookupNode("a");
+  ASSERT_EQ(size_t(1), node->out_edges().size());
+  EXPECT_EQ(state.LookupNode("b")->in_edge(), node->out_edges()[0]);
 }
 
 TEST_F(ParserTest, PhonySelfReferenceKept) {


### PR DESCRIPTION
Fixes #1518.

`phonycycle=warn` treated phony edges with order-only inputs as legacy CMake self-cycles. Removing a self input also left the edge in `Node::out_edges_`. This change limits compatibility filtering to edges without order-only inputs and removes the matching reverse edge when filtering.

Tests:
- `build-cmake\Debug\ninja_test.exe --gtest_filter=ParserTest.*`
- `build-cmake\Debug\ninja_test.exe --gtest_filter=ParserTest.PhonySelfReference*`
- `python misc/ninja_syntax_test.py`