### PR TITLE
Tests: lengthen jobserver span to survive CI oversubscription

### DIFF
--- a/misc/jobserver_test.py
+++ b/misc/jobserver_test.py
@@ -134,12 +134,16 @@ def span_output_file(span_n: int) -> str:
 def generate_build_plan(command_count: int) -> str:
     """Generate a Ninja build plan for |command_count| parallel tasks.
 
-    Each task calls the test helper script which waits for 50ms
-    then writes its own start and end time to its output file.
+    Each task calls the test helper script which waits then writes its
+    own start and end time to its output file.
+
+    400ms (not 50ms): GitHub Actions containers often share CPUs with
+    sibling ninja_test processes. Short spans finish before the next
+    task is scheduled, so max_overlaps never reaches task_count (#2827).
     """
     result = f"""
 rule span
-    command = {sys.executable} -S {_JOBSERVER_TEST_HELPER_SCRIPT} --duration-ms=50 $out
+    command = {sys.executable} -S {_JOBSERVER_TEST_HELPER_SCRIPT} --duration-ms=400 $out
 
 """
 


### PR DESCRIPTION
The jobserver client tests spawn four 50ms tasks and assert they all overlap. On GitHub Actions, sibling ninja_test containers steal CPUs so a task can finish before the next is scheduled, and max_overlaps is 2 instead of 4.

Use 400ms spans so the overlap assertion still holds when the runner is busy.

Fixes #2827