### PR TITLE
Fix building with libc++ 23

### DIFF
--- a/src/jobserver_pool.cc
+++ b/src/jobserver_pool.cc
@@ -15,6 +15,7 @@
 #include "jobserver_pool.h"
 
 #include <assert.h>
+#include <stdlib.h>
 
 #include "util.h"
 

--- a/src/line_printer.cc
+++ b/src/line_printer.cc
@@ -14,6 +14,8 @@
 
 #include "line_printer.h"
 
+#include <cstdlib>
+
 #include <stdio.h>
 #include <stdlib.h>
 #ifdef _WIN32


### PR DESCRIPTION
jobserver_pool.cc uses getenv and line_printer.cc uses std::getenv, but they don't include `<stdlib.h>` and `<cstdlib>`, which causes a build failure with libc++ 23 due to it dropping transitive includes.

```
./src/jobserver_pool.cc:166:27: error: use of undeclared identifier 'getenv'
  166 |     const char* tmp_dir = getenv("TMPDIR");
      |                           ^~~~~~
1 error generated.
./src/line_printer.cc:38:20: error: no member named 'getenv' in namespace 'std'; did you mean simply 'getenv'?
   38 |   char* no_color = std::getenv("NO_COLOR");
      |                    ^~~~~~~~~~~
      |                    getenv
/usr/include/stdlib.h:795:14: note: 'getenv' declared here
  795 | extern char *getenv (const char *__name) __THROW __nonnull ((1)) __wur;
      |              ^
./src/line_printer.cc:43:26: error: no member named 'getenv' in namespace 'std'; did you mean simply 'getenv'?
   43 |   char* clicolor_force = std::getenv("CLICOLOR_FORCE");
      |                          ^~~~~~~~~~~
      |                          getenv
/usr/include/stdlib.h:795:14: note: 'getenv' declared here
  795 | extern char *getenv (const char *__name) __THROW __nonnull ((1)) __wur;
      |              ^
./src/line_printer.cc:48:23: error: no member named 'getenv' in namespace 'std'; did you mean simply 'getenv'?
   48 |   char* force_color = std::getenv("FORCE_COLOR");
      |                       ^~~~~~~~~~~
      |                       getenv
/usr/include/stdlib.h:795:14: note: 'getenv' declared here
  795 | extern char *getenv (const char *__name) __THROW __nonnull ((1)) __wur;
      |              ^
```

See also: https://discourse.llvm.org/t/rfc-remove-unused-transitive-includes-from-the-libc-headers/90157