### PR TITLE
Enable tweaking the scheduling order for first-time builds via explicit targets

### DIFF
--- a/src/build.cc
+++ b/src/build.cc
@@ -541,11 +541,30 @@ void Plan::ComputeCriticalPath() {
 
   const auto& sorted_edges = topo_sort.result();
 
-  // First, reset all weights to 1.
+  // First, reset all weights to the previous elapsed time,
+  // falling back to 1 if unavailable, or 0 for phony edges.
   for (Edge* edge : sorted_edges)
     edge->set_critical_path_weight(EdgeWeightHeuristic(edge));
 
-  // Second propagate / increment weights from
+  // Secondly, override the weights of edges producing the targets,
+  // based on the (reversed) targets order - but only if the edge
+  // doesn't have a valid previous elapsed time yet.
+  // This enables tweaking the scheduling order of first-time builds
+  // (without previous build times) via explicit targets in the ninja
+  // command-line, e.g., by prepending long-running outputs.
+  const int64_t n_targets = targets_.size();
+  if (n_targets > 1) {
+    // process the targets in reversed order, so that shared in edges
+    // get the max weight of the target with lowest index
+    for (int64_t i = n_targets - 1; i >= 0; --i) {
+      if (auto edge = targets_[i]->in_edge()) {
+        if (edge->is_phony() || edge->prev_elapsed_time_millis < 0)
+          edge->set_critical_path_weight((n_targets - i) << 32);
+      }
+    }
+  }
+
+  // Third propagate / increment weights from
   // children to parents. Scan the list
   // in reverse order to do so.
   for (auto reverse_it = sorted_edges.rbegin();

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -55,9 +55,16 @@ struct PlanTest : public StateTestWithBuiltinRules {
   }
 
   void PrepareForTarget(const char* node, BuildLog *log=NULL) {
-    string err;
-    EXPECT_TRUE(plan_.AddTarget(GetNode(node), &err));
-    ASSERT_EQ("", err);
+    PrepareForTargets({node}, log);
+  }
+
+  void PrepareForTargets(std::initializer_list<const char*> nodes,
+                         BuildLog* log = nullptr) {
+    std::string err;
+    for (const char* node : nodes) {
+      EXPECT_TRUE(plan_.AddTarget(GetNode(node), &err));
+      ASSERT_EQ("", err);
+    }
     plan_.PrepareQueue();
     ASSERT_TRUE(plan_.more_to_do());
   }
@@ -504,6 +511,52 @@ TEST_F(PlanTest, PriorityWithoutBuildLog) {
   const int n_edges = 5;
   const char *expected_order[n_edges] = {
     "a1", "a0", "b0", "c0", "out"};
+  for (int i = 0; i < n_edges; ++i) {
+    Edge* edge = plan_.FindWork();
+    ASSERT_TRUE(edge != nullptr);
+    EXPECT_EQ(expected_order[i], edge->outputs_[0]->path());
+
+    std::string err;
+    ASSERT_TRUE(plan_.EdgeFinished(edge, Plan::kEdgeSucceeded, &err));
+    EXPECT_EQ(err, "");
+  }
+
+  EXPECT_FALSE(plan_.FindWork());
+}
+
+TEST_F(PlanTest, PriorityWithoutBuildLog_MultipleTargets) {
+  // same graph as above, but building multiple targets
+  ASSERT_NO_FATAL_FAILURE(AssertParse(&state_,
+    "rule r\n"
+    "  command = unused\n"
+    "build out: r a0 b0 c0\n"
+    "build a0: r a1\n"
+    "build a1: r a2\n"
+    "build b0: r b1\n"
+    "build c0: r b1\n"
+  ));
+  GetNode("a1")->MarkDirty();
+  GetNode("a0")->MarkDirty();
+  GetNode("b0")->MarkDirty();
+  GetNode("c0")->MarkDirty();
+  GetNode("out")->MarkDirty();
+  BuildLog log;
+  // build c0 explicitly as first target, mimicking a `ninja c0 out` CLI run
+  PrepareForTargets({"c0", "out"}, &log);
+
+  // c0  is the 1st out of N=2 targets => edge gets (N-0)<<32 as target-order-specific weight
+  EXPECT_EQ(GetNode("c0")->in_edge()->critical_path_weight(),  int64_t(2) << 32);
+  // out is the 2nd out of N=2 targets => edge gets (N-1)<<32 as target-order-specific weight
+  EXPECT_EQ(GetNode("out")->in_edge()->critical_path_weight(), int64_t(1) << 32);
+  // the weights propagate to the parent edges
+  EXPECT_EQ(GetNode("a0")->in_edge()->critical_path_weight(), (int64_t(1) << 32) + 1);
+  EXPECT_EQ(GetNode("b0")->in_edge()->critical_path_weight(), (int64_t(1) << 32) + 1);
+  EXPECT_EQ(GetNode("a1")->in_edge()->critical_path_weight(), (int64_t(1) << 32) + 2);
+
+  const int n_edges = 5;
+  // => c0 is scheduled first, not 4th
+  const char *expected_order[n_edges] = {
+    "c0", "a1", "a0", "b0", "out"};
   for (int i = 0; i < n_edges; ++i) {
     Edge* edge = plan_.FindWork();
     ASSERT_TRUE(edge != nullptr);


### PR DESCRIPTION
This is a stab at https://github.com/ninja-build/ninja/issues/232, allowing to tweak the scheduling order via e.g. `ninja <slow output> all`, for first-time builds without previous build times yet, such as fresh CI builds in ephemeral containers.

Implemented by overriding the weight of target-producing edges iff.
* multiple targets have been specified, and
* there is no previous build time for that edge yet.

This target-order-specific weight is stored in the upper 32 bits of the 64-bit weight, starting with 1<<32 for the last target's edge, 2<<32 for the 2nd-last target's, 3<<32 for the 3rd-last etc. It should thus always dominate normal weights (e.g., elapsed milliseconds for the previous build).

(Something similar to this was implemented in #2019, but not in accepted #2177. With #2686 having landed, I think this is the last remaining interesting piece from #2019.)